### PR TITLE
Add nullable filetype and platform to releases

### DIFF
--- a/app/controllers/api/v1/releases_controller.rb
+++ b/app/controllers/api/v1/releases_controller.rb
@@ -142,14 +142,14 @@ module Api::V1
             param :name, type: :string, optional: true
             param :filename, type: :string
             param :filesize, type: :integer, optional: true
-            param :filetype, type: :string, transform: -> (k, v) {
-              [:filetype_attributes, { key: v.downcase }]
+            param :filetype, type: :string, optional: true, transform: -> (k, v) {
+              [:filetype_attributes, { key: v.downcase.presence }]
             }
-            param :platform, type: :string, transform: -> (k, v) {
-              [:platform_attributes, { key: v.downcase }]
+            param :platform, type: :string, optional: true, transform: -> (k, v) {
+              [:platform_attributes, { key: v.downcase.presence }]
             }
             param :channel, type: :string, inclusion: %w[stable rc beta alpha dev], transform: -> (k, v) {
-              [:channel_attributes, { key: v.downcase }]
+              [:channel_attributes, { key: v.downcase.presence }]
             }
             param :version, type: :string
             param :description, type: :string, optional: true
@@ -190,14 +190,14 @@ module Api::V1
             param :name, type: :string, optional: true, allow_nil: true
             param :filename, type: :string
             param :filesize, type: :integer, optional: true, allow_nil: true
-            param :filetype, type: :string, transform: -> (k, v) {
-              [:filetype_attributes, { key: v.downcase }]
+            param :filetype, type: :string, optional: true, transform: -> (k, v) {
+              [:filetype_attributes, { key: v.downcase.presence }]
             }
-            param :platform, type: :string, transform: -> (k, v) {
-              [:platform_attributes, { key: v.downcase }]
+            param :platform, type: :string, optional: true, transform: -> (k, v) {
+              [:platform_attributes, { key: v.downcase.presence }]
             }
             param :channel, type: :string, inclusion: %w[stable rc beta alpha dev], transform: -> (k, v) {
-              [:channel_attributes, { key: v.downcase }]
+              [:channel_attributes, { key: v.downcase.presence }]
             }
             param :version, type: :string
             param :description, type: :string, optional: true, allow_nil: true

--- a/app/serializers/release_serializer.rb
+++ b/app/serializers/release_serializer.rb
@@ -9,14 +9,14 @@ class ReleaseSerializer < BaseSerializer
   attribute :checksum
   attribute :filename
   attribute :filetype do
-    @object.filetype.key
+    @object.filetype&.key
   end
   attribute :filesize
   attribute :platform do
-    @object.platform.key
+    @object.platform&.key
   end
   attribute :channel do
-    @object.channel.key
+    @object.channel&.key
   end
   attribute :downloads do
     @object.download_count

--- a/db/migrate/20211214215323_add_nullable_release_platform_for_releases.rb
+++ b/db/migrate/20211214215323_add_nullable_release_platform_for_releases.rb
@@ -1,0 +1,9 @@
+class AddNullableReleasePlatformForReleases < ActiveRecord::Migration[6.1]
+  def up
+    change_column :releases, :release_platform_id, :uuid, null: true
+  end
+
+  def down
+    change_column :releases, :release_platform_id, :uuid, null: false
+  end
+end

--- a/db/migrate/20211214215330_add_nullable_release_filetype_for_releases.rb
+++ b/db/migrate/20211214215330_add_nullable_release_filetype_for_releases.rb
@@ -1,0 +1,9 @@
+class AddNullableReleaseFiletypeForReleases < ActiveRecord::Migration[6.1]
+  def up
+    change_column :releases, :release_filetype_id, :uuid, null: true
+  end
+
+  def down
+    change_column :releases, :release_filetype_id, :uuid, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_27_135950) do
+ActiveRecord::Schema.define(version: 2021_12_14_215330) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
@@ -374,7 +374,7 @@ ActiveRecord::Schema.define(version: 2021_11_27_135950) do
   create_table "releases", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
     t.uuid "account_id", null: false
     t.uuid "product_id", null: false
-    t.uuid "release_platform_id", null: false
+    t.uuid "release_platform_id"
     t.uuid "release_channel_id", null: false
     t.string "name"
     t.string "version"
@@ -386,7 +386,7 @@ ActiveRecord::Schema.define(version: 2021_11_27_135950) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "upgrade_count", default: 0
-    t.uuid "release_filetype_id", null: false
+    t.uuid "release_filetype_id"
     t.text "description"
     t.string "signature"
     t.string "checksum"

--- a/features/api/v1/releases/create.feature
+++ b/features/api/v1/releases/create.feature
@@ -1115,3 +1115,206 @@ Feature: Create release
     And sidekiq should have 0 "webhook" jobs
     And sidekiq should have 0 "metric" jobs
     And sidekiq should have 1 "request-log" job
+
+  Scenario: Admin creates a release with a null filetype
+    Given I am an admin of account "test1"
+    And the current account is "test1"
+    And the current account has 1 "webhook-endpoint"
+    And the current account has 1 "product"
+    And I use an authentication token
+    When I send a POST request to "/accounts/test1/releases" with the following:
+      """
+      {
+        "data": {
+          "type": "release",
+          "attributes": {
+            "name": "Rubygem Manifest: Spec",
+            "filename": "gems/specs.4.8",
+            "filetype": null,
+            "version": "1.0.0",
+            "platform": null,
+            "channel": "stable"
+          },
+          "relationships": {
+            "product": {
+              "data": {
+                "type": "product",
+                "id": "$products[0]"
+              }
+            }
+          }
+        }
+      }
+      """
+    Then the response status should be "201"
+    And the JSON response should be a "release" with the following attributes:
+      """
+      {
+        "name": "Rubygem Manifest: Spec",
+        "filename": "gems/specs.4.8",
+        "filetype": null,
+        "version": "1.0.0",
+        "platform": null,
+        "channel": "stable"
+      }
+      """
+    And the current account should have 0 "release-platforms"
+    And the current account should have 0 "release-filetypes"
+    And sidekiq should have 1 "webhook" job
+    And sidekiq should have 1 "metric" job
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: Admin creates a release with a null platform
+    Given I am an admin of account "test1"
+    And the current account is "test1"
+    And the current account has 1 "webhook-endpoint"
+    And the current account has 1 "product"
+    And I use an authentication token
+    When I send a POST request to "/accounts/test1/releases" with the following:
+      """
+      {
+        "data": {
+          "type": "release",
+          "attributes": {
+            "name": "Rubygem Manifest: Latest",
+            "filename": "gems/latest_specs.4.8.gz",
+            "filetype": "gz",
+            "version": "1.0.0",
+            "platform": null,
+            "channel": "stable"
+          },
+          "relationships": {
+            "product": {
+              "data": {
+                "type": "product",
+                "id": "$products[0]"
+              }
+            }
+          }
+        }
+      }
+      """
+    Then the response status should be "201"
+    And the JSON response should be a "release" with the following attributes:
+      """
+      {
+        "name": "Rubygem Manifest: Latest",
+        "filename": "gems/latest_specs.4.8.gz",
+        "filetype": "gz",
+        "version": "1.0.0",
+        "platform": null,
+        "channel": "stable"
+      }
+      """
+    And the current account should have 0 "release-platforms"
+    And sidekiq should have 1 "webhook" job
+    And sidekiq should have 1 "metric" job
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: Admin creates a duplicate release with a null platform
+    Given I am an admin of account "test1"
+    And the current account is "test1"
+    And the current account has 1 "webhook-endpoint"
+    And the current account has 1 "product"
+    And the current account has 1 "release" for an existing "product"
+    And the first "release" has the following attributes:
+      """
+      {
+        "filename": "gems/latest_specs.4.8.gz",
+        "platform": null
+      }
+      """
+    And I use an authentication token
+    When I send a POST request to "/accounts/test1/releases" with the following:
+      """
+      {
+        "data": {
+          "type": "release",
+          "attributes": {
+            "name": "Rubygem Manifest: Latest",
+            "filename": "gems/latest_specs.4.8.gz",
+            "filetype": "gz",
+            "version": "1.0.0",
+            "platform": null,
+            "channel": "stable"
+          },
+          "relationships": {
+            "product": {
+              "data": {
+                "type": "product",
+                "id": "$products[0]"
+              }
+            }
+          }
+        }
+      }
+      """
+    Then the response status should be "422"
+    And the first error should have the following properties:
+      """
+      {
+        "title": "Unprocessable resource",
+        "detail": "already exists",
+        "code": "FILENAME_TAKEN",
+        "source": {
+          "pointer": "/data/attributes/filename"
+        }
+      }
+      """
+    And sidekiq should have 0 "webhook" jobs
+    And sidekiq should have 0 "metric" jobs
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: Admin creates a duplicate release with a null filetype
+    Given I am an admin of account "test1"
+    And the current account is "test1"
+    And the current account has 1 "webhook-endpoint"
+    And the current account has 1 "product"
+    And the current account has 1 "release" for an existing "product"
+    And the first "release" has the following attributes:
+      """
+      {
+        "filename": "gems/specs.4.8",
+        "filetype": null,
+        "platform": null
+      }
+      """
+    And I use an authentication token
+    When I send a POST request to "/accounts/test1/releases" with the following:
+      """
+      {
+        "data": {
+          "type": "release",
+          "attributes": {
+            "name": "Rubygem Manifest: Spec",
+            "filename": "gems/specs.4.8",
+            "filetype": null,
+            "version": "1.0.0",
+            "channel": "stable"
+          },
+          "relationships": {
+            "product": {
+              "data": {
+                "type": "product",
+                "id": "$products[0]"
+              }
+            }
+          }
+        }
+      }
+      """
+    Then the response status should be "422"
+    And the first error should have the following properties:
+      """
+      {
+        "title": "Unprocessable resource",
+        "detail": "already exists",
+        "code": "FILENAME_TAKEN",
+        "source": {
+          "pointer": "/data/attributes/filename"
+        }
+      }
+      """
+    And sidekiq should have 0 "webhook" jobs
+    And sidekiq should have 0 "metric" jobs
+    And sidekiq should have 1 "request-log" job

--- a/features/api/v1/releases/upsert.feature
+++ b/features/api/v1/releases/upsert.feature
@@ -1746,3 +1746,324 @@ Feature: Upsert release
     And sidekiq should have 0 "webhook" jobs
     And sidekiq should have 0 "metric" jobs
     And sidekiq should have 1 "request-log" job
+
+  Scenario: Admin upserts a release with a null platform
+    Given I am an admin of account "test1"
+    And the current account is "test1"
+    And the current account has 1 "webhook-endpoint"
+    And the current account has 1 "product"
+    And the current account has 1 "release" for an existing "product"
+    And the first "release" has the following attributes:
+      """
+      {
+        "filename": "gems/latest_specs.4.8.gz",
+        "platform": null
+      }
+      """
+    And I use an authentication token
+    When I send a PUT request to "/accounts/test1/releases" with the following:
+      """
+      {
+        "data": {
+          "type": "release",
+          "attributes": {
+            "name": "Rubygem Manifest: Latest Spec",
+            "filename": "gems/latest_specs.4.8.gz",
+            "filetype": "gz",
+            "version": "1.0.0",
+            "platform": null,
+            "channel": "stable"
+          },
+          "relationships": {
+            "product": {
+              "data": {
+                "type": "product",
+                "id": "$products[0]"
+              }
+            }
+          }
+        }
+      }
+      """
+    Then the response status should be "200"
+    And the JSON response should be a "release" with the following attributes:
+      """
+      {
+        "name": "Rubygem Manifest: Latest Spec",
+        "filename": "gems/latest_specs.4.8.gz",
+        "filetype": "gz",
+        "version": "1.0.0",
+        "platform": null,
+        "channel": "stable"
+      }
+      """
+    And sidekiq should have 1 "webhook" job
+    And sidekiq should have 1 "metric" job
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: Admin upserts a release with an empty platform (coalesce to null)
+    Given I am an admin of account "test1"
+    And the current account is "test1"
+    And the current account has 1 "webhook-endpoint"
+    And the current account has 1 "product"
+    And the current account has 1 "release" for an existing "product"
+    And the first "release" has the following attributes:
+      """
+      {
+        "filename": "gems/latest_specs.4.8.gz",
+        "platform": null
+      }
+      """
+    And I use an authentication token
+    When I send a PUT request to "/accounts/test1/releases" with the following:
+      """
+      {
+        "data": {
+          "type": "release",
+          "attributes": {
+            "name": "Rubygem Manifest: Latest Spec",
+            "filename": "gems/latest_specs.4.8.gz",
+            "filetype": "gz",
+            "version": "1.0.0",
+            "platform": "",
+            "channel": "stable"
+          },
+          "relationships": {
+            "product": {
+              "data": {
+                "type": "product",
+                "id": "$products[0]"
+              }
+            }
+          }
+        }
+      }
+      """
+    Then the response status should be "200"
+    And the JSON response should be a "release" with the following attributes:
+      """
+      {
+        "name": "Rubygem Manifest: Latest Spec",
+        "filename": "gems/latest_specs.4.8.gz",
+        "filetype": "gz",
+        "version": "1.0.0",
+        "platform": null,
+        "channel": "stable"
+      }
+      """
+    And sidekiq should have 1 "webhook" job
+    And sidekiq should have 1 "metric" job
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: Admin upserts a release with a null filetype
+    Given I am an admin of account "test1"
+    And the current account is "test1"
+    And the current account has 1 "webhook-endpoint"
+    And the current account has 1 "product"
+    And the current account has 1 "release" for an existing "product"
+    And the first "release" has the following attributes:
+      """
+      {
+        "filename": "gems/specs.4.8",
+        "filetype": null,
+        "platform": null
+      }
+      """
+    And I use an authentication token
+    When I send a PUT request to "/accounts/test1/releases" with the following:
+      """
+      {
+        "data": {
+          "type": "release",
+          "attributes": {
+            "name": "Rubygem Manifest: Spec",
+            "filename": "gems/specs.4.8",
+            "filetype": null,
+            "version": "1.0.0",
+            "platform": null,
+            "channel": "stable"
+          },
+          "relationships": {
+            "product": {
+              "data": {
+                "type": "product",
+                "id": "$products[0]"
+              }
+            }
+          }
+        }
+      }
+      """
+    Then the response status should be "200"
+    And the JSON response should be a "release" with the following attributes:
+      """
+      {
+        "name": "Rubygem Manifest: Spec",
+        "filename": "gems/specs.4.8",
+        "filetype": null,
+        "version": "1.0.0",
+        "platform": null,
+        "channel": "stable"
+      }
+      """
+    And sidekiq should have 1 "webhook" job
+    And sidekiq should have 1 "metric" job
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: Admin upserts a release with an empty filetype (coalesce to null)
+    Given I am an admin of account "test1"
+    And the current account is "test1"
+    And the current account has 1 "webhook-endpoint"
+    And the current account has 1 "product"
+    And the current account has 1 "release" for an existing "product"
+    And the first "release" has the following attributes:
+      """
+      {
+        "filename": "gems/specs.4.8",
+        "filetype": null,
+        "platform": null
+      }
+      """
+    And I use an authentication token
+    When I send a PUT request to "/accounts/test1/releases" with the following:
+      """
+      {
+        "data": {
+          "type": "release",
+          "attributes": {
+            "name": "Rubygem Manifest: Spec",
+            "filename": "gems/specs.4.8",
+            "filetype": "",
+            "version": "1.0.0",
+            "channel": "stable"
+          },
+          "relationships": {
+            "product": {
+              "data": {
+                "type": "product",
+                "id": "$products[0]"
+              }
+            }
+          }
+        }
+      }
+      """
+    Then the response status should be "200"
+    And the JSON response should be a "release" with the following attributes:
+      """
+      {
+        "name": "Rubygem Manifest: Spec",
+        "filename": "gems/specs.4.8",
+        "filetype": null,
+        "version": "1.0.0",
+        "platform": null,
+        "channel": "stable"
+      }
+      """
+    And sidekiq should have 1 "webhook" job
+    And sidekiq should have 1 "metric" job
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: Admin upserts a release with a null channel
+    Given I am an admin of account "test1"
+    And the current account is "test1"
+    And the current account has 1 "webhook-endpoint"
+    And the current account has 1 "product"
+    And the current account has 1 "release" for an existing "product"
+    And the first "release" has the following attributes:
+      """
+      {
+        "filename": "gems/hello.gem"
+      }
+      """
+    And I use an authentication token
+    When I send a PUT request to "/accounts/test1/releases" with the following:
+      """
+      {
+        "data": {
+          "type": "release",
+          "attributes": {
+            "name": "Rubygem: Hello",
+            "filename": "gems/hello.gem",
+            "filetype": "gem",
+            "version": "1.0.0",
+            "platform": null,
+            "channel": null
+          },
+          "relationships": {
+            "product": {
+              "data": {
+                "type": "product",
+                "id": "$products[0]"
+              }
+            }
+          }
+        }
+      }
+      """
+    Then the response status should be "400"
+    And the first error should have the following properties:
+      """
+      {
+        "title": "Bad request",
+        "detail": "is missing",
+        "source": {
+          "pointer": "/data/attributes/channel"
+        }
+      }
+      """
+    And sidekiq should have 0 "webhook" jobs
+    And sidekiq should have 0 "metric" jobs
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: Admin upserts a release with an empty channel (coalesce to null)
+    Given I am an admin of account "test1"
+    And the current account is "test1"
+    And the current account has 1 "webhook-endpoint"
+    And the current account has 1 "product"
+    And the current account has 1 "release" for an existing "product"
+    And the first "release" has the following attributes:
+      """
+      {
+        "filename": "gems/hello.gem"
+      }
+      """
+    And I use an authentication token
+    When I send a PUT request to "/accounts/test1/releases" with the following:
+      """
+      {
+        "data": {
+          "type": "release",
+          "attributes": {
+            "name": "Rubygem: Hello",
+            "filename": "gems/hello.gem",
+            "filetype": "gem",
+            "version": "1.0.0",
+            "platform": null,
+            "channel": ""
+          },
+          "relationships": {
+            "product": {
+              "data": {
+                "type": "product",
+                "id": "$products[0]"
+              }
+            }
+          }
+        }
+      }
+      """
+    Then the response status should be "400"
+    And the first error should have the following properties:
+      """
+      {
+        "title": "Bad request",
+        "detail": "must be one of: stable, rc, beta, alpha, dev (received )",
+        "source": {
+          "pointer": "/data/attributes/channel"
+        }
+      }
+      """
+    And sidekiq should have 0 "webhook" jobs
+    And sidekiq should have 0 "metric" jobs
+    And sidekiq should have 1 "request-log" job


### PR DESCRIPTION
This will let us better support non-upgradable artifacts, such as Rubygem's spec files. These files don't necessarily have a platform, and some do not have a filetype. We should allow these, but note that they’ll be excluded from upgrade requests, which are tied to a platform and filetype.