### PR TITLE
Fix issue with possible duplicate Stripe subscriptions

### DIFF
--- a/app/controllers/api/v1/accounts/relationships/plans_controller.rb
+++ b/app/controllers/api/v1/accounts/relationships/plans_controller.rb
@@ -31,7 +31,8 @@ module Api::V1::Accounts::Relationships
                end
 
       if status
-        if @account.update(plan: @plan)
+        if @account.billing.update(state: :pending) &&
+           @account.update(plan: @plan)
           CreateWebhookEventService.new(
             event: "account.plan.updated",
             account: @account,


### PR DESCRIPTION
When the update plan endpoint was hit twice in quick succession, the webhook which changes the account's billing state from canceled would not have occurred yet, so a duplicate subscription would be created. This resolves that issue by setting the account to a pending state upon plan change.

Closes #321. 