### PR TITLE
Add metadata filter to licenses index

### DIFF
--- a/app/controllers/api/v1/licenses_controller.rb
+++ b/app/controllers/api/v1/licenses_controller.rb
@@ -2,6 +2,7 @@
 
 module Api::V1
   class LicensesController < Api::V1::BaseController
+    has_scope :metadata, type: :hash, only: :index
     has_scope :suspended
     has_scope :expired
     has_scope :unassigned

--- a/app/models/license.rb
+++ b/app/models/license.rb
@@ -81,6 +81,7 @@ class License < ApplicationRecord
       where 'expiry IS NULL OR expiry >= ?', Time.current
     end
   }
+  scope :metadata, -> (meta) { search_metadata meta }
   scope :policy, -> (id) { where policy: id }
   scope :user, -> (id) { where user: id }
   scope :product, -> (id) { joins(:policy).where policies: { product_id: id } }

--- a/features/api/v1/licenses/index.feature
+++ b/features/api/v1/licenses/index.feature
@@ -217,6 +217,69 @@ Feature: List license
     Then the response status should be "200"
     And the JSON response should be an array with 2 "licenses"
 
+  Scenario: Admin retrieves 1 license filtered by metadata ID
+    Given I am an admin of account "test1"
+    And the current account is "test1"
+    And the current account has 3 "licenses"
+    And the first "license" has the following attributes:
+      """
+      { "metadata": { "id": "e029e80d-7649-4770-8744-74bd794ddc08" } }
+      """
+    And the second "license" has the following attributes:
+      """
+      { "metadata": { "id": "6f79fb2e-f072-44f6-b014-7e304bcf5fcd" } }
+      """
+    And the third "license" has the following attributes:
+      """
+      { "metadata": { "id": "9cd5a11f-01be-4dc3-a8d4-c44ff2068a04" } }
+      """
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/licenses?metadata[id]=e029e80d"
+    Then the response status should be "200"
+    And the JSON response should be an array with 1 "license"
+
+  Scenario: Admin retrieves 1 license filtered by metadata ID and user email
+    Given I am an admin of account "test1"
+    And the current account is "test1"
+    And the current account has 3 "licenses"
+    And the first "license" has the following attributes:
+      """
+      { "metadata": { "id": "9cd5a11f-7649-4770-8744-74bd794ddc08", "user": "foo-1@example.com" } }
+      """
+    And the second "license" has the following attributes:
+      """
+      { "metadata": { "id": "9cd5a11f-f072-44f6-b014-7e304bcf5fcd", "user": "foo-2@example.com" } }
+      """
+    And the third "license" has the following attributes:
+      """
+      { "metadata": { "id": "9cd5a11f-01be-4dc3-a8d4-c44ff2068a04", "user": "foo-3@example.com" } }
+      """
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/licenses?metadata[id]=9cd5a11f&metadata[user]=foo-1@example.com"
+    Then the response status should be "200"
+    And the JSON response should be an array with 1 "license"
+
+  Scenario: Admin retrieves 3 licenses filtered by metadata ID
+    Given I am an admin of account "test1"
+    And the current account is "test1"
+    And the current account has 6 "licenses"
+    And the first "license" has the following attributes:
+      """
+      { "metadata": { "id": "9cd5a11f-7649-4770-8744-74bd794ddc08", "user": "foo-1@example.com" } }
+      """
+    And the second "license" has the following attributes:
+      """
+      { "metadata": { "id": "9cd5a11f-f072-44f6-b014-7e304bcf5fcd", "user": "foo-2@example.com" } }
+      """
+    And the third "license" has the following attributes:
+      """
+      { "metadata": { "id": "9cd5a11f-01be-4dc3-a8d4-c44ff2068a04", "user": "foo-3@example.com" } }
+      """
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/licenses?metadata[id]=9cd5a11f"
+    Then the response status should be "200"
+    And the JSON response should be an array with 3 "licenses"
+
   Scenario: Product retrieves all licenses for their product
     Given the current account is "test1"
     And the current account has 1 "product"


### PR DESCRIPTION
Uses the same underlying queries as the private search API.

```
/v1/accounts/test1/licenses?metadata[id]=9cd5a11f&metadata[user]=foo@example.com
```