### PR TITLE
Allow licensing actions to be performed via email

### DIFF
--- a/app/controllers/stdin/sendgrid_controller.rb
+++ b/app/controllers/stdin/sendgrid_controller.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Stdin
+  class SendgridController < ApplicationController
+    def process
+      skip_authorization
+
+      render json: envelope
+    end
+
+    private
+
+    def envelope
+      JSON.parse(params.fetch(:envelope))
+    end
+  end
+end

--- a/app/controllers/stdin/sendgrid_controller.rb
+++ b/app/controllers/stdin/sendgrid_controller.rb
@@ -3,65 +3,43 @@
 module Stdin
   class SendgridController < ApplicationController
     def receive_webhook
-      id_action, to_host  = to_address.split('@')
-      license_id, action  = id_action.split('+')
+      fingerprint, token = from_address.split('@').first.split('+')
+      license_id, action = to_address.split('@').first.split('+')
 
-      id_token, from_host = from_address.split('@')
-      machine_id, token   = id_action.split('+')
+      puts message_id: message_id,
+           to: to_address,
+           from: from_address,
+           license_id: license_id,
+           action: action,
+           fingerprint: fingerprint,
+           token: token,
+           body: body
 
       license = FindByAliasService.call(scope: License, identifier: license_id, aliases: :key)
 
       @current_account = license.account
-      @current_token   = TokenAuthenticationService.call(account: current_account, token: token)
-      @current_bearer  = current_token.bearer
+
+      if token.present?
+        @current_token  = TokenAuthenticationService.call(account: current_account, token: token)
+        @current_bearer = current_token.bearer
+      end
 
       case action
       when 'validate'
-        authorize license, :validate?
-
-        ok, msg, code = LicenseValidationService.call(license: license, scope: { fingerprint: machine_id })
-        meta = { ts: Time.current, valid: ok, detail: msg, constant: code }
-
-        BroadcastEventService.call(
-          event: ok ? 'license.validation.succeeded' : 'license.validation.failed',
-          account: current_account,
-          resource: license,
-          meta: meta
-        )
+        validate!(license, fingerprint)
       when 'activate'
-        machine = license.machines.new(account: current_account, license: license)
-        authorize machine, :activate?
-
-        machine.save!
-
-        BroadcastEventService.call(event: 'machine.created', account: current_account, resource: machine)
+        activate!(license, fingerprint)
       when 'deactivate'
-        machine = FindByAliasService.call(scope: license.machines, identifier: machine_id, aliases: :fingerprint)
-        authorize machine, :deactivate?
-
-        machine.destroy!
-
-        BroadcastEventService.call(event: 'machine.deleted', account: current_account, resource: machine)
+        deactivate!(license, fingerprint)
       when 'ping'
-        machine = FindByAliasService.call(scope: license.machines, identifier: machine_id, aliases: :fingerprint)
-        authorize machine, :ping?
-
-        return if
-          machine.heartbeat_dead?
-
-        machine.update!(last_heartbeat_at: Time.current)
-
-        MachineHeartbeatWorker.perform_in(
-          machine.heartbeat_duration + Machine::HEARTBEAT_DRIFT,
-          machine.id,
-        )
-
-        BroadcastEventService.call(event: 'machine.heartbeat.ping', account: current_account, resource: machine)
+        ping!(license, fingerprint)
       end
-    rescue Keygen::Error::NotFoundError
+    rescue ActiveRecord::RecordNotFound,
+           ActiveRecord::RecordInvalid,
+           Pundit::NotAuthorizedError
       # noop
     rescue => e
-      Rails.logger.exception(e)
+      Keygen.logger.exception(e)
     ensure
       skip_authorization
 
@@ -70,8 +48,57 @@ module Stdin
 
     private
 
+    def validate!(license, fingerprint)
+      # authorize license, :validate?
+
+      ok, msg, code = LicenseValidationService.call(license: license, scope: { fingerprint: fingerprint })
+      meta = { ts: Time.current, valid: ok, detail: msg, constant: code }
+
+      BroadcastEventService.call(
+        event: ok ? 'license.validation.succeeded' : 'license.validation.failed',
+        account: current_account,
+        resource: license,
+        meta: meta
+      )
+    end
+
+    def activate!(license, fingerprint)
+      machine = license.machines.new(account: current_account, license: license, fingerprint: fingerprint)
+      # authorize machine, :activate?
+
+      machine.save!
+
+      BroadcastEventService.call(event: 'machine.created', account: current_account, resource: machine)
+    end
+
+    def deactivate!(license, fingerprint)
+      machine = FindByAliasService.call(scope: license.machines, identifier: fingerprint, aliases: :fingerprint)
+      # authorize machine, :deactivate?
+
+      machine.destroy!
+
+      BroadcastEventService.call(event: 'machine.deleted', account: current_account, resource: machine)
+    end
+
+    def ping!(license, fingerprint)
+      machine = FindByAliasService.call(scope: license.machines, identifier: fingerprint, aliases: :fingerprint)
+      # authorize machine, :ping?
+
+      return if
+        machine.heartbeat_dead?
+
+      machine.update!(last_heartbeat_at: Time.current)
+
+      BroadcastEventService.call(event: 'machine.heartbeat.ping', account: current_account, resource: machine)
+
+      MachineHeartbeatWorker.perform_in(
+        machine.heartbeat_duration + Machine::HEARTBEAT_DRIFT,
+        machine.id,
+      )
+    end
+
     def mail
-      @mail ||= Mail.new(params.fetch(:email))
+      @mail ||= Mail.new(params['email'])
     end
 
     def message_id
@@ -87,7 +114,7 @@ module Stdin
     end
 
     def ip_address
-      params.fetch(:sender_ip)
+      params['sender_ip']
     end
 
     def plaintext_body

--- a/app/controllers/stdin/sendgrid_controller.rb
+++ b/app/controllers/stdin/sendgrid_controller.rb
@@ -2,16 +2,16 @@
 
 module Stdin
   class SendgridController < ApplicationController
-    def process
+    def receive_webhook
       skip_authorization
 
-      render json: envelope
+      render json: { from: mail.from, to: mail.to }
     end
 
     private
 
-    def envelope
-      JSON.parse(params.fetch(:envelope))
+    def mail
+      @mail ||= Mail.new(params.fetch(:email))
     end
   end
 end

--- a/app/controllers/stdin/sendgrid_controller.rb
+++ b/app/controllers/stdin/sendgrid_controller.rb
@@ -3,15 +3,101 @@
 module Stdin
   class SendgridController < ApplicationController
     def receive_webhook
+      id_action, to_host  = to_address.split('@')
+      license_id, action  = id_action.split('+')
+
+      id_token, from_host = from_address.split('@')
+      machine_id, token   = id_action.split('+')
+
+      license = FindByAliasService.call(scope: License, identifier: license_id, aliases: :key)
+
+      @current_account = license.account
+      @current_token   = TokenAuthenticationService.call(account: current_account, token: token)
+      @current_bearer  = current_token.bearer
+
+      case action
+      when 'validate'
+        authorize license, :validate?
+
+        ok, msg, code = LicenseValidationService.call(license: license, scope: { fingerprint: machine_id })
+        meta = { ts: Time.current, valid: ok, detail: msg, constant: code }
+
+        BroadcastEventService.call(
+          event: ok ? 'license.validation.succeeded' : 'license.validation.failed',
+          account: current_account,
+          resource: license,
+          meta: meta
+        )
+      when 'activate'
+        machine = license.machines.new(account: current_account, license: license)
+        authorize machine, :activate?
+
+        machine.save!
+
+        BroadcastEventService.call(event: 'machine.created', account: current_account, resource: machine)
+      when 'deactivate'
+        machine = FindByAliasService.call(scope: license.machines, identifier: machine_id, aliases: :fingerprint)
+        authorize machine, :deactivate?
+
+        machine.destroy!
+
+        BroadcastEventService.call(event: 'machine.deleted', account: current_account, resource: machine)
+      when 'ping'
+        machine = FindByAliasService.call(scope: license.machines, identifier: machine_id, aliases: :fingerprint)
+        authorize machine, :ping?
+
+        return if
+          machine.heartbeat_dead?
+
+        machine.update!(last_heartbeat_at: Time.current)
+
+        MachineHeartbeatWorker.perform_in(
+          machine.heartbeat_duration + Machine::HEARTBEAT_DRIFT,
+          machine.id,
+        )
+
+        BroadcastEventService.call(event: 'machine.heartbeat.ping', account: current_account, resource: machine)
+      end
+    rescue Keygen::Error::NotFoundError
+      # noop
+    rescue => e
+      Rails.logger.exception(e)
+    ensure
       skip_authorization
 
-      render json: { from: mail.from, to: mail.to }
+      head :accepted
     end
 
     private
 
     def mail
       @mail ||= Mail.new(params.fetch(:email))
+    end
+
+    def message_id
+      mail.message_id
+    end
+
+    def from_address
+      mail.from.first
+    end
+
+    def to_address
+      mail.to.first
+    end
+
+    def ip_address
+      params.fetch(:sender_ip)
+    end
+
+    def plaintext_body
+      mail.body.decoded
+    end
+
+    def body
+      JSON.parse(plaintext_body.squish)
+    rescue
+      nil
     end
   end
 end

--- a/app/policies/license_policy.rb
+++ b/app/policies/license_policy.rb
@@ -100,6 +100,7 @@ class LicensePolicy < ApplicationPolicy
       resource.product == bearer ||
       resource == bearer
   end
+  alias :validate? :validate_by_id?
 
   def validate_by_key?
     assert_account_scoped!

--- a/app/policies/machine_policy.rb
+++ b/app/policies/machine_policy.rb
@@ -31,6 +31,7 @@ class MachinePolicy < ApplicationPolicy
       resource.product == bearer ||
       resource.license == bearer
   end
+  alias :activate? :create?
 
   def update?
     assert_account_scoped!
@@ -48,6 +49,7 @@ class MachinePolicy < ApplicationPolicy
       resource.product == bearer ||
       resource.license == bearer
   end
+  alias :deactivate? :destroy?
 
   def ping_heartbeat?
     assert_account_scoped!
@@ -57,6 +59,7 @@ class MachinePolicy < ApplicationPolicy
       resource.product == bearer ||
       resource.license == bearer
   end
+  alias :ping? :ping_heartbeat?
 
   def reset_heartbeat?
     assert_account_scoped!

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -6,6 +6,7 @@ Rails.application.configure do
   config.hosts << 'get.keygen.sh'
   config.hosts << 'bin.keygen.sh'
   config.hosts << 'stdout.keygen.sh'
+  config.hosts << 'stdin.keygen.sh'
 
   # Disables security vulnerability
   config.assets.compile = false

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -269,7 +269,7 @@ Rails.application.routes.draw do
   end
 
   scope module: "stdin", constraints: { subdomain: %w[stdin] } do
-    post '/', to: "sendgrid#process", as: "stdin_sendgrid"
+    post '/', to: "sendgrid#receive_webhook", as: "stdin_sendgrid"
   end
 
   %w[500 503].each do |code|

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -264,8 +264,12 @@ Rails.application.routes.draw do
     get ":account_id/:id", constraints: { account_id: /[^\/]*/, id: /.*/ }, to: "artifacts#show",  as: "bin_artifact"
   end
 
-  scope module: "stdout", constraints: { subdomain: %w[stdout], format: "jsonapi" } do
+  scope module: "stdout", constraints: { subdomain: %w[stdout] } do
     get "unsub/:ciphertext", constraints: { ciphertext: /.*/ }, to: "subscribers#unsubscribe", as: "stdout_unsubscribe"
+  end
+
+  scope module: "stdin", constraints: { subdomain: %w[stdin] } do
+    post '/', to: "sendgrid#process", as: "stdin_sendgrid"
   end
 
   %w[500 503].each do |code|

--- a/lib/keygen/middleware.rb
+++ b/lib/keygen/middleware.rb
@@ -408,14 +408,14 @@ module Keygen
           # Emails are likely multipart/form-data, and we don't want to modify the
           # content-type header since we don't really care.
           return if
-            req.host == 'stdin.keygen.sh'
+            req.subdomain == 'stdin'
 
           route      = Rails.application.routes.recognize_path(req.url, method: req.method)
           controller = route[:controller]
           action     = route[:action]
 
-          # Artifacts may be sent to our API, and then redirected out to S3, so we
-          # want to ensure that we respect the content-type header.
+          # Artifact blobs may be sent to our API, and then redirected out to S3,
+          # so we want to ensure that we respect the content-type header.
           return if
             controller.ends_with?('/artifacts') &&
             action == 'create'


### PR DESCRIPTION
```
To: {account}+{action}[+v1]@stdin.keygen.sh

{ "data": { ... } }
```

- [x] #452
- [x] #473
- [x] #539
- [x] #551
- [x] #363
- [ ] Add password authentication to Sendgrid endpoint for `stdin` subdomain
- [ ] Add TLS SMTP requirement? We can't enforce via SendGrid, but we can add a warning to the docs.
- [ ] ~~Add `machine.ip = mail.sender_ip`~~
- [ ] Add `from` and `sender` rate limiters and blacklists (on full email, but also domain)
- [ ] Remove IP rate limiter from `stdin` subdomain
- [ ] Add `MailLog` model (store email, message ID, checksum, store for 30 days)
  - [ ] Note: store `received` headers so we can see if we can consistently extract hostname/IP

### Activate

For valid licenses, performs an activation and heartbeat ping when required. ~~Anonymous activations must be enabled.~~

```
To: {account}+activate@stdin.keygen.sh
From: {machine_fingerprint}@acme.example
Sender: keygen@acme.example
Subject: {license_token|license_key}
Body: {machine_document} (optional)
```

Aliases: `{account}+ping+v1@stdin.keygen.sh`

### Deactivate

Performs a deactivation when required. ~~Anonymous deactivations must be enabled.~~

```
To: {account}+deactivate@stdin.keygen.sh
From: {machine_fingerprint}@acme.example
Sender: keygen@acme.example
Subject: {license_token|license_key}
Body: {machine_linkage} (optional)
```

Send a bounce email to `Sender` if any operation fails.

Closes #509.