### PR TITLE
Refactor pattern matching for role checks

### DIFF
--- a/app/models/entitlement.rb
+++ b/app/models/entitlement.rb
@@ -23,11 +23,11 @@ class Entitlement < ApplicationRecord
 
   scope :accessible_by, -> accessor {
     case accessor
-    in role: { name: 'admin' | 'product' }
+    in role: Role(:admin | :product)
       self.all
-    in role: { name: 'environment' }
+    in role: Role(:environment)
       self.for_environment(accessor)
-    in role: { name: 'user' | 'license' }
+    in role: Role(:user | :license)
       self.merge(accessor.entitlements)
     else
       self.none

--- a/app/models/environment.rb
+++ b/app/models/environment.rb
@@ -68,9 +68,9 @@ class Environment < ApplicationRecord
 
   scope :accessible_by, -> accessor {
     case accessor
-    in role: { name: 'admin' }
+    in role: Role(:admin)
       self.all
-    in role: { name: 'environment' }
+    in role: Role(:environment)
       self.where(id: accessor)
     else
       self.none

--- a/app/models/group_owner.rb
+++ b/app/models/group_owner.rb
@@ -18,16 +18,16 @@ class GroupOwner < ApplicationRecord
 
   scope :accessible_by, -> accessor {
     case accessor
-    in role: { name: 'admin' | 'product' }
+    in role: Role(:admin | :product)
       self.all
-    in role: { name: 'environment' }
+    in role: Role(:environment)
       self.for_environment(accessor.id)
-    in role: { name: 'user' }
+    in role: Role(:user)
       self.where(group_id: accessor.group_id)
           .or(
             where(group_id: accessor.group_ids),
           )
-    in role: { name: 'license' }
+    in role: Role(:license)
       self.where(group_id: accessor.group_id)
     else
       self.none

--- a/app/models/release_entitlement_constraint.rb
+++ b/app/models/release_entitlement_constraint.rb
@@ -24,15 +24,15 @@ class ReleaseEntitlementConstraint < ApplicationRecord
 
   scope :accessible_by, -> accessor {
     case accessor
-    in role: { name: 'admin' }
+    in role: Role(:admin)
       self.all
-    in role: { name: 'environment' }
+    in role: Role(:environment)
       self.for_environment(accessor.id)
-    in role: { name: 'product' }
+    in role: Role(:product)
       self.for_product(accessor.id)
-    in role: { name: 'license' }
+    in role: Role(:license)
       self.for_license(accessor.id)
-    in role: { name: 'user' }
+    in role: Role(:user)
       self.for_user(accessor.id)
     else
       self.none

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -164,6 +164,13 @@ class Role < ApplicationRecord
     end
   end
 
+  ##
+  # deconstruct allows pattern pattern matching like:
+  #
+  #   role in Role(:admin | :user)
+  #
+  def deconstruct = [name.to_sym]
+
   def rank
     ROLE_RANK.fetch(name) { -1 }
   end

--- a/app/models/token.rb
+++ b/app/models/token.rb
@@ -95,14 +95,14 @@ class Token < ApplicationRecord
 
   scope :accessible_by, -> accessor {
     case accessor
-    in role: { name: 'admin' }
+    in role: Role(:admin)
       self.all
-    in role: { name: 'environment' }
+    in role: Role(:environment)
       self.for_environment(accessor)
           .or(
             where(bearer: accessor)
           )
-    in role: { name: 'product' }
+    in role: Role(:product)
       self.for_product(accessor.id)
           .or(
             where(bearer: accessor.licenses.reorder(nil)),
@@ -110,9 +110,9 @@ class Token < ApplicationRecord
           .or(
             where(bearer: accessor.users.reorder(nil)),
           )
-    in role: { name: 'user' }
+    in role: Role(:user)
       self.for_user(accessor.id)
-    in role: { name: 'license' }
+    in role: Role(:license)
       self.for_license(accessor.id)
     else
       self.none
@@ -393,7 +393,7 @@ class Token < ApplicationRecord
 
   def set_default_expiry
     # NOTE(ezekg) Non-user tokens do not expire by default (admin, env, product, license, etc.)
-    self.expiry = if bearer in role: { name: 'user' }
+    self.expiry = if bearer in role: Role(:user)
                     Time.current + TOKEN_DURATION
                   else
                     nil

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -41,9 +41,9 @@ class User < ApplicationRecord
              end
 
       case role
-      in name: 'admin' | 'developer' | 'support_agent' | 'sales_agent'
+      in Role(:admin | :developer | :support_agent | :sales_agent)
         Permission::ADMIN_PERMISSIONS
-      in name: 'read_only'
+      in Role(:read_only)
         Permission::READ_ONLY_PERMISSIONS
       else
         Permission::USER_PERMISSIONS
@@ -61,9 +61,9 @@ class User < ApplicationRecord
       #              deprecated, but still may be a good idea for correctness.
       #              When the admin is in an environment, we should also remove
       #              permissions such as account.billing.update, etc.
-      in name: 'admin' | 'developer' | 'support_agent' | 'sales_agent'
+      in Role(:admin | :developer | :support_agent | :sales_agent)
         Permission::ADMIN_PERMISSIONS
-      in name: 'read_only'
+      in Role(:read_only)
         Permission::READ_ONLY_PERMISSIONS
       else
         # NOTE(ezekg) Removing these from defaults for backwards compatibility
@@ -236,13 +236,13 @@ class User < ApplicationRecord
   # Give products the ability to read all groups
   scope :accessible_by, -> accessor {
     case accessor
-    in role: { name: 'admin' | 'product' }
+    in role: Role(:admin | :product)
       self.all
-    in role: { name: 'environment' }
+    in role: Role(:environment)
       self.for_environment(accessor.id)
-    in role: { name: 'user' }
+    in role: Role(:user)
       self.for_user(accessor.id)
-    in role: { name: 'license' }
+    in role: Role(:license)
       self.for_license(accessor.id)
     else
       self.none

--- a/app/policies/account_policy.rb
+++ b/app/policies/account_policy.rb
@@ -29,7 +29,7 @@ class AccountPolicy < ApplicationPolicy
     verify_environment!
 
     case bearer
-    in role: { name: 'admin' | 'developer' }
+    in role: Role(:admin | :developer)
       record == bearer.account
     else
       deny!

--- a/app/policies/accounts/analytics_policy.rb
+++ b/app/policies/accounts/analytics_policy.rb
@@ -7,7 +7,7 @@ module Accounts
       verify_environment!
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only)
         allow!
       else
         deny!

--- a/app/policies/accounts/billing_policy.rb
+++ b/app/policies/accounts/billing_policy.rb
@@ -9,7 +9,7 @@ module Accounts
       )
 
       case bearer
-      in role: { name: 'admin' }
+      in role: Role(:admin)
         allow!
       else
         deny!
@@ -21,7 +21,7 @@ module Accounts
       verify_environment!
 
       case bearer
-      in role: { name: 'admin' }
+      in role: Role(:admin)
         allow!
       else
         deny!

--- a/app/policies/accounts/plan_policy.rb
+++ b/app/policies/accounts/plan_policy.rb
@@ -9,7 +9,7 @@ module Accounts
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only)
         allow!
       else
         deny!
@@ -21,7 +21,7 @@ module Accounts
       verify_environment!
 
       case bearer
-      in role: { name: 'admin' }
+      in role: Role(:admin)
         allow!
       else
         deny!

--- a/app/policies/accounts/subscription_policy.rb
+++ b/app/policies/accounts/subscription_policy.rb
@@ -7,7 +7,7 @@ module Accounts
       verify_environment!
 
       case bearer
-      in role: { name: 'admin' }
+      in role: Role(:admin)
         allow!
       else
         deny!
@@ -19,7 +19,7 @@ module Accounts
       verify_environment!
 
       case bearer
-      in role: { name: 'admin' }
+      in role: Role(:admin)
         allow!
       else
         deny!
@@ -31,7 +31,7 @@ module Accounts
       verify_environment!
 
       case bearer
-      in role: { name: 'admin' }
+      in role: Role(:admin)
         allow!
       else
         deny!
@@ -43,7 +43,7 @@ module Accounts
       verify_environment!
 
       case bearer
-      in role: { name: 'admin' }
+      in role: Role(:admin)
         allow!
       else
         deny!
@@ -55,7 +55,7 @@ module Accounts
       verify_environment!
 
       case bearer
-      in role: { name: 'admin' }
+      in role: Role(:admin)
         allow!
       else
         deny!

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -22,17 +22,17 @@ class ApplicationPolicy
       relation.respond_to?(:for_environment)
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'read_only' | 'sales_agent' | 'support_agent' }
+    in role: Role(:admin | :developer | :read_only | :sales_agent | :support_agent)
       relation.all
-    in role: { name: 'environment' | 'product' | 'user' | 'license' } if relation.respond_to?(:accessible_by)
+    in role: Role(:environment | :product | :user | :license) if relation.respond_to?(:accessible_by)
       relation.accessible_by(bearer)
-    in role: { name: 'environment' } if relation.respond_to?(:for_environment)
+    in role: Role(:environment) if relation.respond_to?(:for_environment)
       relation.for_environment(bearer.id)
-    in role: { name: 'product' } if relation.respond_to?(:for_product)
+    in role: Role(:product) if relation.respond_to?(:for_product)
       relation.for_product(bearer.id)
-    in role: { name: 'user' } if relation.respond_to?(:for_user)
+    in role: Role(:user) if relation.respond_to?(:for_user)
       relation.for_user(bearer.id)
-    in role: { name: 'license' } if relation.respond_to?(:for_license)
+    in role: Role(:license) if relation.respond_to?(:for_license)
       relation.for_license(bearer.id)
     else
       relation.none

--- a/app/policies/entitlement_policy.rb
+++ b/app/policies/entitlement_policy.rb
@@ -8,9 +8,9 @@ class EntitlementPolicy < ApplicationPolicy
     )
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'product' | 'environment' }
+    in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :product | :environment)
       allow!
-    in role: { name: 'user' | 'license' } if record.all? { _1.id.in?(bearer.entitlement_ids) }
+    in role: Role(:user | :license) if record.all? { _1.id.in?(bearer.entitlement_ids) }
       allow!
     else
       deny!
@@ -24,9 +24,9 @@ class EntitlementPolicy < ApplicationPolicy
     )
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'product' | 'environment' }
+    in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :product | :environment)
       allow!
-    in role: { name: 'user' | 'license' } if record.id.in?(bearer.entitlement_ids)
+    in role: Role(:user | :license) if record.id.in?(bearer.entitlement_ids)
       allow!
     else
       deny!
@@ -38,7 +38,7 @@ class EntitlementPolicy < ApplicationPolicy
     verify_environment!
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'environment' }
+    in role: Role(:admin | :developer | :environment)
       allow!
     else
       deny!
@@ -50,7 +50,7 @@ class EntitlementPolicy < ApplicationPolicy
     verify_environment!
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'environment' }
+    in role: Role(:admin | :developer | :environment)
       allow!
     else
       deny!
@@ -62,7 +62,7 @@ class EntitlementPolicy < ApplicationPolicy
     verify_environment!
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'environment' }
+    in role: Role(:admin | :developer | :environment)
       allow!
     else
       deny!

--- a/app/policies/environment_policy.rb
+++ b/app/policies/environment_policy.rb
@@ -8,7 +8,7 @@ class EnvironmentPolicy < ApplicationPolicy
     )
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' }
+    in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only)
       allow!
     else
       deny!
@@ -22,9 +22,9 @@ class EnvironmentPolicy < ApplicationPolicy
     )
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' }
+    in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only)
       allow!
-    in role: { name: 'environment' } if record == bearer
+    in role: Role(:environment) if record == bearer
       allow!
     else
       deny!
@@ -36,7 +36,7 @@ class EnvironmentPolicy < ApplicationPolicy
     verify_environment!
 
     case bearer
-    in role: { name: 'admin' | 'developer' }
+    in role: Role(:admin | :developer)
       allow!
     else
       deny!
@@ -48,7 +48,7 @@ class EnvironmentPolicy < ApplicationPolicy
     verify_environment!
 
     case bearer
-    in role: { name: 'admin' | 'developer' }
+    in role: Role(:admin | :developer)
       allow!
     else
       deny!
@@ -60,7 +60,7 @@ class EnvironmentPolicy < ApplicationPolicy
     verify_environment!
 
     case bearer
-    in role: { name: 'admin' | 'developer' }
+    in role: Role(:admin | :developer)
       allow!
     else
       deny!
@@ -74,7 +74,7 @@ class EnvironmentPolicy < ApplicationPolicy
     )
 
     case bearer
-    in role: { name: 'environment' } if record == bearer
+    in role: Role(:environment) if record == bearer
       allow!
     else
       deny!

--- a/app/policies/environments/token_policy.rb
+++ b/app/policies/environments/token_policy.rb
@@ -9,9 +9,9 @@ module Environments
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only)
         allow!
-      in role: { name: 'environment' } if environment == bearer
+      in role: Role(:environment) if environment == bearer
         record.all? { _1 in bearer_type: ^(Environment.name), bearer_id: ^(bearer.id) }
       else
         deny!
@@ -25,9 +25,9 @@ module Environments
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only)
         allow!
-      in role: { name: 'environment' } if environment == bearer && record.bearer == bearer
+      in role: Role(:environment) if environment == bearer && record.bearer == bearer
         allow!
       else
         deny!
@@ -39,7 +39,7 @@ module Environments
       verify_environment!
 
       case bearer
-      in role: { name: 'admin' | 'developer' }
+      in role: Role(:admin | :developer)
         allow!
       else
         deny!

--- a/app/policies/event_log_policy.rb
+++ b/app/policies/event_log_policy.rb
@@ -11,7 +11,7 @@ class EventLogPolicy < ApplicationPolicy
       account.ent?
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'read_only' | 'environment' }
+    in role: Role(:admin | :developer | :read_only | :environment)
       allow!
     else
       deny!
@@ -28,7 +28,7 @@ class EventLogPolicy < ApplicationPolicy
       account.ent?
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'read_only' | 'environment' }
+    in role: Role(:admin | :developer | :read_only | :environment)
       allow!
     else
       deny!

--- a/app/policies/group_policy.rb
+++ b/app/policies/group_policy.rb
@@ -8,11 +8,11 @@ class GroupPolicy < ApplicationPolicy
     )
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'product' | 'environment' }
+    in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :product | :environment)
       allow!
-    in role: { name: 'user' } if record.all? { _1.id == bearer.group_id || _1.id.in?(bearer.group_ids) }
+    in role: Role(:user) if record.all? { _1.id == bearer.group_id || _1.id.in?(bearer.group_ids) }
       allow!
-    in role: { name: 'license' } if record.all? { _1.id == bearer.group_id }
+    in role: Role(:license) if record.all? { _1.id == bearer.group_id }
       allow!
     else
       deny!
@@ -26,11 +26,11 @@ class GroupPolicy < ApplicationPolicy
     )
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'product' | 'environment' }
+    in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :product | :environment)
       allow!
-    in role: { name: 'user' } if record.id == bearer.group_id || record.id.in?(bearer.group_ids)
+    in role: Role(:user) if record.id == bearer.group_id || record.id.in?(bearer.group_ids)
       allow!
-    in role: { name: 'license' } if record.id == bearer.group_id
+    in role: Role(:license) if record.id == bearer.group_id
       allow!
     else
       deny!
@@ -42,7 +42,7 @@ class GroupPolicy < ApplicationPolicy
     verify_environment!
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'product' | 'environment' }
+    in role: Role(:admin | :developer | :product | :environment)
       allow!
     else
       deny!
@@ -54,7 +54,7 @@ class GroupPolicy < ApplicationPolicy
     verify_environment!
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'product' | 'environment' }
+    in role: Role(:admin | :developer | :product | :environment)
       allow!
     else
       deny!
@@ -66,7 +66,7 @@ class GroupPolicy < ApplicationPolicy
     verify_environment!
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'product' | 'environment' }
+    in role: Role(:admin | :developer | :product | :environment)
       allow!
     else
       deny!

--- a/app/policies/groups/group_owner_policy.rb
+++ b/app/policies/groups/group_owner_policy.rb
@@ -11,11 +11,11 @@ module Groups
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'product' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :product | :environment)
         allow!
-      in role: { name: 'user' } if group.id == bearer.group_id || group.id.in?(bearer.group_ids)
+      in role: Role(:user) if group.id == bearer.group_id || group.id.in?(bearer.group_ids)
         allow!
-      in role: { name: 'license' } if group.id == bearer.group_id
+      in role: Role(:license) if group.id == bearer.group_id
         allow!
       else
         deny!
@@ -29,11 +29,11 @@ module Groups
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'product' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :product | :environment)
         allow!
-      in role: { name: 'user' } if group.id == bearer.group_id || group.id.in?(bearer.group_ids)
+      in role: Role(:user) if group.id == bearer.group_id || group.id.in?(bearer.group_ids)
         allow!
-      in role: { name: 'license' } if group.id == bearer.group_id
+      in role: Role(:license) if group.id == bearer.group_id
         allow!
       else
         deny!
@@ -50,7 +50,7 @@ module Groups
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'product' | 'environment' }
+      in role: Role(:admin | :developer | :product | :environment)
         allow!
       else
         deny!
@@ -65,7 +65,7 @@ module Groups
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'product' | 'environment' }
+      in role: Role(:admin | :developer | :product | :environment)
         allow!
       else
         deny!

--- a/app/policies/groups/license_policy.rb
+++ b/app/policies/groups/license_policy.rb
@@ -9,13 +9,13 @@ module Groups
         relation.respond_to?(:for_environment)
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'read_only' | 'sales_agent' | 'support_agent' }
+      in role: Role(:admin | :developer | :read_only | :sales_agent | :support_agent)
         relation.all
-      in role: { name: 'environment' } if relation.respond_to?(:for_environment)
+      in role: Role(:environment) if relation.respond_to?(:for_environment)
         relation.for_environment(bearer.id)
-      in role: { name: 'product' } if relation.respond_to?(:for_product)
+      in role: Role(:product) if relation.respond_to?(:for_product)
         relation.for_product(bearer.id)
-      in role: { name: 'user' } if relation.respond_to?(:for_owner)
+      in role: Role(:user) if relation.respond_to?(:for_owner)
         relation.for_owner(bearer.id)
       else
         relation.none
@@ -29,11 +29,11 @@ module Groups
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
         allow!
-      in role: { name: 'product' } if record.all? { _1.product == bearer }
+      in role: Role(:product) if record.all? { _1.product == bearer }
         allow!
-      in role: { name: 'user' } if bearer.group_ids? && record.all? { _1.group_id? && _1.group_id.in?(bearer.group_ids) }
+      in role: Role(:user) if bearer.group_ids? && record.all? { _1.group_id? && _1.group_id.in?(bearer.group_ids) }
         allow!
       else
         deny!
@@ -47,11 +47,11 @@ module Groups
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
         allow!
-      in role: { name: 'product' } if record.product == bearer
+      in role: Role(:product) if record.product == bearer
         allow!
-      in role: { name: 'user' } if bearer.group_ids? && record.group_id? && record.group_id.in?(bearer.group_ids)
+      in role: Role(:user) if bearer.group_ids? && record.group_id? && record.group_id.in?(bearer.group_ids)
         allow!
       else
         deny!

--- a/app/policies/groups/machine_policy.rb
+++ b/app/policies/groups/machine_policy.rb
@@ -9,13 +9,13 @@ module Groups
         relation.respond_to?(:for_environment)
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'read_only' | 'sales_agent' | 'support_agent' }
+      in role: Role(:admin | :developer | :read_only | :sales_agent | :support_agent)
         relation.all
-      in role: { name: 'environment' } if relation.respond_to?(:for_environment)
+      in role: Role(:environment) if relation.respond_to?(:for_environment)
         relation.for_environment(bearer.id)
-      in role: { name: 'product' } if relation.respond_to?(:for_product)
+      in role: Role(:product) if relation.respond_to?(:for_product)
         relation.for_product(bearer.id)
-      in role: { name: 'user' } if relation.respond_to?(:for_owner)
+      in role: Role(:user) if relation.respond_to?(:for_owner)
         relation.for_owner(bearer.id)
       else
         relation.none
@@ -29,11 +29,11 @@ module Groups
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
         allow!
-      in role: { name: 'product' } if record.all? { _1.product == bearer }
+      in role: Role(:product) if record.all? { _1.product == bearer }
         allow!
-      in role: { name: 'user' } if bearer.group_ids? && record.all? { _1.group_id? && _1.group_id.in?(bearer.group_ids) }
+      in role: Role(:user) if bearer.group_ids? && record.all? { _1.group_id? && _1.group_id.in?(bearer.group_ids) }
         allow!
       else
         deny!
@@ -47,11 +47,11 @@ module Groups
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
         allow!
-      in role: { name: 'product' } if record.product == bearer
+      in role: Role(:product) if record.product == bearer
         allow!
-      in role: { name: 'user' } if bearer.group_ids? && record.group_id? && record.group_id.in?(bearer.group_ids)
+      in role: Role(:user) if bearer.group_ids? && record.group_id? && record.group_id.in?(bearer.group_ids)
         allow!
       else
         deny!

--- a/app/policies/groups/user_policy.rb
+++ b/app/policies/groups/user_policy.rb
@@ -9,13 +9,13 @@ module Groups
         relation.respond_to?(:for_environment)
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'read_only' | 'sales_agent' | 'support_agent' }
+      in role: Role(:admin | :developer | :read_only | :sales_agent | :support_agent)
         relation.all
-      in role: { name: 'environment' } if relation.respond_to?(:for_environment)
+      in role: Role(:environment) if relation.respond_to?(:for_environment)
         relation.for_environment(bearer.id)
-      in role: { name: 'product' } if relation.respond_to?(:for_product)
+      in role: Role(:product) if relation.respond_to?(:for_product)
         relation.for_product(bearer.id)
-      in role: { name: 'user' } if relation.respond_to?(:for_owner)
+      in role: Role(:user) if relation.respond_to?(:for_owner)
         relation.for_owner(bearer.id)
       else
         relation.none
@@ -29,11 +29,11 @@ module Groups
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
         allow!
-      in role: { name: 'product' }
+      in role: Role(:product)
         allow!
-      in role: { name: 'user' } if bearer.group_ids? && record.all? { _1.group_id? && _1.group_id.in?(bearer.group_ids) }
+      in role: Role(:user) if bearer.group_ids? && record.all? { _1.group_id? && _1.group_id.in?(bearer.group_ids) }
         allow!
       else
         deny!
@@ -47,11 +47,11 @@ module Groups
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
         allow!
-      in role: { name: 'product' }
+      in role: Role(:product)
         allow!
-      in role: { name: 'user' } if bearer.group_ids? && record.group_id? && record.group_id.in?(bearer.group_ids)
+      in role: Role(:user) if bearer.group_ids? && record.group_id? && record.group_id.in?(bearer.group_ids)
         allow!
       else
         deny!

--- a/app/policies/key_policy.rb
+++ b/app/policies/key_policy.rb
@@ -8,9 +8,9 @@ class KeyPolicy < ApplicationPolicy
     )
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'read_only' | 'sales_agent' | 'support_agent' | 'environment' }
+    in role: Role(:admin | :developer | :read_only | :sales_agent | :support_agent | :environment)
       allow!
-    in role: { name: 'product' } if record.all? { _1.product == bearer }
+    in role: Role(:product) if record.all? { _1.product == bearer }
       allow!
     else
       deny!
@@ -24,9 +24,9 @@ class KeyPolicy < ApplicationPolicy
     )
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'read_only' | 'sales_agent' | 'support_agent' | 'environment' }
+    in role: Role(:admin | :developer | :read_only | :sales_agent | :support_agent | :environment)
       allow!
-    in role: { name: 'product' } if record.product == bearer
+    in role: Role(:product) if record.product == bearer
       allow!
     else
       deny!
@@ -38,9 +38,9 @@ class KeyPolicy < ApplicationPolicy
     verify_environment!
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'environment' }
+    in role: Role(:admin | :developer | :environment)
       allow!
-    in role: { name: 'product' } if record.product == bearer
+    in role: Role(:product) if record.product == bearer
       allow!
     else
       deny!
@@ -52,9 +52,9 @@ class KeyPolicy < ApplicationPolicy
     verify_environment!
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'environment' }
+    in role: Role(:admin | :developer | :environment)
       allow!
-    in role: { name: 'product' } if record.product == bearer
+    in role: Role(:product) if record.product == bearer
       allow!
     else
       deny!
@@ -66,9 +66,9 @@ class KeyPolicy < ApplicationPolicy
     verify_environment!
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'environment' }
+    in role: Role(:admin | :developer | :environment)
       allow!
-    in role: { name: 'product' } if record.product == bearer
+    in role: Role(:product) if record.product == bearer
       allow!
     else
       deny!

--- a/app/policies/keys/policy_policy.rb
+++ b/app/policies/keys/policy_policy.rb
@@ -11,9 +11,9 @@ module Keys
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
         allow!
-      in role: { name: 'product' } if key.product == bearer
+      in role: Role(:product) if key.product == bearer
         allow!
       else
         deny!

--- a/app/policies/keys/product_policy.rb
+++ b/app/policies/keys/product_policy.rb
@@ -11,9 +11,9 @@ module Keys
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
         allow!
-      in role: { name: 'product' } if key.product == bearer
+      in role: Role(:product) if key.product == bearer
         allow!
       else
         deny!

--- a/app/policies/license_file_policy.rb
+++ b/app/policies/license_file_policy.rb
@@ -8,13 +8,13 @@ class LicenseFilePolicy < ApplicationPolicy
     )
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+    in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
       allow!
-    in role: { name: 'product' } if record.product == bearer
+    in role: Role(:product) if record.product == bearer
       allow!
-    in role: { name: 'user' } if record.user == bearer
+    in role: Role(:user) if record.user == bearer
       allow!
-    in role: { name: 'license' } if record.license == bearer
+    in role: Role(:license) if record.license == bearer
       allow!
     else
       deny!

--- a/app/policies/license_policy.rb
+++ b/app/policies/license_policy.rb
@@ -10,11 +10,11 @@ class LicensePolicy < ApplicationPolicy
     )
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+    in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
       allow!
-    in role: { name: 'product' } if record.all? { _1.product == bearer }
+    in role: Role(:product) if record.all? { _1.product == bearer }
       allow!
-    in role: { name: 'user' } if record.all? { _1.user == bearer }
+    in role: Role(:user) if record.all? { _1.user == bearer }
       allow!
     else
       deny!
@@ -28,13 +28,13 @@ class LicensePolicy < ApplicationPolicy
     )
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+    in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
       allow!
-    in role: { name: 'product' } if record.product == bearer
+    in role: Role(:product) if record.product == bearer
       allow!
-    in role: { name: 'user' } if record.user == bearer
+    in role: Role(:user) if record.user == bearer
       allow!
-    in role: { name: 'license' } if record == bearer
+    in role: Role(:license) if record == bearer
       allow!
     else
       deny!
@@ -46,11 +46,11 @@ class LicensePolicy < ApplicationPolicy
     verify_environment!
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'sales_agent' | 'environment' }
+    in role: Role(:admin | :developer | :sales_agent | :environment)
       allow!
-    in role: { name: 'product' } if record.product == bearer
+    in role: Role(:product) if record.product == bearer
       allow!
-    in role: { name: 'user' } if record.user == bearer
+    in role: Role(:user) if record.user == bearer
       !record.policy&.protected?
     else
       deny!
@@ -62,9 +62,9 @@ class LicensePolicy < ApplicationPolicy
     verify_environment!
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'environment' }
+    in role: Role(:admin | :developer | :sales_agent | :support_agent | :environment)
       allow!
-    in role: { name: 'product' } if record.product == bearer
+    in role: Role(:product) if record.product == bearer
       allow!
     else
       deny!
@@ -76,11 +76,11 @@ class LicensePolicy < ApplicationPolicy
     verify_environment!
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'sales_agent' | 'environment' }
+    in role: Role(:admin | :developer | :sales_agent | :environment)
       allow!
-    in role: { name: 'product' } if record.product == bearer
+    in role: Role(:product) if record.product == bearer
       allow!
-    in role: { name: 'user' } if record.user == bearer
+    in role: Role(:user) if record.user == bearer
       !record.policy.protected?
     else
       deny!
@@ -92,13 +92,13 @@ class LicensePolicy < ApplicationPolicy
     verify_environment!
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'environment' }
+    in role: Role(:admin | :developer | :sales_agent | :support_agent | :environment)
       allow!
-    in role: { name: 'product' } if record.product == bearer
+    in role: Role(:product) if record.product == bearer
       allow!
-    in role: { name: 'user' } if record.user == bearer
+    in role: Role(:user) if record.user == bearer
       !record.policy.protected?
-    in role: { name: 'license' } if record == bearer
+    in role: Role(:license) if record == bearer
       allow!
     else
       deny!
@@ -110,13 +110,13 @@ class LicensePolicy < ApplicationPolicy
     verify_environment!
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'environment' }
+    in role: Role(:admin | :developer | :sales_agent | :support_agent | :environment)
       allow!
-    in role: { name: 'product' } if record.product == bearer
+    in role: Role(:product) if record.product == bearer
       allow!
-    in role: { name: 'user' } if record.user == bearer
+    in role: Role(:user) if record.user == bearer
       !record.policy.protected?
-    in role: { name: 'license' } if record == bearer
+    in role: Role(:license) if record == bearer
       allow!
     else
       deny!
@@ -130,13 +130,13 @@ class LicensePolicy < ApplicationPolicy
     )
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+    in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
       allow!
-    in role: { name: 'product' } if record.product == bearer
+    in role: Role(:product) if record.product == bearer
       allow!
-    in role: { name: 'user' } if record.user == bearer
+    in role: Role(:user) if record.user == bearer
       allow!
-    in role: { name: 'license' } if record == bearer
+    in role: Role(:license) if record == bearer
       allow!
     else
       deny!
@@ -158,11 +158,11 @@ class LicensePolicy < ApplicationPolicy
     verify_environment!
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'sales_agent' | 'environment' }
+    in role: Role(:admin | :developer | :sales_agent | :environment)
       allow!
-    in role: { name: 'product' } if record.product == bearer
+    in role: Role(:product) if record.product == bearer
       allow!
-    in role: { name: 'user' } if record.user == bearer
+    in role: Role(:user) if record.user == bearer
       !record.policy.protected?
     else
       deny!
@@ -174,11 +174,11 @@ class LicensePolicy < ApplicationPolicy
     verify_environment!
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'sales_agent' | 'environment' }
+    in role: Role(:admin | :developer | :sales_agent | :environment)
       allow!
-    in role: { name: 'product' } if record.product == bearer
+    in role: Role(:product) if record.product == bearer
       allow!
-    in role: { name: 'user' } if record.user == bearer
+    in role: Role(:user) if record.user == bearer
       !record.policy.protected?
     else
       deny!
@@ -190,9 +190,9 @@ class LicensePolicy < ApplicationPolicy
     verify_environment!
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'environment' }
+    in role: Role(:admin | :developer | :sales_agent | :support_agent | :environment)
       allow!
-    in role: { name: 'product' } if record.product == bearer
+    in role: Role(:product) if record.product == bearer
       allow!
     else
       deny!
@@ -204,9 +204,9 @@ class LicensePolicy < ApplicationPolicy
     verify_environment!
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'environment' }
+    in role: Role(:admin | :developer | :sales_agent | :support_agent | :environment)
       allow!
-    in role: { name: 'product' } if record.product == bearer
+    in role: Role(:product) if record.product == bearer
       allow!
     else
       deny!
@@ -220,7 +220,7 @@ class LicensePolicy < ApplicationPolicy
     )
 
     case bearer
-    in role: { name: 'license' } if record == bearer
+    in role: Role(:license) if record == bearer
       allow!
     else
       deny!

--- a/app/policies/licenses/entitlement_policy.rb
+++ b/app/policies/licenses/entitlement_policy.rb
@@ -11,13 +11,13 @@ module Licenses
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
         allow!
-      in role: { name: 'product' } if license.product == bearer
+      in role: Role(:product) if license.product == bearer
         allow!
-      in role: { name: 'user' } if license.user == bearer
+      in role: Role(:user) if license.user == bearer
         allow!
-      in role: { name: 'license' } if license == bearer
+      in role: Role(:license) if license == bearer
         allow!
       else
         deny!
@@ -31,13 +31,13 @@ module Licenses
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
         allow!
-      in role: { name: 'product' } if license.product == bearer
+      in role: Role(:product) if license.product == bearer
         allow!
-      in role: { name: 'user' } if license.user == bearer
+      in role: Role(:user) if license.user == bearer
         allow!
-      in role: { name: 'license' } if license == bearer
+      in role: Role(:license) if license == bearer
         allow!
       else
         deny!
@@ -54,9 +54,9 @@ module Licenses
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :environment)
         allow!
-      in role: { name: 'product' } if license.product == bearer
+      in role: Role(:product) if license.product == bearer
         allow!
       else
         deny!
@@ -71,9 +71,9 @@ module Licenses
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :environment)
         allow!
-      in role: { name: 'product' } if license.product == bearer
+      in role: Role(:product) if license.product == bearer
         allow!
       else
         deny!

--- a/app/policies/licenses/group_policy.rb
+++ b/app/policies/licenses/group_policy.rb
@@ -11,13 +11,13 @@ module Licenses
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
         allow!
-      in role: { name: 'product' } if license.product == bearer
+      in role: Role(:product) if license.product == bearer
         allow!
-      in role: { name: 'user' } if license.user == bearer
+      in role: Role(:user) if license.user == bearer
         allow!
-      in role: { name: 'license' } if license == bearer
+      in role: Role(:license) if license == bearer
         allow!
       else
         deny!
@@ -29,9 +29,9 @@ module Licenses
       verify_environment!
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :environment)
         allow!
-      in role: { name: 'product' } if license.product == bearer
+      in role: Role(:product) if license.product == bearer
         allow!
       else
         deny!

--- a/app/policies/licenses/machine_policy.rb
+++ b/app/policies/licenses/machine_policy.rb
@@ -11,13 +11,13 @@ module Licenses
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
         allow!
-      in role: { name: 'product' } if license.product == bearer
+      in role: Role(:product) if license.product == bearer
         allow!
-      in role: { name: 'user' } if license.user == bearer
+      in role: Role(:user) if license.user == bearer
         allow!
-      in role: { name: 'license' } if license == bearer
+      in role: Role(:license) if license == bearer
         allow!
       else
         deny!
@@ -31,13 +31,13 @@ module Licenses
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
         allow!
-      in role: { name: 'product' } if license.product == bearer
+      in role: Role(:product) if license.product == bearer
         allow!
-      in role: { name: 'user' } if license.user == bearer
+      in role: Role(:user) if license.user == bearer
         allow!
-      in role: { name: 'license' } if license == bearer
+      in role: Role(:license) if license == bearer
         allow!
       else
         deny!

--- a/app/policies/licenses/policy_policy.rb
+++ b/app/policies/licenses/policy_policy.rb
@@ -11,13 +11,13 @@ module Licenses
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
         allow!
-      in role: { name: 'product' } if license.product == bearer
+      in role: Role(:product) if license.product == bearer
         allow!
-      in role: { name: 'user' } if license.user == bearer
+      in role: Role(:user) if license.user == bearer
         allow!
-      in role: { name: 'license' } if license == bearer
+      in role: Role(:license) if license == bearer
         allow!
       else
         deny!
@@ -29,11 +29,11 @@ module Licenses
       verify_environment!
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :environment)
         allow!
-      in role: { name: 'product' } if license.product == bearer
+      in role: Role(:product) if license.product == bearer
         record&.product == bearer
-      in role: { name: 'user' } if license.user == bearer
+      in role: Role(:user) if license.user == bearer
         !license.protected? && !record&.protected?
       else
         deny!

--- a/app/policies/licenses/product_policy.rb
+++ b/app/policies/licenses/product_policy.rb
@@ -11,13 +11,13 @@ module Licenses
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
         allow!
-      in role: { name: 'product' } if license.product == bearer
+      in role: Role(:product) if license.product == bearer
         allow!
-      in role: { name: 'user' } if license.user == bearer
+      in role: Role(:user) if license.user == bearer
         allow!
-      in role: { name: 'license' } if license == bearer
+      in role: Role(:license) if license == bearer
         allow!
       else
         deny!

--- a/app/policies/licenses/token_policy.rb
+++ b/app/policies/licenses/token_policy.rb
@@ -11,9 +11,9 @@ module Licenses
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
         allow!
-      in role: { name: 'product' } if license.product == bearer
+      in role: Role(:product) if license.product == bearer
         allow!
       else
         deny!
@@ -27,9 +27,9 @@ module Licenses
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
         allow!
-      in role: { name: 'product' } if license.product == bearer
+      in role: Role(:product) if license.product == bearer
         allow!
       else
         deny!
@@ -41,9 +41,9 @@ module Licenses
       verify_environment!
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :environment)
         allow!
-      in role: { name: 'product' } if license.product == bearer
+      in role: Role(:product) if license.product == bearer
         allow!
       else
         deny!

--- a/app/policies/licenses/usage_policy.rb
+++ b/app/policies/licenses/usage_policy.rb
@@ -9,13 +9,13 @@ module Licenses
       verify_environment!
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :environment)
         allow!
-      in role: { name: 'product' } if license.product == bearer
+      in role: Role(:product) if license.product == bearer
         allow!
-      in role: { name: 'user' } if license.user == bearer
+      in role: Role(:user) if license.user == bearer
         !license.policy.protected?
-      in role: { name: 'license' } if license == bearer
+      in role: Role(:license) if license == bearer
         allow!
       else
         deny!
@@ -27,9 +27,9 @@ module Licenses
       verify_environment!
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :environment)
         allow!
-      in role: { name: 'product' } if license.product == bearer
+      in role: Role(:product) if license.product == bearer
         allow!
       else
         deny!
@@ -41,9 +41,9 @@ module Licenses
       verify_environment!
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :environment)
         allow!
-      in role: { name: 'product' } if license.product == bearer
+      in role: Role(:product) if license.product == bearer
         allow!
       else
         deny!

--- a/app/policies/licenses/user_policy.rb
+++ b/app/policies/licenses/user_policy.rb
@@ -11,13 +11,13 @@ module Licenses
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
         allow!
-      in role: { name: 'product' } if license.product == bearer
+      in role: Role(:product) if license.product == bearer
         allow!
-      in role: { name: 'user' } if license.user == bearer
+      in role: Role(:user) if license.user == bearer
         allow!
-      in role: { name: 'license' } if license == bearer
+      in role: Role(:license) if license == bearer
         allow!
       else
         deny!
@@ -29,9 +29,9 @@ module Licenses
       verify_environment!
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :environment)
         allow!
-      in role: { name: 'product' } if license.product == bearer
+      in role: Role(:product) if license.product == bearer
         allow!
       else
         deny!

--- a/app/policies/machine_file_policy.rb
+++ b/app/policies/machine_file_policy.rb
@@ -8,13 +8,13 @@ class MachineFilePolicy < ApplicationPolicy
     )
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+    in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
       allow!
-    in role: { name: 'product' } if record.product == bearer
+    in role: Role(:product) if record.product == bearer
       allow!
-    in role: { name: 'user' } if record.user == bearer
+    in role: Role(:user) if record.user == bearer
       allow!
-    in role: { name: 'license' } if record.license == bearer
+    in role: Role(:license) if record.license == bearer
       allow!
     else
       deny!

--- a/app/policies/machine_policy.rb
+++ b/app/policies/machine_policy.rb
@@ -8,13 +8,13 @@ class MachinePolicy < ApplicationPolicy
     )
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+    in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
       allow!
-    in role: { name: 'product' } if record.all? { _1.product == bearer }
+    in role: Role(:product) if record.all? { _1.product == bearer }
       allow!
-    in role: { name: 'user' } if record.all? { _1.user == bearer }
+    in role: Role(:user) if record.all? { _1.user == bearer }
       allow!
-    in role: { name: 'license' } if record.all? { _1.license == bearer }
+    in role: Role(:license) if record.all? { _1.license == bearer }
       allow!
     else
       deny!
@@ -28,13 +28,13 @@ class MachinePolicy < ApplicationPolicy
     )
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+    in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
       allow!
-    in role: { name: 'product' } if record.product == bearer
+    in role: Role(:product) if record.product == bearer
       allow!
-    in role: { name: 'user' } if record.user == bearer
+    in role: Role(:user) if record.user == bearer
       allow!
-    in role: { name: 'license' } if record.license == bearer
+    in role: Role(:license) if record.license == bearer
       allow!
     else
       deny!
@@ -46,13 +46,13 @@ class MachinePolicy < ApplicationPolicy
     verify_environment!
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'sales_agent' | 'environment' }
+    in role: Role(:admin | :developer | :sales_agent | :environment)
       allow!
-    in role: { name: 'product' } if record.product == bearer
+    in role: Role(:product) if record.product == bearer
       allow!
-    in role: { name: 'user' } if record.user == bearer
+    in role: Role(:user) if record.user == bearer
       !record.license&.protected?
-    in role: { name: 'license' } if record.license == bearer
+    in role: Role(:license) if record.license == bearer
       allow!
     else
       deny!
@@ -64,13 +64,13 @@ class MachinePolicy < ApplicationPolicy
     verify_environment!
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'environment' }
+    in role: Role(:admin | :developer | :sales_agent | :support_agent | :environment)
       allow!
-    in role: { name: 'product' } if record.product == bearer
+    in role: Role(:product) if record.product == bearer
       allow!
-    in role: { name: 'user' } if record.user == bearer
+    in role: Role(:user) if record.user == bearer
       !record.license.protected?
-    in role: { name: 'license' } if record.license == bearer
+    in role: Role(:license) if record.license == bearer
       !record.license.protected?
     else
       deny!
@@ -82,13 +82,13 @@ class MachinePolicy < ApplicationPolicy
     verify_environment!
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'sales_agent' | 'environment' }
+    in role: Role(:admin | :developer | :sales_agent | :environment)
       allow!
-    in role: { name: 'product' } if record.product == bearer
+    in role: Role(:product) if record.product == bearer
       allow!
-    in role: { name: 'user' } if record.user == bearer
+    in role: Role(:user) if record.user == bearer
       !record.license.protected?
-    in role: { name: 'license' } if record.license == bearer
+    in role: Role(:license) if record.license == bearer
       allow!
     else
       deny!
@@ -100,13 +100,13 @@ class MachinePolicy < ApplicationPolicy
     verify_environment!
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'environment' }
+    in role: Role(:admin | :developer | :sales_agent | :support_agent | :environment)
       allow!
-    in role: { name: 'product' } if record.product == bearer
+    in role: Role(:product) if record.product == bearer
       allow!
-    in role: { name: 'user' } if record.user == bearer
+    in role: Role(:user) if record.user == bearer
       !record.license.protected?
-    in role: { name: 'license' } if record.license == bearer
+    in role: Role(:license) if record.license == bearer
       allow!
     else
       deny!

--- a/app/policies/machine_process_policy.rb
+++ b/app/policies/machine_process_policy.rb
@@ -8,13 +8,13 @@ class MachineProcessPolicy < ApplicationPolicy
     )
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+    in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
       allow!
-    in role: { name: 'product' } if record.all? { _1.product == bearer }
+    in role: Role(:product) if record.all? { _1.product == bearer }
       allow!
-    in role: { name: 'user' } if record.all? { _1.user == bearer }
+    in role: Role(:user) if record.all? { _1.user == bearer }
       allow!
-    in role: { name: 'license' } if record.all? { _1.license == bearer }
+    in role: Role(:license) if record.all? { _1.license == bearer }
       allow!
     else
       deny!
@@ -28,13 +28,13 @@ class MachineProcessPolicy < ApplicationPolicy
     )
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+    in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
       allow!
-    in role: { name: 'product' } if record.product == bearer
+    in role: Role(:product) if record.product == bearer
       allow!
-    in role: { name: 'user' } if record.user == bearer
+    in role: Role(:user) if record.user == bearer
       allow!
-    in role: { name: 'license' } if record.license == bearer
+    in role: Role(:license) if record.license == bearer
       allow!
     else
       deny!
@@ -46,13 +46,13 @@ class MachineProcessPolicy < ApplicationPolicy
     verify_environment!
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'sales_agent' | 'environment' }
+    in role: Role(:admin | :developer | :sales_agent | :environment)
       allow!
-    in role: { name: 'product' } if record.product == bearer
+    in role: Role(:product) if record.product == bearer
       allow!
-    in role: { name: 'user' } if record.user == bearer
+    in role: Role(:user) if record.user == bearer
       !record.license&.protected?
-    in role: { name: 'license' } if record.license == bearer
+    in role: Role(:license) if record.license == bearer
       allow!
     else
       deny!
@@ -64,13 +64,13 @@ class MachineProcessPolicy < ApplicationPolicy
     verify_environment!
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'environment' }
+    in role: Role(:admin | :developer | :sales_agent | :support_agent | :environment)
       allow!
-    in role: { name: 'product' } if record.product == bearer
+    in role: Role(:product) if record.product == bearer
       allow!
-    in role: { name: 'user' } if record.user == bearer
+    in role: Role(:user) if record.user == bearer
       !record.license.protected?
-    in role: { name: 'license' } if record.license == bearer
+    in role: Role(:license) if record.license == bearer
       allow!
     else
       deny!
@@ -82,13 +82,13 @@ class MachineProcessPolicy < ApplicationPolicy
     verify_environment!
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'sales_agent' | 'environment' }
+    in role: Role(:admin | :developer | :sales_agent | :environment)
       allow!
-    in role: { name: 'product' } if record.product == bearer
+    in role: Role(:product) if record.product == bearer
       allow!
-    in role: { name: 'user' } if record.user == bearer
+    in role: Role(:user) if record.user == bearer
       !record.license.protected?
-    in role: { name: 'license' } if record.license == bearer
+    in role: Role(:license) if record.license == bearer
       allow!
     else
       deny!

--- a/app/policies/machine_processes/heartbeat_policy.rb
+++ b/app/policies/machine_processes/heartbeat_policy.rb
@@ -11,13 +11,13 @@ module MachineProcesses
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'environment' }
+      in role: Role(:admin | :developer | :environment)
         allow!
-      in role: { name: 'product' } if machine_process.product == bearer
+      in role: Role(:product) if machine_process.product == bearer
         allow!
-      in role: { name: 'user' } if machine_process.user == bearer
+      in role: Role(:user) if machine_process.user == bearer
         !machine_process.license.protected?
-      in role: { name: 'license' } if machine_process.license == bearer
+      in role: Role(:license) if machine_process.license == bearer
         allow!
       else
         deny!

--- a/app/policies/machine_processes/license_policy.rb
+++ b/app/policies/machine_processes/license_policy.rb
@@ -11,13 +11,13 @@ module MachineProcesses
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
         allow!
-      in role: { name: 'product' } if machine_process.product == bearer
+      in role: Role(:product) if machine_process.product == bearer
         allow!
-      in role: { name: 'user' } if machine_process.user == bearer
+      in role: Role(:user) if machine_process.user == bearer
         allow!
-      in role: { name: 'license' } if machine_process.license == bearer
+      in role: Role(:license) if machine_process.license == bearer
         allow!
       else
         deny!

--- a/app/policies/machine_processes/machine_policy.rb
+++ b/app/policies/machine_processes/machine_policy.rb
@@ -11,13 +11,13 @@ module MachineProcesses
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
         allow!
-      in role: { name: 'product' } if machine_process.product == bearer
+      in role: Role(:product) if machine_process.product == bearer
         allow!
-      in role: { name: 'user' } if machine_process.user == bearer
+      in role: Role(:user) if machine_process.user == bearer
         allow!
-      in role: { name: 'license' } if machine_process.license == bearer
+      in role: Role(:license) if machine_process.license == bearer
         allow!
       else
         deny!

--- a/app/policies/machine_processes/product_policy.rb
+++ b/app/policies/machine_processes/product_policy.rb
@@ -11,13 +11,13 @@ module MachineProcesses
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
         allow!
-      in role: { name: 'product' } if machine_process.product == bearer
+      in role: Role(:product) if machine_process.product == bearer
         allow!
-      in role: { name: 'user' } if machine_process.user == bearer
+      in role: Role(:user) if machine_process.user == bearer
         allow!
-      in role: { name: 'license' } if machine_process.license == bearer
+      in role: Role(:license) if machine_process.license == bearer
         allow!
       else
         deny!

--- a/app/policies/machines/group_policy.rb
+++ b/app/policies/machines/group_policy.rb
@@ -11,13 +11,13 @@ module Machines
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
         allow!
-      in role: { name: 'product' } if machine.product == bearer
+      in role: Role(:product) if machine.product == bearer
         allow!
-      in role: { name: 'user' } if machine.user == bearer || record.id == bearer.group_id || record.id.in?(bearer.group_ids)
+      in role: Role(:user) if machine.user == bearer || record.id == bearer.group_id || record.id.in?(bearer.group_ids)
         allow!
-      in role: { name: 'license' } if machine.license == bearer
+      in role: Role(:license) if machine.license == bearer
         allow!
       else
         deny!
@@ -29,9 +29,9 @@ module Machines
       verify_environment!
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :environment)
         allow!
-      in role: { name: 'product' } if machine.product == bearer
+      in role: Role(:product) if machine.product == bearer
         allow!
       else
         deny!

--- a/app/policies/machines/heartbeat_policy.rb
+++ b/app/policies/machines/heartbeat_policy.rb
@@ -11,13 +11,13 @@ module Machines
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'environment' }
+      in role: Role(:admin | :developer | :environment)
         allow!
-      in role: { name: 'product' } if machine.product == bearer
+      in role: Role(:product) if machine.product == bearer
         allow!
-      in role: { name: 'user' } if machine.user == bearer
+      in role: Role(:user) if machine.user == bearer
         !machine.license.protected?
-      in role: { name: 'license' } if machine.license == bearer
+      in role: Role(:license) if machine.license == bearer
         allow!
       else
         deny!
@@ -31,9 +31,9 @@ module Machines
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :environment)
         allow!
-      in role: { name: 'product' } if machine.product == bearer
+      in role: Role(:product) if machine.product == bearer
         allow!
       else
         deny!

--- a/app/policies/machines/license_policy.rb
+++ b/app/policies/machines/license_policy.rb
@@ -11,13 +11,13 @@ module Machines
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
         allow!
-      in role: { name: 'product' } if machine.product == bearer
+      in role: Role(:product) if machine.product == bearer
         allow!
-      in role: { name: 'user' } if machine.user == bearer
+      in role: Role(:user) if machine.user == bearer
         allow!
-      in role: { name: 'license' } if machine.license == bearer
+      in role: Role(:license) if machine.license == bearer
         allow!
       else
         deny!

--- a/app/policies/machines/machine_process_policy.rb
+++ b/app/policies/machines/machine_process_policy.rb
@@ -11,13 +11,13 @@ module Machines
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
         allow!
-      in role: { name: 'product' } if machine.product == bearer
+      in role: Role(:product) if machine.product == bearer
         allow!
-      in role: { name: 'user' } if machine.user == bearer
+      in role: Role(:user) if machine.user == bearer
         allow!
-      in role: { name: 'license' } if machine.license == bearer
+      in role: Role(:license) if machine.license == bearer
         allow!
       else
         deny!
@@ -31,13 +31,13 @@ module Machines
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
         allow!
-      in role: { name: 'product' } if machine.product == bearer
+      in role: Role(:product) if machine.product == bearer
         allow!
-      in role: { name: 'user' } if machine.user == bearer
+      in role: Role(:user) if machine.user == bearer
         allow!
-      in role: { name: 'license' } if machine.license == bearer
+      in role: Role(:license) if machine.license == bearer
         allow!
       else
         deny!

--- a/app/policies/machines/product_policy.rb
+++ b/app/policies/machines/product_policy.rb
@@ -11,13 +11,13 @@ module Machines
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
         allow!
-      in role: { name: 'product' } if machine.product == bearer
+      in role: Role(:product) if machine.product == bearer
         allow!
-      in role: { name: 'user' } if machine.user == bearer
+      in role: Role(:user) if machine.user == bearer
         allow!
-      in role: { name: 'license' } if machine.license == bearer
+      in role: Role(:license) if machine.license == bearer
         allow!
       else
         deny!

--- a/app/policies/machines/user_policy.rb
+++ b/app/policies/machines/user_policy.rb
@@ -11,13 +11,13 @@ module Machines
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
         allow!
-      in role: { name: 'product' } if machine.product == bearer
+      in role: Role(:product) if machine.product == bearer
         allow!
-      in role: { name: 'user' } if machine.user == bearer
+      in role: Role(:user) if machine.user == bearer
         allow!
-      in role: { name: 'license' } if machine.license == bearer
+      in role: Role(:license) if machine.license == bearer
         allow!
       else
         deny!

--- a/app/policies/machines/v1x0/proof_policy.rb
+++ b/app/policies/machines/v1x0/proof_policy.rb
@@ -11,13 +11,13 @@ module Machines::V1x0
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :environment)
         allow!
-      in role: { name: 'product' } if machine.product == bearer
+      in role: Role(:product) if machine.product == bearer
         allow!
-      in role: { name: 'user' } if machine.user == bearer
+      in role: Role(:user) if machine.user == bearer
         !machine.license.protected?
-      in role: { name: 'license' } if machine.license == bearer
+      in role: Role(:license) if machine.license == bearer
         allow!
       else
         deny!

--- a/app/policies/metric_policy.rb
+++ b/app/policies/metric_policy.rb
@@ -6,7 +6,7 @@ class MetricPolicy < ApplicationPolicy
     verify_environment!
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' }
+    in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only)
       allow!
     else
       deny!
@@ -18,7 +18,7 @@ class MetricPolicy < ApplicationPolicy
     verify_environment!
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' }
+    in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only)
       allow!
     else
       deny!

--- a/app/policies/policies/entitlement_policy.rb
+++ b/app/policies/policies/entitlement_policy.rb
@@ -11,9 +11,9 @@ module Policies
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
         allow!
-      in role: { name: 'product' } if policy.product == bearer
+      in role: Role(:product) if policy.product == bearer
         allow!
       else
         deny!
@@ -27,9 +27,9 @@ module Policies
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
         allow!
-      in role: { name: 'product' } if policy.product == bearer
+      in role: Role(:product) if policy.product == bearer
         allow!
       else
         deny!
@@ -46,9 +46,9 @@ module Policies
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :environment)
         allow!
-      in role: { name: 'product' } if policy.product == bearer
+      in role: Role(:product) if policy.product == bearer
         allow!
       else
         deny!
@@ -63,9 +63,9 @@ module Policies
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :environment)
         allow!
-      in role: { name: 'product' } if policy.product == bearer
+      in role: Role(:product) if policy.product == bearer
         allow!
       else
         deny!

--- a/app/policies/policies/license_policy.rb
+++ b/app/policies/policies/license_policy.rb
@@ -11,9 +11,9 @@ module Policies
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
         allow!
-      in role: { name: 'product' } if policy.product == bearer
+      in role: Role(:product) if policy.product == bearer
         allow!
       else
         deny!
@@ -27,9 +27,9 @@ module Policies
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
         allow!
-      in role: { name: 'product' } if policy.product == bearer
+      in role: Role(:product) if policy.product == bearer
         allow!
       else
         deny!

--- a/app/policies/policies/pool_policy.rb
+++ b/app/policies/policies/pool_policy.rb
@@ -11,9 +11,9 @@ module Policies
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
         allow!
-      in role: { name: 'product' } if policy.product == bearer
+      in role: Role(:product) if policy.product == bearer
         record.all? { _1.product == bearer }
       else
         deny!
@@ -27,9 +27,9 @@ module Policies
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
         allow!
-      in role: { name: 'product' } if policy.product == bearer
+      in role: Role(:product) if policy.product == bearer
         record.product == bearer
       else
         deny!
@@ -43,9 +43,9 @@ module Policies
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'environment' }
+      in role: Role(:admin | :developer | :environment)
         allow!
-      in role: { name: 'product' } if policy.product == bearer
+      in role: Role(:product) if policy.product == bearer
         allow!
       else
         deny!

--- a/app/policies/policies/product_policy.rb
+++ b/app/policies/policies/product_policy.rb
@@ -11,9 +11,9 @@ module Policies
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
         allow!
-      in role: { name: 'product' } if policy.product == bearer
+      in role: Role(:product) if policy.product == bearer
         allow!
       else
         deny!

--- a/app/policies/policy_policy.rb
+++ b/app/policies/policy_policy.rb
@@ -8,13 +8,13 @@ class PolicyPolicy < ApplicationPolicy
     )
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+    in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
       allow!
-    in role: { name: 'product' } if record.all? { _1.product_id == bearer.id }
+    in role: Role(:product) if record.all? { _1.product_id == bearer.id }
       allow!
-    in role: { name: 'license' } if record == [bearer.policy]
+    in role: Role(:license) if record == [bearer.policy]
       allow!
-    in role: { name: 'user' } if record_ids & bearer.policy_ids == record_ids
+    in role: Role(:user) if record_ids & bearer.policy_ids == record_ids
       allow!
     else
       deny!
@@ -28,13 +28,13 @@ class PolicyPolicy < ApplicationPolicy
     )
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+    in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
       allow!
-    in role: { name: 'product' } if record.product == bearer
+    in role: Role(:product) if record.product == bearer
       allow!
-    in role: { name: 'user' } if bearer.policies.exists?(record.id)
+    in role: Role(:user) if bearer.policies.exists?(record.id)
       allow!
-    in role: { name: 'license' } if record == bearer.policy
+    in role: Role(:license) if record == bearer.policy
       allow!
     else
       deny!
@@ -46,9 +46,9 @@ class PolicyPolicy < ApplicationPolicy
     verify_environment!
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'sales_agent' | 'environment' }
+    in role: Role(:admin | :developer | :sales_agent | :environment)
       allow!
-    in role: { name: 'product' } if record.product == bearer
+    in role: Role(:product) if record.product == bearer
       allow!
     else
       deny!
@@ -60,9 +60,9 @@ class PolicyPolicy < ApplicationPolicy
     verify_environment!
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'sales_agent' | 'environment' }
+    in role: Role(:admin | :developer | :sales_agent | :environment)
       allow!
-    in role: { name: 'product' } if record.product == bearer
+    in role: Role(:product) if record.product == bearer
       allow!
     else
       deny!
@@ -74,9 +74,9 @@ class PolicyPolicy < ApplicationPolicy
     verify_environment!
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'environment' }
+    in role: Role(:admin | :developer | :environment)
       allow!
-    in role: { name: 'product' } if record.product == bearer
+    in role: Role(:product) if record.product == bearer
       allow!
     else
       deny!

--- a/app/policies/product_policy.rb
+++ b/app/policies/product_policy.rb
@@ -8,11 +8,11 @@ class ProductPolicy < ApplicationPolicy
     )
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+    in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
       allow!
-    in role: { name: 'user' } if record_ids & bearer.product_ids == record_ids
+    in role: Role(:user) if record_ids & bearer.product_ids == record_ids
       allow!
-    in role: { name: 'license' } if record == [bearer.product]
+    in role: Role(:license) if record == [bearer.product]
       allow!
     else
       deny!
@@ -26,13 +26,13 @@ class ProductPolicy < ApplicationPolicy
     )
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+    in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
       allow!
-    in role: { name: 'product' } if record == bearer
+    in role: Role(:product) if record == bearer
       allow!
-    in role: { name: 'user' } if bearer.products.exists?(record.id)
+    in role: Role(:user) if bearer.products.exists?(record.id)
       allow!
-    in role: { name: 'license' } if record == bearer.product
+    in role: Role(:license) if record == bearer.product
       allow!
     else
       deny!
@@ -44,7 +44,7 @@ class ProductPolicy < ApplicationPolicy
     verify_environment!
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'environment' }
+    in role: Role(:admin | :developer | :environment)
       allow!
     else
       deny!
@@ -56,9 +56,9 @@ class ProductPolicy < ApplicationPolicy
     verify_environment!
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'environment' }
+    in role: Role(:admin | :developer | :environment)
       allow!
-    in role: { name: 'product' } if record == bearer
+    in role: Role(:product) if record == bearer
       allow!
     else
       deny!
@@ -70,7 +70,7 @@ class ProductPolicy < ApplicationPolicy
     verify_environment!
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'environment' }
+    in role: Role(:admin | :developer | :environment)
       allow!
     else
       deny!
@@ -84,7 +84,7 @@ class ProductPolicy < ApplicationPolicy
     )
 
     case bearer
-    in role: { name: 'product' } if record == bearer
+    in role: Role(:product) if record == bearer
       allow!
     else
       deny!

--- a/app/policies/products/license_policy.rb
+++ b/app/policies/products/license_policy.rb
@@ -11,9 +11,9 @@ module Products
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
         allow!
-      in role: { name: 'product' } if product == bearer
+      in role: Role(:product) if product == bearer
         allow!
       else
         deny!
@@ -27,9 +27,9 @@ module Products
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
         allow!
-      in role: { name: 'product' } if product == bearer
+      in role: Role(:product) if product == bearer
         allow!
       else
         deny!

--- a/app/policies/products/machine_policy.rb
+++ b/app/policies/products/machine_policy.rb
@@ -11,9 +11,9 @@ module Products
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
         allow!
-      in role: { name: 'product' } if product == bearer
+      in role: Role(:product) if product == bearer
         allow!
       else
         deny!
@@ -27,9 +27,9 @@ module Products
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
         allow!
-      in role: { name: 'product' } if product == bearer
+      in role: Role(:product) if product == bearer
         allow!
       else
         deny!

--- a/app/policies/products/policy_policy.rb
+++ b/app/policies/products/policy_policy.rb
@@ -11,9 +11,9 @@ module Products
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
         allow!
-      in role: { name: 'product' } if product == bearer
+      in role: Role(:product) if product == bearer
         allow!
       else
         deny!
@@ -27,9 +27,9 @@ module Products
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
         allow!
-      in role: { name: 'product' } if product == bearer
+      in role: Role(:product) if product == bearer
         allow!
       else
         deny!

--- a/app/policies/products/release_arch_policy.rb
+++ b/app/policies/products/release_arch_policy.rb
@@ -13,13 +13,13 @@ module Products
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
         allow!
-      in role: { name: 'product' } if product == bearer
+      in role: Role(:product) if product == bearer
         allow!
-      in role: { name: 'user' } if bearer.products.exists?(product.id)
+      in role: Role(:user) if bearer.products.exists?(product.id)
         allow!
-      in role: { name: 'license' } if product == bearer.product
+      in role: Role(:license) if product == bearer.product
         allow!
       else
         product.open_distribution?
@@ -33,13 +33,13 @@ module Products
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
         allow!
-      in role: { name: 'product' } if product == bearer
+      in role: Role(:product) if product == bearer
         allow!
-      in role: { name: 'user' } if bearer.products.exists?(product.id)
+      in role: Role(:user) if bearer.products.exists?(product.id)
         allow!
-      in role: { name: 'license' } if product == bearer.product
+      in role: Role(:license) if product == bearer.product
         allow!
       else
         product.open_distribution?

--- a/app/policies/products/release_artifact_policy.rb
+++ b/app/policies/products/release_artifact_policy.rb
@@ -13,13 +13,13 @@ module Products
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
         allow!
-      in role: { name: 'product' } if product == bearer
+      in role: Role(:product) if product == bearer
         allow!
-      in role: { name: 'user' } if bearer.products.exists?(product.id)
+      in role: Role(:user) if bearer.products.exists?(product.id)
         allow? :index, record, skip_verify_permissions: true, with: ::ReleaseArtifactPolicy
-      in role: { name: 'license' } if product == bearer.product
+      in role: Role(:license) if product == bearer.product
         allow? :index, record, skip_verify_permissions: true, with: ::ReleaseArtifactPolicy
       else
         product.open_distribution? && record.none?(&:constraints?)
@@ -33,13 +33,13 @@ module Products
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
         allow!
-      in role: { name: 'product' } if product == bearer
+      in role: Role(:product) if product == bearer
         allow!
-      in role: { name: 'user' } if bearer.products.exists?(product.id)
+      in role: Role(:user) if bearer.products.exists?(product.id)
         allow? :show, record, skip_verify_permissions: true, with: ::ReleaseArtifactPolicy
-      in role: { name: 'license' } if product == bearer.product
+      in role: Role(:license) if product == bearer.product
         allow? :show, record, skip_verify_permissions: true, with: ::ReleaseArtifactPolicy
       else
         product.open_distribution? && record.constraints.none?

--- a/app/policies/products/release_channel_policy.rb
+++ b/app/policies/products/release_channel_policy.rb
@@ -13,13 +13,13 @@ module Products
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
         allow!
-      in role: { name: 'product' } if product == bearer
+      in role: Role(:product) if product == bearer
         allow!
-      in role: { name: 'user' } if bearer.products.exists?(product.id)
+      in role: Role(:user) if bearer.products.exists?(product.id)
         allow!
-      in role: { name: 'license' } if product == bearer.product
+      in role: Role(:license) if product == bearer.product
         allow!
       else
         product.open_distribution?
@@ -33,13 +33,13 @@ module Products
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
         allow!
-      in role: { name: 'product' } if product == bearer
+      in role: Role(:product) if product == bearer
         allow!
-      in role: { name: 'user' } if bearer.products.exists?(product.id)
+      in role: Role(:user) if bearer.products.exists?(product.id)
         allow!
-      in role: { name: 'license' } if product == bearer.product
+      in role: Role(:license) if product == bearer.product
         allow!
       else
         product.open_distribution?

--- a/app/policies/products/release_platform_policy.rb
+++ b/app/policies/products/release_platform_policy.rb
@@ -13,13 +13,13 @@ module Products
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
         allow!
-      in role: { name: 'product' } if product == bearer
+      in role: Role(:product) if product == bearer
         allow!
-      in role: { name: 'user' } if bearer.products.exists?(product.id)
+      in role: Role(:user) if bearer.products.exists?(product.id)
         allow!
-      in role: { name: 'license' } if product == bearer.product
+      in role: Role(:license) if product == bearer.product
         allow!
       else
         product.open_distribution?
@@ -33,13 +33,13 @@ module Products
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
         allow!
-      in role: { name: 'product' } if product == bearer
+      in role: Role(:product) if product == bearer
         allow!
-      in role: { name: 'user' } if bearer.products.exists?(product.id)
+      in role: Role(:user) if bearer.products.exists?(product.id)
         allow!
-      in role: { name: 'license' } if product == bearer.product
+      in role: Role(:license) if product == bearer.product
         allow!
       else
         product.open_distribution?

--- a/app/policies/products/release_policy.rb
+++ b/app/policies/products/release_policy.rb
@@ -13,13 +13,13 @@ module Products
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
         allow!
-      in role: { name: 'product' } if product == bearer
+      in role: Role(:product) if product == bearer
         allow!
-      in role: { name: 'user' } if bearer.products.exists?(product.id)
+      in role: Role(:user) if bearer.products.exists?(product.id)
         allow? :index, record, skip_verify_permissions: true, with: ::ReleasePolicy
-      in role: { name: 'license' } if product == bearer.product
+      in role: Role(:license) if product == bearer.product
         allow? :index, record, skip_verify_permissions: true, with: ::ReleasePolicy
       else
         product.open_distribution? && record.none?(&:constraints?)
@@ -33,13 +33,13 @@ module Products
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
         allow!
-      in role: { name: 'product' } if product == bearer
+      in role: Role(:product) if product == bearer
         allow!
-      in role: { name: 'user' } if bearer.products.exists?(product.id)
+      in role: Role(:user) if bearer.products.exists?(product.id)
         allow? :show, record, skip_verify_permissions: true, with: ::ReleasePolicy
-      in role: { name: 'license' } if product == bearer.product
+      in role: Role(:license) if product == bearer.product
         allow? :show, record, skip_verify_permissions: true, with: ::ReleasePolicy
       else
         product.open_distribution? && record.constraints.none?

--- a/app/policies/products/token_policy.rb
+++ b/app/policies/products/token_policy.rb
@@ -11,9 +11,9 @@ module Products
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
         allow!
-      in role: { name: 'product' } if product == bearer
+      in role: Role(:product) if product == bearer
         record.all? { _1 in bearer_type: ^(Product.name), bearer_id: ^(bearer.id) }
       else
         deny!
@@ -27,9 +27,9 @@ module Products
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
         allow!
-      in role: { name: 'product' } if product == bearer && record.bearer == bearer
+      in role: Role(:product) if product == bearer && record.bearer == bearer
         allow!
       else
         deny!
@@ -41,7 +41,7 @@ module Products
       verify_environment!
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'environment' }
+      in role: Role(:admin | :developer | :environment)
         allow!
       else
         deny!

--- a/app/policies/products/user_policy.rb
+++ b/app/policies/products/user_policy.rb
@@ -11,9 +11,9 @@ module Products
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
         allow!
-      in role: { name: 'product' } if product == bearer
+      in role: Role(:product) if product == bearer
         allow!
       else
         deny!
@@ -27,9 +27,9 @@ module Products
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
         allow!
-      in role: { name: 'product' } if product == bearer
+      in role: Role(:product) if product == bearer
         allow!
       else
         deny!

--- a/app/policies/release_arch_policy.rb
+++ b/app/policies/release_arch_policy.rb
@@ -8,15 +8,15 @@ class ReleaseArchPolicy < ApplicationPolicy
       relation.respond_to?(:for_environment)
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'read_only' | 'sales_agent' | 'support_agent' }
+    in role: Role(:admin | :developer | :read_only | :sales_agent | :support_agent)
       relation.all
-    in role: { name: 'environment' } if relation.respond_to?(:for_environment)
+    in role: Role(:environment) if relation.respond_to?(:for_environment)
       relation.for_environment(bearer.id)
-    in role: { name: 'product' } if relation.respond_to?(:for_product)
+    in role: Role(:product) if relation.respond_to?(:for_product)
       relation.for_product(bearer.id)
-    in role: { name: 'license' } if relation.respond_to?(:for_license)
+    in role: Role(:license) if relation.respond_to?(:for_license)
       relation.for_license(bearer.id)
-    in role: { name: 'user' } if relation.respond_to?(:for_user)
+    in role: Role(:user) if relation.respond_to?(:for_user)
       relation.for_user(bearer.id)
     else
       relation.open

--- a/app/policies/release_artifact_policy.rb
+++ b/app/policies/release_artifact_policy.rb
@@ -8,17 +8,17 @@ class ReleaseArtifactPolicy < ApplicationPolicy
       relation.respond_to?(:for_environment)
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'read_only' | 'sales_agent' | 'support_agent' }
+    in role: Role(:admin | :developer | :read_only | :sales_agent | :support_agent)
       relation.all
-    in role: { name: 'environment' } if relation.respond_to?(:for_environment)
+    in role: Role(:environment) if relation.respond_to?(:for_environment)
       relation.for_environment(bearer.id)
-    in role: { name: 'product' } if relation.respond_to?(:for_product)
+    in role: Role(:product) if relation.respond_to?(:for_product)
       relation.for_product(bearer.id)
-    in role: { name: 'user' } if relation.respond_to?(:for_user)
+    in role: Role(:user) if relation.respond_to?(:for_user)
       relation.for_user(bearer.id)
               .published
               .uploaded
-    in role: { name: 'license' } if relation.respond_to?(:for_license)
+    in role: Role(:license) if relation.respond_to?(:for_license)
       relation.for_license(bearer.id)
               .published
               .uploaded
@@ -52,9 +52,9 @@ class ReleaseArtifactPolicy < ApplicationPolicy
     verify_environment!
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'environment' }
+    in role: Role(:admin | :developer | :environment)
       allow!
-    in role: { name: 'product' } if record.product == bearer
+    in role: Role(:product) if record.product == bearer
       allow!
     else
       deny!
@@ -66,9 +66,9 @@ class ReleaseArtifactPolicy < ApplicationPolicy
     verify_environment!
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'environment' }
+    in role: Role(:admin | :developer | :environment)
       allow!
-    in role: { name: 'product' } if record.product == bearer
+    in role: Role(:product) if record.product == bearer
       allow!
     else
       deny!
@@ -80,9 +80,9 @@ class ReleaseArtifactPolicy < ApplicationPolicy
     verify_environment!
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'environment' }
+    in role: Role(:admin | :developer | :environment)
       allow!
-    in role: { name: 'product' } if record.product == bearer
+    in role: Role(:product) if record.product == bearer
       allow!
     else
       deny!

--- a/app/policies/release_channel_policy.rb
+++ b/app/policies/release_channel_policy.rb
@@ -8,15 +8,15 @@ class ReleaseChannelPolicy < ApplicationPolicy
       relation.respond_to?(:for_environment)
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'read_only' | 'sales_agent' | 'support_agent' }
+    in role: Role(:admin | :developer | :read_only | :sales_agent | :support_agent)
       relation.all
-    in role: { name: 'environment' } if relation.respond_to?(:for_environment)
+    in role: Role(:environment) if relation.respond_to?(:for_environment)
       relation.for_environment(bearer.id)
-    in role: { name: 'product' } if relation.respond_to?(:for_product)
+    in role: Role(:product) if relation.respond_to?(:for_product)
       relation.for_product(bearer.id)
-    in role: { name: 'license' } if relation.respond_to?(:for_license)
+    in role: Role(:license) if relation.respond_to?(:for_license)
       relation.for_license(bearer.id)
-    in role: { name: 'user' } if relation.respond_to?(:for_user)
+    in role: Role(:user) if relation.respond_to?(:for_user)
       relation.for_user(bearer.id)
     else
       relation.open

--- a/app/policies/release_platform_policy.rb
+++ b/app/policies/release_platform_policy.rb
@@ -8,15 +8,15 @@ class ReleasePlatformPolicy < ApplicationPolicy
       relation.respond_to?(:for_environment)
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'read_only' | 'sales_agent' | 'support_agent' }
+    in role: Role(:admin | :developer | :read_only | :sales_agent | :support_agent)
       relation.all
-    in role: { name: 'environment' } if relation.respond_to?(:for_environment)
+    in role: Role(:environment) if relation.respond_to?(:for_environment)
       relation.for_environment(bearer.id)
-    in role: { name: 'product' } if relation.respond_to?(:for_product)
+    in role: Role(:product) if relation.respond_to?(:for_product)
       relation.for_product(bearer.id)
-    in role: { name: 'license' } if relation.respond_to?(:for_license)
+    in role: Role(:license) if relation.respond_to?(:for_license)
       relation.for_license(bearer.id)
-    in role: { name: 'user' } if relation.respond_to?(:for_user)
+    in role: Role(:user) if relation.respond_to?(:for_user)
       relation.for_user(bearer.id)
     else
       relation.open

--- a/app/policies/release_policy.rb
+++ b/app/policies/release_policy.rb
@@ -8,16 +8,16 @@ class ReleasePolicy < ApplicationPolicy
       relation.respond_to?(:for_environment)
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'read_only' | 'sales_agent' | 'support_agent' }
+    in role: Role(:admin | :developer | :read_only | :sales_agent | :support_agent)
       relation.all
-    in role: { name: 'environment' } if relation.respond_to?(:for_environment)
+    in role: Role(:environment) if relation.respond_to?(:for_environment)
       relation.for_environment(bearer.id)
-    in role: { name: 'product' } if relation.respond_to?(:for_product)
+    in role: Role(:product) if relation.respond_to?(:for_product)
       relation.for_product(bearer.id)
-    in role: { name: 'user' } if relation.respond_to?(:for_user)
+    in role: Role(:user) if relation.respond_to?(:for_user)
       relation.for_user(bearer.id)
               .published
-    in role: { name: 'license' } if relation.respond_to?(:for_license)
+    in role: Role(:license) if relation.respond_to?(:for_license)
       relation.for_license(bearer.id)
               .published
     else
@@ -39,12 +39,12 @@ class ReleasePolicy < ApplicationPolicy
       bearer.nil?
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+    in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
       allow!
-    in role: { name: 'product' } if record.all? { _1.product == bearer }
+    in role: Role(:product) if record.all? { _1.product == bearer }
       allow!
-    in role: { name: 'user' } if record.all? { _1.open_distribution? && _1.constraints.none? ||
-                                               _1.product_id.in?(bearer.product_ids) }
+    in role: Role(:user) if record.all? { _1.open_distribution? && _1.constraints.none? ||
+                                          _1.product_id.in?(bearer.product_ids) }
       deny! 'release distribution strategy is closed' if
         record.any?(&:closed_distribution?)
 
@@ -64,8 +64,8 @@ class ReleasePolicy < ApplicationPolicy
       end
 
       allow!
-    in role: { name: 'license' } if record.all? { _1.open_distribution? && _1.constraints.none? ||
-                                                  _1.product == bearer.product }
+    in role: Role(:license) if record.all? { _1.open_distribution? && _1.constraints.none? ||
+                                             _1.product == bearer.product }
       deny! 'release distribution strategy is closed' if
         record.any?(&:closed_distribution?)
 
@@ -99,11 +99,11 @@ class ReleasePolicy < ApplicationPolicy
       bearer.nil?
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+    in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
       allow!
-    in role: { name: 'product' } if record.product == bearer
+    in role: Role(:product) if record.product == bearer
       allow!
-    in role: { name: 'user' } if bearer.licenses.for_product(record.product).any?
+    in role: Role(:user) if bearer.licenses.for_product(record.product).any?
       deny! 'release distribution strategy is closed' if
         record.closed_distribution?
 
@@ -116,7 +116,7 @@ class ReleasePolicy < ApplicationPolicy
       )
 
       allow!
-    in role: { name: 'license' } if record.product == bearer.product
+    in role: Role(:license) if record.product == bearer.product
       deny! 'release distribution strategy is closed' if
         record.closed_distribution?
 
@@ -136,9 +136,9 @@ class ReleasePolicy < ApplicationPolicy
     verify_environment!
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'environment' }
+    in role: Role(:admin | :developer | :environment)
       allow!
-    in role: { name: 'product' } if record.product == bearer
+    in role: Role(:product) if record.product == bearer
       allow!
     else
       deny!
@@ -150,9 +150,9 @@ class ReleasePolicy < ApplicationPolicy
     verify_environment!
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'environment' }
+    in role: Role(:admin | :developer | :environment)
       allow!
-    in role: { name: 'product' } if record.product == bearer
+    in role: Role(:product) if record.product == bearer
       allow!
     else
       deny!
@@ -164,9 +164,9 @@ class ReleasePolicy < ApplicationPolicy
     verify_environment!
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'environment' }
+    in role: Role(:admin | :developer | :environment)
       allow!
-    in role: { name: 'product' } if record.product == bearer
+    in role: Role(:product) if record.product == bearer
       allow!
     else
       deny!
@@ -184,9 +184,9 @@ class ReleasePolicy < ApplicationPolicy
     verify_environment!
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'environment' }
+    in role: Role(:admin | :developer | :environment)
       allow!
-    in role: { name: 'product' } if record.product == bearer
+    in role: Role(:product) if record.product == bearer
       allow!
     else
       deny!
@@ -198,9 +198,9 @@ class ReleasePolicy < ApplicationPolicy
     verify_environment!
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'environment' }
+    in role: Role(:admin | :developer | :environment)
       allow!
-    in role: { name: 'product' } if record.product == bearer
+    in role: Role(:product) if record.product == bearer
       allow!
     else
       deny!
@@ -212,9 +212,9 @@ class ReleasePolicy < ApplicationPolicy
     verify_environment!
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'environment' }
+    in role: Role(:admin | :developer | :environment)
       allow!
-    in role: { name: 'product' } if record.product == bearer
+    in role: Role(:product) if record.product == bearer
       allow!
     else
       deny!

--- a/app/policies/releases/entitlement_policy.rb
+++ b/app/policies/releases/entitlement_policy.rb
@@ -22,13 +22,13 @@ module Releases
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
         allow!
-      in role: { name: 'product' } if release.product == bearer
+      in role: Role(:product) if release.product == bearer
         allow!
-      in role: { name: 'user' } if bearer.products.exists?(release.product.id)
+      in role: Role(:user) if bearer.products.exists?(release.product.id)
         allow!
-      in role: { name: 'license' } if release.product == bearer.product
+      in role: Role(:license) if release.product == bearer.product
         allow!
       else
         deny!
@@ -42,13 +42,13 @@ module Releases
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
         allow!
-      in role: { name: 'product' } if release.product == bearer
+      in role: Role(:product) if release.product == bearer
         allow!
-      in role: { name: 'user' } if bearer.products.exists?(release.product.id)
+      in role: Role(:user) if bearer.products.exists?(release.product.id)
         allow!
-      in role: { name: 'license' } if release.product == bearer.product
+      in role: Role(:license) if release.product == bearer.product
         allow!
       else
         deny!

--- a/app/policies/releases/product_policy.rb
+++ b/app/policies/releases/product_policy.rb
@@ -11,13 +11,13 @@ module Releases
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
         allow!
-      in role: { name: 'product' } if release.product == bearer
+      in role: Role(:product) if release.product == bearer
         allow!
-      in role: { name: 'user' } if bearer.products.exists?(record.id)
+      in role: Role(:user) if bearer.products.exists?(record.id)
         allow!
-      in role: { name: 'license' } if record == bearer.product
+      in role: Role(:license) if record == bearer.product
         allow!
       else
         deny!

--- a/app/policies/releases/release_artifact_policy.rb
+++ b/app/policies/releases/release_artifact_policy.rb
@@ -13,13 +13,13 @@ module Releases
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
         allow!
-      in role: { name: 'product' } if release.product == bearer
+      in role: Role(:product) if release.product == bearer
         allow!
-      in role: { name: 'user' } if bearer.products.exists?(release.product.id)
+      in role: Role(:user) if bearer.products.exists?(release.product.id)
         allow? :index, record, skip_verify_permissions: true, with: ::ReleaseArtifactPolicy
-      in role: { name: 'license' } if release.product == bearer.product
+      in role: Role(:license) if release.product == bearer.product
         allow? :index, record, skip_verify_permissions: true, with: ::ReleaseArtifactPolicy
       else
         release.open_distribution? && release.constraints.none?
@@ -33,13 +33,13 @@ module Releases
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
         allow!
-      in role: { name: 'product' } if release.product == bearer
+      in role: Role(:product) if release.product == bearer
         allow!
-      in role: { name: 'user' } if bearer.products.exists?(release.product.id)
+      in role: Role(:user) if bearer.products.exists?(release.product.id)
         allow? :show, record, skip_verify_permissions: true, with: ::ReleaseArtifactPolicy
-      in role: { name: 'license' } if release.product == bearer.product
+      in role: Role(:license) if release.product == bearer.product
         allow? :show, record, skip_verify_permissions: true, with: ::ReleaseArtifactPolicy
       else
         release.open_distribution? && release.constraints.none?

--- a/app/policies/releases/release_entitlement_constraint_policy.rb
+++ b/app/policies/releases/release_entitlement_constraint_policy.rb
@@ -11,13 +11,13 @@ module Releases
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
         allow!
-      in role: { name: 'product' } if release.product == bearer
+      in role: Role(:product) if release.product == bearer
         allow!
-      in role: { name: 'user' } if bearer.products.exists?(release.product.id)
+      in role: Role(:user) if bearer.products.exists?(release.product.id)
         allow!
-      in role: { name: 'license' } if release.product == bearer.product
+      in role: Role(:license) if release.product == bearer.product
         allow!
       else
         deny!
@@ -31,13 +31,13 @@ module Releases
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
         allow!
-      in role: { name: 'product' } if release.product == bearer
+      in role: Role(:product) if release.product == bearer
         allow!
-      in role: { name: 'user' } if bearer.products.exists?(release.product.id)
+      in role: Role(:user) if bearer.products.exists?(release.product.id)
         allow!
-      in role: { name: 'license' } if release.product == bearer.product
+      in role: Role(:license) if release.product == bearer.product
         allow!
       else
         deny!
@@ -54,9 +54,9 @@ module Releases
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'environment' }
+      in role: Role(:admin | :developer | :environment)
         allow!
-      in role: { name: 'product' } if release.product == bearer
+      in role: Role(:product) if release.product == bearer
         allow!
       else
         deny!
@@ -71,9 +71,9 @@ module Releases
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'environment' }
+      in role: Role(:admin | :developer | :environment)
         allow!
-      in role: { name: 'product' } if release.product == bearer
+      in role: Role(:product) if release.product == bearer
         allow!
       else
         deny!

--- a/app/policies/releases/v1x0/download_policy.rb
+++ b/app/policies/releases/v1x0/download_policy.rb
@@ -13,13 +13,13 @@ module Releases::V1x0
       deny! if record.nil?
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
         allow!
-      in role: { name: 'product' } if record.product == bearer
+      in role: Role(:product) if record.product == bearer
         allow!
-      in role: { name: 'user' }
+      in role: Role(:user)
         allow? :show, record, skip_verify_permissions: true, with: ::ReleasePolicy
-      in role: { name: 'license' }
+      in role: Role(:license)
         allow? :show, record, skip_verify_permissions: true, with: ::ReleasePolicy
       else
         record.open_distribution? && record.constraints.none?
@@ -36,13 +36,13 @@ module Releases::V1x0
       allow! if record.nil?
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
         allow!
-      in role: { name: 'product' } if record.product == bearer
+      in role: Role(:product) if record.product == bearer
         allow!
-      in role: { name: 'user' }
+      in role: Role(:user)
         allow? :upgrade, record, skip_verify_permissions: true, with: ::ReleasePolicy
-      in role: { name: 'license' }
+      in role: Role(:license)
         allow? :upgrade, record, skip_verify_permissions: true, with: ::ReleasePolicy
       else
         record.open_distribution? && record.constraints.none?

--- a/app/policies/releases/v1x0/upload_policy.rb
+++ b/app/policies/releases/v1x0/upload_policy.rb
@@ -7,9 +7,9 @@ module Releases::V1x0
       verify_environment!
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
         allow!
-      in role: { name: 'product' } if record.product == bearer
+      in role: Role(:product) if record.product == bearer
         allow!
       else
         deny!

--- a/app/policies/releases/v1x0/yank_policy.rb
+++ b/app/policies/releases/v1x0/yank_policy.rb
@@ -7,9 +7,9 @@ module Releases::V1x0
       verify_environment!
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
         allow!
-      in role: { name: 'product' } if record.product == bearer
+      in role: Role(:product) if record.product == bearer
         allow!
       else
         deny!

--- a/app/policies/request_log_policy.rb
+++ b/app/policies/request_log_policy.rb
@@ -8,7 +8,7 @@ class RequestLogPolicy < ApplicationPolicy
     )
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'read_only' | 'environment' }
+    in role: Role(:admin | :developer | :read_only | :environment)
       allow!
     else
       deny!
@@ -22,7 +22,7 @@ class RequestLogPolicy < ApplicationPolicy
     )
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'read_only' | 'environment' }
+    in role: Role(:admin | :developer | :read_only | :environment)
       allow!
     else
       deny!

--- a/app/policies/search_policy.rb
+++ b/app/policies/search_policy.rb
@@ -7,7 +7,7 @@ class SearchPolicy < ApplicationPolicy
     )
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'read_only' | 'sales_agent' | 'support_agent' }
+    in role: Role(:admin | :developer | :read_only | :sales_agent | :support_agent)
       allow!
     else
       deny!

--- a/app/policies/token_policy.rb
+++ b/app/policies/token_policy.rb
@@ -8,14 +8,14 @@ class TokenPolicy < ApplicationPolicy
     )
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+    in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
       allow!
-    in role: { name: 'product' }
+    in role: Role(:product)
       record.all? { _1 in { bearer_type: ^(Product.name), bearer_id: ^(bearer.id) } |
                           { bearer_type: ^(License.name) | ^(User.name) } }
-    in role: { name: 'license' }
+    in role: Role(:license)
       record.all? { _1 in { bearer_type: ^(License.name), bearer_id: ^(bearer.id) } }
-    in role: { name: 'user' }
+    in role: Role(:user)
       record.all? { _1 in { bearer_type: ^(User.name), bearer_id: ^(bearer.id) } }
     else
       deny!
@@ -29,7 +29,7 @@ class TokenPolicy < ApplicationPolicy
     )
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+    in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
       allow!
     else
       record.bearer == bearer
@@ -45,11 +45,11 @@ class TokenPolicy < ApplicationPolicy
     )
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' } if record.bearer == bearer
+    in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment) if record.bearer == bearer
       allow!
-    in role: { name: 'admin' | 'developer'  | 'environment' } if record.bearer.user?
+    in role: Role(:admin | :developer | :environment) if record.bearer.user?
       allow!
-    in role: { name: 'user' } if record.bearer == bearer
+    in role: Role(:user) if record.bearer == bearer
       deny! 'user is banned' if
         bearer.banned?
 
@@ -64,9 +64,9 @@ class TokenPolicy < ApplicationPolicy
     verify_environment!
 
     case bearer
-    in role: { name: 'admin' | 'developer' } if record.bearer == bearer || record.bearer.environment? || record.bearer.product? || record.bearer.license? || record.bearer.user?
+    in role: Role(:admin | :developer) if record.bearer == bearer || record.bearer.environment? || record.bearer.product? || record.bearer.license? || record.bearer.user?
       allow!
-    in role: { name: 'environment' } if record.bearer == bearer || record.bearer.product? || record.bearer.license? || record.bearer.user?
+    in role: Role(:environment) if record.bearer == bearer || record.bearer.product? || record.bearer.license? || record.bearer.user?
       allow!
     else
       record.bearer == bearer
@@ -78,7 +78,7 @@ class TokenPolicy < ApplicationPolicy
     verify_environment!
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'environment' }
+    in role: Role(:admin | :developer | :environment)
       allow!
     else
       record.bearer == bearer

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -10,9 +10,9 @@ class UserPolicy < ApplicationPolicy
     )
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' }
+    in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only)
       allow!
-    in role: { name: 'product' | 'environment' } if record.all?(&:user?)
+    in role: Role(:product | :environment) if record.all?(&:user?)
       allow!
     else
       deny!
@@ -26,13 +26,13 @@ class UserPolicy < ApplicationPolicy
     )
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' }
+    in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only)
       allow!
-    in role: { name: 'product' | 'environment' } if record.user?
+    in role: Role(:product | :environment) if record.user?
       allow!
-    in role: { name: 'user' } if record == bearer
+    in role: Role(:user) if record == bearer
       allow!
-    in role: { name: 'license' } if record == bearer.user
+    in role: Role(:license) if record == bearer.user
       allow!
     else
       deny!
@@ -45,9 +45,9 @@ class UserPolicy < ApplicationPolicy
     verify_privileges!
 
     case bearer
-    in role: { name: 'admin' | 'developer' }
+    in role: Role(:admin | :developer)
       allow!
-    in role: { name: 'product' | 'environment' } if record.user?
+    in role: Role(:product | :environment) if record.user?
       allow!
     in nil
       !account.protected?
@@ -62,11 +62,11 @@ class UserPolicy < ApplicationPolicy
     verify_privileges!
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'sales_agent' }
+    in role: Role(:admin | :developer | :sales_agent)
       allow!
-    in role: { name: 'product' | 'environment' } if record.user?
+    in role: Role(:product | :environment) if record.user?
       allow!
-    in role: { name: 'user' } if record == bearer
+    in role: Role(:user) if record == bearer
       allow!
     else
       deny!
@@ -79,9 +79,9 @@ class UserPolicy < ApplicationPolicy
     verify_privileges!
 
     case bearer
-    in role: { name: 'admin' | 'developer' }
+    in role: Role(:admin | :developer)
       allow!
-    in role: { name: 'environment' } if record.user?
+    in role: Role(:environment) if record.user?
       allow!
     else
       deny!
@@ -93,9 +93,9 @@ class UserPolicy < ApplicationPolicy
     verify_environment!
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' }
+    in role: Role(:admin | :developer | :sales_agent | :support_agent)
       allow!
-    in role: { name: 'environment' } if record.user?
+    in role: Role(:environment) if record.user?
       allow!
     else
       deny!
@@ -110,7 +110,7 @@ class UserPolicy < ApplicationPolicy
       record.user?
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'product' | 'environment' }
+    in role: Role(:admin | :developer | :sales_agent | :support_agent | :product | :environment)
       allow!
     else
       deny!
@@ -125,7 +125,7 @@ class UserPolicy < ApplicationPolicy
       record.user?
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'product' | 'environment' }
+    in role: Role(:admin | :developer | :sales_agent | :support_agent | :product | :environment)
       allow!
     else
       deny!

--- a/app/policies/users/group_policy.rb
+++ b/app/policies/users/group_policy.rb
@@ -11,11 +11,11 @@ module Users
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
         allow!
-      in role: { name: 'product' } if user.user?
+      in role: Role(:product) if user.user?
         allow!
-      in role: { name: 'user' } if user == bearer
+      in role: Role(:user) if user == bearer
         allow!
       else
         deny!
@@ -27,9 +27,9 @@ module Users
       verify_environment!
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :environment)
         allow!
-      in role: { name: 'product' } if user.user?
+      in role: Role(:product) if user.user?
         allow!
       else
         deny!

--- a/app/policies/users/license_policy.rb
+++ b/app/policies/users/license_policy.rb
@@ -11,11 +11,11 @@ module Users
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
         allow!
-      in role: { name: 'product' } if user.user?
+      in role: Role(:product) if user.user?
         record.all? { _1.product == bearer }
-      in role: { name: 'user' } if user == bearer
+      in role: Role(:user) if user == bearer
         record.all? { _1.user == bearer }
       else
         deny!
@@ -29,11 +29,11 @@ module Users
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
         allow!
-      in role: { name: 'product' } if user.user?
+      in role: Role(:product) if user.user?
         record.product == bearer
-      in role: { name: 'user' } if user == bearer
+      in role: Role(:user) if user == bearer
         record.user == bearer
       else
         deny!

--- a/app/policies/users/machine_policy.rb
+++ b/app/policies/users/machine_policy.rb
@@ -11,11 +11,11 @@ module Users
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
         allow!
-      in role: { name: 'product' } if user.user?
+      in role: Role(:product) if user.user?
         record.all? { _1.product == bearer }
-      in role: { name: 'user' } if user == bearer
+      in role: Role(:user) if user == bearer
         record.all? { _1.user == bearer }
       else
         deny!
@@ -29,11 +29,11 @@ module Users
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
         allow!
-      in role: { name: 'product' } if user.user?
+      in role: Role(:product) if user.user?
         record.product == bearer
-      in role: { name: 'user' } if user == bearer
+      in role: Role(:user) if user == bearer
         record.user == bearer
       else
         deny!

--- a/app/policies/users/product_policy.rb
+++ b/app/policies/users/product_policy.rb
@@ -11,11 +11,11 @@ module Users
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
         allow!
-      in role: { name: 'product'} if record.all? { _1 == bearer }
+      in role: Role(:product) if record.all? { _1 == bearer }
         allow!
-      in role: { name: 'user' } if user == bearer
+      in role: Role(:user) if user == bearer
         allow!
       else
         deny!
@@ -29,11 +29,11 @@ module Users
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'environment' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
         allow!
-      in role: { name: 'product' } if record == bearer
+      in role: Role(:product) if record == bearer
         allow!
-      in role: { name: 'user' } if user == bearer
+      in role: Role(:user) if user == bearer
         allow!
       else
         deny!

--- a/app/policies/users/second_factor_policy.rb
+++ b/app/policies/users/second_factor_policy.rb
@@ -11,9 +11,9 @@ module Users
       )
 
       case bearer
-      in role: { name: 'admin' }
+      in role: Role(:admin)
         allow!
-      in role: { name: 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'user' }
+      in role: Role(:developer | :sales_agent | :support_agent | :read_only | :user)
         record.all? { _1.user_id == bearer.id }
       else
         deny!
@@ -27,9 +27,9 @@ module Users
       )
 
       case bearer
-      in role: { name: 'admin' }
+      in role: Role(:admin)
         allow!
-      in role: { name: 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'user' }
+      in role: Role(:developer | :sales_agent | :support_agent | :read_only | :user)
         record.user_id == bearer.id
       else
         deny!
@@ -45,9 +45,9 @@ module Users
         bearer.has_role?(:read_only)
 
       case bearer
-      in role: { name: 'admin' }
+      in role: Role(:admin)
         allow!
-      in role: { name: 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'user' }
+      in role: Role(:developer | :sales_agent | :support_agent | :read_only | :user)
         record.user_id == bearer.id
       else
         deny!
@@ -63,9 +63,9 @@ module Users
         bearer.has_role?(:read_only)
 
       case bearer
-      in role: { name: 'admin' }
+      in role: Role(:admin)
         allow!
-      in role: { name: 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'user' }
+      in role: Role(:developer | :sales_agent | :support_agent | :read_only | :user)
         record.user_id == bearer.id
       else
         deny!
@@ -81,9 +81,9 @@ module Users
         bearer.has_role?(:read_only)
 
       case bearer
-      in role: { name: 'admin' }
+      in role: Role(:admin)
         allow!
-      in role: { name: 'developer' | 'sales_agent' | 'support_agent' | 'read_only' | 'user' }
+      in role: Role(:developer | :sales_agent | :support_agent | :read_only | :user)
         record.user_id == bearer.id
       else
         deny!

--- a/app/policies/users/token_policy.rb
+++ b/app/policies/users/token_policy.rb
@@ -11,11 +11,11 @@ module Users
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only)
         allow!
-      in role: { name: 'product' | 'environment' } if user.user?
+      in role: Role(:product | :environment) if user.user?
         allow!
-      in role: { name: 'user' } if user == bearer
+      in role: Role(:user) if user == bearer
         allow!
       else
         deny!
@@ -29,11 +29,11 @@ module Users
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' | 'sales_agent' | 'support_agent' | 'read_only' }
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only)
         allow!
-      in role: { name: 'product' | 'environment' } if user.user?
+      in role: Role(:product | :environment) if user.user?
         allow!
-      in role: { name: 'user' } if user == bearer
+      in role: Role(:user) if user == bearer
         allow!
       else
         deny!
@@ -49,9 +49,9 @@ module Users
       )
 
       case bearer
-      in role: { name: 'admin' | 'developer' } if user == bearer || user.user?
+      in role: Role(:admin | :developer) if user == bearer || user.user?
         allow!
-      in role: { name: 'product' | 'environment' } if user.user?
+      in role: Role(:product | :environment) if user.user?
         allow!
       else
         deny!

--- a/app/policies/webhook_endpoint_policy.rb
+++ b/app/policies/webhook_endpoint_policy.rb
@@ -8,7 +8,7 @@ class WebhookEndpointPolicy < ApplicationPolicy
     )
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'read_only' | 'product' | 'environment' }
+    in role: Role(:admin | :developer | :read_only | :product | :environment)
       allow!
     else
       deny!
@@ -22,7 +22,7 @@ class WebhookEndpointPolicy < ApplicationPolicy
     )
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'read_only' | 'product' | 'environment' }
+    in role: Role(:admin | :developer | :read_only | :product | :environment)
       allow!
     else
       deny!
@@ -34,7 +34,7 @@ class WebhookEndpointPolicy < ApplicationPolicy
     verify_environment!
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'product' | 'environment' }
+    in role: Role(:admin | :developer | :product | :environment)
       allow!
     else
       deny!
@@ -46,7 +46,7 @@ class WebhookEndpointPolicy < ApplicationPolicy
     verify_environment!
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'product' | 'environment' }
+    in role: Role(:admin | :developer | :product | :environment)
       allow!
     else
       deny!
@@ -58,7 +58,7 @@ class WebhookEndpointPolicy < ApplicationPolicy
     verify_environment!
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'product' | 'environment' }
+    in role: Role(:admin | :developer | :product | :environment)
       allow!
     else
       deny!

--- a/app/policies/webhook_event_policy.rb
+++ b/app/policies/webhook_event_policy.rb
@@ -8,7 +8,7 @@ class WebhookEventPolicy < ApplicationPolicy
     )
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'read_only' | 'product' | 'environment' }
+    in role: Role(:admin | :developer | :read_only | :product | :environment)
       allow!
     else
       deny!
@@ -22,7 +22,7 @@ class WebhookEventPolicy < ApplicationPolicy
     )
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'read_only' | 'product' | 'environment' }
+    in role: Role(:admin | :developer | :read_only | :product | :environment)
       allow!
     else
       deny!
@@ -34,7 +34,7 @@ class WebhookEventPolicy < ApplicationPolicy
     verify_environment!
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'environment' }
+    in role: Role(:admin | :developer | :environment)
       allow!
     else
       deny!
@@ -46,7 +46,7 @@ class WebhookEventPolicy < ApplicationPolicy
     verify_environment!
 
     case bearer
-    in role: { name: 'admin' | 'developer' | 'environment' }
+    in role: Role(:admin | :developer | :environment)
       allow!
     else
       deny!

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'spec_helper'
+
+describe Role, type: :model do
+  let(:account)  { create(:account) }
+  let(:resource) { create(:user, account:) }
+
+  subject { resource.role }
+
+  describe 'pattern matching' do
+    context 'with admin role' do
+      let(:resource) { create(:admin, account:) }
+
+      it 'should pattern match with attribute hash' do
+        expect((subject in name: 'user' | 'admin' | 'environment' | 'product' | 'license')).to be true
+        expect((subject in name: 'user')).to be false
+        expect((subject in name: 'admin')).to be true
+        expect((subject in name: 'environment')).to be false
+        expect((subject in name: 'product')).to be false
+        expect((subject in name: 'license')).to be false
+      end
+
+      it 'should pattern match with role symbols' do
+        expect((subject in Role(:user | :admin | :environment | :product | :license))).to be true
+        expect((subject in Role(:user))).to be false
+        expect((subject in Role(:admin))).to be true
+        expect((subject in Role(:environment))).to be false
+        expect((subject in Role(:product))).to be false
+        expect((subject in Role(:license))).to be false
+      end
+    end
+
+    context 'with user role' do
+      let(:resource) { create(:user, account:) }
+
+      it 'should pattern match with attribute hash' do
+        expect((subject in name: 'user' | 'admin' | 'environment' | 'product' | 'license')).to be true
+        expect((subject in name: 'user')).to be true
+        expect((subject in name: 'admin')).to be false
+        expect((subject in name: 'environment')).to be false
+        expect((subject in name: 'product')).to be false
+        expect((subject in name: 'license')).to be false
+      end
+
+      it 'should pattern match with role symbols' do
+        expect((subject in Role(:user | :admin | :environment | :product | :license))).to be true
+        expect((subject in Role(:user))).to be true
+        expect((subject in Role(:admin))).to be false
+        expect((subject in Role(:environment))).to be false
+        expect((subject in Role(:product))).to be false
+        expect((subject in Role(:license))).to be false
+      end
+    end
+
+    context 'with environment role' do
+      let(:resource) { create(:environment, account:) }
+
+      it 'should pattern match with attribute hash' do
+        expect((subject in name: 'user' | 'admin' | 'environment' | 'product' | 'license')).to be true
+        expect((subject in name: 'user')).to be false
+        expect((subject in name: 'admin')).to be false
+        expect((subject in name: 'environment')).to be true
+        expect((subject in name: 'product')).to be false
+        expect((subject in name: 'license')).to be false
+      end
+
+      it 'should pattern match with role symbols' do
+        expect((subject in Role(:user | :admin | :environment | :product | :license))).to be true
+        expect((subject in Role(:user))).to be false
+        expect((subject in Role(:admin))).to be false
+        expect((subject in Role(:environment))).to be true
+        expect((subject in Role(:product))).to be false
+        expect((subject in Role(:license))).to be false
+      end
+    end
+
+    context 'with product role' do
+      let(:resource) { create(:product, account:) }
+
+      it 'should pattern match with attribute hash' do
+        expect((subject in name: 'user' | 'admin' | 'environment' | 'product' | 'license')).to be true
+        expect((subject in name: 'user')).to be false
+        expect((subject in name: 'admin')).to be false
+        expect((subject in name: 'environment')).to be false
+        expect((subject in name: 'product')).to be true
+        expect((subject in name: 'license')).to be false
+      end
+
+      it 'should pattern match with role symbols' do
+        expect((subject in Role(:user | :admin | :environment | :product | :license))).to be true
+        expect((subject in Role(:user))).to be false
+        expect((subject in Role(:admin))).to be false
+        expect((subject in Role(:environment))).to be false
+        expect((subject in Role(:product))).to be true
+        expect((subject in Role(:license))).to be false
+      end
+    end
+
+    context 'with license role' do
+      let(:resource) { create(:license, account:) }
+
+      it 'should pattern match with attribute hash' do
+        expect((subject in name: 'user' | 'admin' | 'environment' | 'product' | 'license')).to be true
+        expect((subject in name: 'user')).to be false
+        expect((subject in name: 'admin')).to be false
+        expect((subject in name: 'environment')).to be false
+        expect((subject in name: 'product')).to be false
+        expect((subject in name: 'license')).to be true
+      end
+
+      it 'should pattern match with role symbols' do
+        expect((subject in Role(:user | :admin | :environment | :product | :license))).to be true
+        expect((subject in Role(:user))).to be false
+        expect((subject in Role(:admin))).to be false
+        expect((subject in Role(:environment))).to be false
+        expect((subject in Role(:product))).to be false
+        expect((subject in Role(:license))).to be true
+      end
+    end
+  end
+end


### PR DESCRIPTION
Cleans up role checks to use a typed `Role(...)` pattern and symbol role names.