### PR TITLE
Add base for fingerprint policy

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_01_25_192607) do
+ActiveRecord::Schema.define(version: 2019_01_28_201532) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
@@ -171,6 +171,7 @@ ActiveRecord::Schema.define(version: 2019_01_25_192607) do
     t.boolean "concurrent", default: true
     t.integer "max_uses"
     t.string "scheme"
+    t.string "fingerprint_policy", default: "UNIQUE_PER_LICENSE"
     t.index "to_tsvector('simple'::regconfig, COALESCE((id)::text, ''::text))", name: "policies_tsv_id_idx", using: :gin
     t.index "to_tsvector('simple'::regconfig, COALESCE((metadata)::text, ''::text))", name: "policies_tsv_metadata_idx", using: :gin
     t.index "to_tsvector('simple'::regconfig, COALESCE((name)::text, ''::text))", name: "policies_tsv_name_idx", using: :gin

--- a/features/api/v1/machines/create.feature
+++ b/features/api/v1/machines/create.feature
@@ -438,6 +438,145 @@ Feature: Create machine
     And sidekiq should have 0 "metric" jobs
     And sidekiq should have 1 "request-log" job
 
+  Scenario: License creates a machine with a fingerprint from another license's machine for a license-scoped policy
+    Given the current account is "test1"
+    And the current account has 2 "webhook-endpoints"
+    And the current account has 1 "policy"
+    And all "policies" have the following attributes:
+      """
+      { "fingerprintPolicy": "UNIQUE_PER_LICENSE" }
+      """
+    And the current account has 2 "licenses"
+    And all "licenses" have the following attributes:
+      """
+      {
+        "policyId": "$policies[0]",
+        "protected": true
+      }
+      """
+    And the current account has 1 "machine"
+    And all "machine" have the following attributes:
+      """
+      {
+        "fingerprint": "mN:8M:uK:WL:Dx:8z:Vb:9A:ut:zD:FA:xL:fv:zt:ZE",
+        "licenseId": "$licenses[1]"
+      }
+      """
+    And I am a license of account "test1"
+    And I use an authentication token
+    And the current token has the following attributes:
+      """
+      {
+        "maxActivations": 1,
+        "activations": 0
+      }
+      """
+    When I send a POST request to "/accounts/test1/machines" with the following:
+      """
+      {
+        "data": {
+          "type": "machines",
+          "attributes": {
+            "fingerprint": "mN:8M:uK:WL:Dx:8z:Vb:9A:ut:zD:FA:xL:fv:zt:ZE"
+          },
+          "relationships": {
+            "license": {
+              "data": {
+                "type": "licenses",
+                "id": "$licenses[0]"
+              }
+            }
+          }
+        }
+      }
+      """
+    Then the response status should be "201"
+    And the JSON response should be a "machine" with the fingerprint "mN:8M:uK:WL:Dx:8z:Vb:9A:ut:zD:FA:xL:fv:zt:ZE"
+    And the current token should have the following attributes:
+      """
+      {
+        "activations": 1
+      }
+      """
+    And sidekiq should have 2 "webhook" jobs
+    And sidekiq should have 1 "metric" job
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: License creates a machine with a fingerprint from another license's machine for a account-scoped policy
+    Given the current account is "test1"
+    And the current account has 2 "webhook-endpoints"
+    And the current account has 1 "policy"
+    And all "policies" have the following attributes:
+      """
+      { "fingerprintPolicy": "UNIQUE_PER_ACCOUNT" }
+      """
+    And the current account has 2 "licenses"
+    And all "licenses" have the following attributes:
+      """
+      {
+        "policyId": "$policies[0]",
+        "protected": true
+      }
+      """
+    And the current account has 1 "machine"
+    And all "machine" have the following attributes:
+      """
+      {
+        "fingerprint": "mN:8M:uK:WL:Dx:8z:Vb:9A:ut:zD:FA:xL:fv:zt:ZE",
+        "licenseId": "$licenses[1]"
+      }
+      """
+    And I am a license of account "test1"
+    And I use an authentication token
+    And the current token has the following attributes:
+      """
+      {
+        "maxActivations": 1,
+        "activations": 0
+      }
+      """
+    When I send a POST request to "/accounts/test1/machines" with the following:
+      """
+      {
+        "data": {
+          "type": "machines",
+          "attributes": {
+            "fingerprint": "mN:8M:uK:WL:Dx:8z:Vb:9A:ut:zD:FA:xL:fv:zt:ZE"
+          },
+          "relationships": {
+            "license": {
+              "data": {
+                "type": "licenses",
+                "id": "$licenses[0]"
+              }
+            }
+          }
+        }
+      }
+      """
+    Then the response status should be "422"
+    And the first error should have the following properties:
+      """
+      {
+        "title": "Unprocessable resource",
+        "detail": "has already been taken",
+        "code": "FINGERPRINT_TAKEN",
+        "source": {
+          "pointer": "/data/attributes/fingerprint"
+        }
+      }
+      """
+    And the current token should have the following attributes:
+      """
+      {
+        "activations": 0
+      }
+      """
+    And the current account should have 1 "machine"
+    And sidekiq should have 0 "webhook" jobs
+    And sidekiq should have 0 "metric" jobs
+    And sidekiq should have 1 "request-log" job
+
   Scenario: License creates a machine for their license with a blank fingerprint
     Given the current account is "test1"
     And the current account has 2 "webhook-endpoints"


### PR DESCRIPTION
Need to figure out a way to scope fingerprints at the policy-level. The machine table not having a `policy_id` column makes this rather difficult.

Closes #301.