### PR TITLE
Add grace period for expired EE licenses

### DIFF
--- a/lib/keygen.rb
+++ b/lib/keygen.rb
@@ -22,13 +22,18 @@ module Keygen
     def ee? = !ce?
 
     def ee(&block)
+      return unless
+        ee?
+
       case block.arity
       when 2
-        yield EE.license, EE.license_file if ee?
+        yield EE.license, EE.license_file
       when 1
-        yield EE.license if ee?
+        yield EE.license
+      when 0
+        yield
       else
-        yield if ee?
+        raise ArgumentError, 'expected block with 0..2 arguments'
       end
     end
 

--- a/lib/keygen/console.rb
+++ b/lib/keygen/console.rb
@@ -54,6 +54,7 @@ module Keygen
       puts '-' * CONSOLE_WIDTH
 
       warn!
+      err!
     end
 
     def warn!
@@ -85,6 +86,10 @@ module Keygen
           puts
         end
       end
+
+      # This will raise if either the license or license file are expired
+      # and past the expiry grace period, or otherwise tampered with.
+      def err! = Keygen.ee { |key, lic| key.valid? && lic.valid? }
     end
 
     private

--- a/lib/keygen/ee/license.rb
+++ b/lib/keygen/ee/license.rb
@@ -2,6 +2,8 @@
 
 module Keygen
   module EE
+    class ExpiredLicenseError < StandardError; end
+
     class License
       class << self
         def current = @current ||= self.new(LicenseFile.current)
@@ -24,7 +26,13 @@ module Keygen
       def expires?  = expiry.present?
       def expiring? = expires? && expiry > Time.current && expiry < 30.days.from_now
       def expired?  = expires? && expiry < Time.current
-      def valid?    = lic.valid? && !expired?
+
+      def valid?
+        raise ExpiredLicenseError, 'license is expired' if
+          expired? && expiry < 30.days.ago
+
+         !expired?
+      end
 
       def entitled?(*codes)
         (codes & entitlements) == codes

--- a/lib/keygen/ee/license_file.rb
+++ b/lib/keygen/ee/license_file.rb
@@ -3,6 +3,7 @@
 module Keygen
   module EE
     class InvalidLicenseFileError < StandardError; end
+    class ExpiredLicenseFileError < StandardError; end
 
     class LicenseFile
       DEFAULT_PATH = '/etc/keygen/ee.lic'.freeze
@@ -35,6 +36,9 @@ module Keygen
       def valid?
         raise InvalidLicenseFileError, 'system clock is out of sync' if
           tampered?
+
+        raise ExpiredLicenseFileError, 'license file is expired' if
+          expired? && expiry < 30.days.ago
 
         !expired?
       end

--- a/lib/keygen/ee/protected_methods.rb
+++ b/lib/keygen/ee/protected_methods.rb
@@ -15,7 +15,9 @@ module Keygen
             Keygen.ce?
 
           raise ProtectedMethodError, "Calling #{method.receiver.name}.#{method.name} is not allowed. Please upgrade Keygen EE." unless
-            Keygen.ee { _1.entitled?(*entitlements) }
+            Keygen.ee { |key, lic|
+              lic.valid? && key.valid? && key.entitled?(*entitlements)
+            }
 
           method.call(...)
         end
@@ -25,7 +27,9 @@ module Keygen
             Keygen.ce?
 
           raise ProtectedMethodError, "Calling #{method.receiver.class.name}##{method.name} is not allowed. Please upgrade Keygen EE." unless
-            Keygen.ee { _1.entitled?(*entitlements) }
+            Keygen.ee { |key, lic|
+              lic.valid? && key.valid? && key.entitled?(*entitlements)
+            }
 
           method.call(...)
         end

--- a/spec/lib/keygen/ee/license_file_spec.rb
+++ b/spec/lib/keygen/ee/license_file_spec.rb
@@ -83,7 +83,31 @@ describe Keygen::EE::LicenseFile, type: :ee do
               lic = described_class.current
 
               expect(lic.expired?).to be true
-              expect(lic.valid?).to be false
+            end
+
+            it 'should be invalid within grace period' do
+              lic = described_class.current
+
+              with_time lic.expiry + 3.days do
+                expect { lic.valid? }.to_not raise_error
+                expect(lic.valid?).to be false
+              end
+            end
+
+            it 'should raise outside grace period' do
+              lic = described_class.current
+
+              with_time lic.expiry + 2.months do
+                expect { lic.valid? }.to raise_error Keygen::EE::ExpiredLicenseFileError
+              end
+            end
+
+            it 'should raise with tampered clock' do
+              lic = described_class.current
+
+              with_time lic.expiry - 3.days do
+                expect { lic.valid? }.to raise_error Keygen::EE::InvalidLicenseFileError
+              end
             end
 
             it 'should not have entitlement attributes' do


### PR DESCRIPTION
The application will not start after 30 day grace period has been exceeded. Mainly implemented for EE trials.