### PR TITLE
Add UUID type for typed_params

### DIFF
--- a/app/controllers/api/v1/accounts/relationships/plans_controller.rb
+++ b/app/controllers/api/v1/accounts/relationships/plans_controller.rb
@@ -18,7 +18,7 @@ module Api::V1::Accounts::Relationships
 
       param :data, type: :hash do
         param :type, type: :string, inclusion: { in: %w[plan plans] }
-        param :id, type: :string
+        param :id, type: :uuid
       end
     }
     def update

--- a/app/controllers/api/v1/accounts_controller.rb
+++ b/app/controllers/api/v1/accounts_controller.rb
@@ -26,7 +26,7 @@ module Api::V1
           param :plan, type: :hash do
             param :data, type: :hash do
               param :type, type: :string, inclusion: { in: %w[plan plans] }
-              param :id, type: :string
+              param :id, type: :uuid
             end
           end
           param :admins, type: :hash, as: :users do
@@ -66,7 +66,7 @@ module Api::V1
 
       param :data, type: :hash do
         param :type, type: :string, inclusion: { in: %w[account accounts] }
-        param :id, type: :string, optional: true, noop: true
+        param :id, type: :uuid, optional: true, noop: true
         param :attributes, type: :hash do
           param :name, type: :string, optional: true
           param :slug, type: :string, optional: true

--- a/app/controllers/api/v1/entitlements_controller.rb
+++ b/app/controllers/api/v1/entitlements_controller.rb
@@ -38,7 +38,7 @@ module Api::V1
             param :environment, type: :hash, optional: true do
               param :data, type: :hash, allow_nil: true do
                 param :type, type: :string, inclusion: { in: %w[environment environments] }
-                param :id, type: :string
+                param :id, type: :uuid
               end
             end
           end
@@ -67,7 +67,7 @@ module Api::V1
 
       param :data, type: :hash do
         param :type, type: :string, inclusion: { in: %w[entitlement entitlements] }
-        param :id, type: :string, optional: true, noop: true
+        param :id, type: :uuid, optional: true, noop: true
         param :attributes, type: :hash do
           param :name, type: :string, optional: true
           param :code, type: :string, optional: true

--- a/app/controllers/api/v1/environments/relationships/tokens_controller.rb
+++ b/app/controllers/api/v1/environments/relationships/tokens_controller.rb
@@ -50,7 +50,7 @@ module Api::V1::Environments::Relationships
             param :environment, type: :hash, optional: true do
               param :data, type: :hash, allow_nil: true do
                 param :type, type: :string, inclusion: { in: %w[environment environments] }
-                param :id, type: :string
+                param :id, type: :uuid
               end
             end
           end

--- a/app/controllers/api/v1/environments_controller.rb
+++ b/app/controllers/api/v1/environments_controller.rb
@@ -72,7 +72,7 @@ module Api::V1
 
       param :data, type: :hash do
         param :type, type: :string, inclusion: { in: %w[environment environments] }
-        param :id, type: :string, optional: true, noop: true
+        param :id, type: :uuid, optional: true, noop: true
         param :attributes, type: :hash do
           param :name, type: :string, optional: true
           param :code, type: :string, optional: true

--- a/app/controllers/api/v1/groups/relationships/group_owners_controller.rb
+++ b/app/controllers/api/v1/groups/relationships/group_owners_controller.rb
@@ -31,7 +31,7 @@ module Api::V1::Groups::Relationships
       param :data, type: :array do
         items type: :hash do
           param :type, type: :string, inclusion: { in: %w[user users] }
-          param :id, type: :string, as: :user_id
+          param :id, type: :uuid, as: :user_id
         end
       end
     }
@@ -59,7 +59,7 @@ module Api::V1::Groups::Relationships
       param :data, type: :array do
         items type: :hash do
           param :type, type: :string, inclusion: { in: %w[user users] }
-          param :id, type: :string, as: :user_id
+          param :id, type: :uuid, as: :user_id
         end
       end
     }

--- a/app/controllers/api/v1/groups_controller.rb
+++ b/app/controllers/api/v1/groups_controller.rb
@@ -40,7 +40,7 @@ module Api::V1
             param :environment, type: :hash, optional: true do
               param :data, type: :hash, allow_nil: true do
                 param :type, type: :string, inclusion: { in: %w[environment environments] }
-                param :id, type: :string
+                param :id, type: :uuid
               end
             end
           end
@@ -69,7 +69,7 @@ module Api::V1
 
       param :data, type: :hash do
         param :type, type: :string, inclusion: { in: %w[group groups] }
-        param :id, type: :string, optional: true, noop: true
+        param :id, type: :uuid, optional: true, noop: true
         param :attributes, type: :hash do
           param :name, type: :string, optional: true
           param :max_users, type: :integer, allow_nil: true, optional: true

--- a/app/controllers/api/v1/keys_controller.rb
+++ b/app/controllers/api/v1/keys_controller.rb
@@ -35,7 +35,7 @@ module Api::V1
           param :policy, type: :hash do
             param :data, type: :hash do
               param :type, type: :string, inclusion: { in: %w[policy policies] }
-              param :id, type: :string
+              param :id, type: :uuid
             end
           end
 
@@ -46,7 +46,7 @@ module Api::V1
             param :environment, type: :hash, optional: true do
               param :data, type: :hash, allow_nil: true do
                 param :type, type: :string, inclusion: { in: %w[environment environments] }
-                param :id, type: :string
+                param :id, type: :uuid
               end
             end
           end
@@ -75,7 +75,7 @@ module Api::V1
 
       param :data, type: :hash do
         param :type, type: :string, inclusion: { in: %w[key keys] }
-        param :id, type: :string, optional: true, noop: true
+        param :id, type: :uuid, optional: true, noop: true
         param :attributes, type: :hash do
           param :key, type: :string, optional: true
         end

--- a/app/controllers/api/v1/licenses/relationships/entitlements_controller.rb
+++ b/app/controllers/api/v1/licenses/relationships/entitlements_controller.rb
@@ -32,7 +32,7 @@ module Api::V1::Licenses::Relationships
       param :data, type: :array, length: { minimum: 1 } do
         items type: :hash do
           param :type, type: :string, inclusion: { in: %w[entitlement entitlements] }
-          param :id, type: :string, as: :entitlement_id
+          param :id, type: :uuid, as: :entitlement_id
         end
       end
     }
@@ -60,7 +60,7 @@ module Api::V1::Licenses::Relationships
       param :data, type: :array, length: { minimum: 1 } do
         items type: :hash do
           param :type, type: :string, inclusion: { in: %w[entitlement entitlements] }
-          param :id, type: :string, as: :entitlement_id
+          param :id, type: :uuid, as: :entitlement_id
         end
       end
     }

--- a/app/controllers/api/v1/licenses/relationships/groups_controller.rb
+++ b/app/controllers/api/v1/licenses/relationships/groups_controller.rb
@@ -22,7 +22,7 @@ module Api::V1::Licenses::Relationships
 
       param :data, type: :hash, allow_nil: true do
         param :type, type: :string, inclusion: { in: %w[group groups] }
-        param :id, type: :string
+        param :id, type: :uuid
       end
     }
     def update

--- a/app/controllers/api/v1/licenses/relationships/policies_controller.rb
+++ b/app/controllers/api/v1/licenses/relationships/policies_controller.rb
@@ -22,7 +22,7 @@ module Api::V1::Licenses::Relationships
 
       param :data, type: :hash do
         param :type, type: :string, inclusion: { in: %w[policy policies] }
-        param :id, type: :string
+        param :id, type: :uuid
       end
     }
     def update

--- a/app/controllers/api/v1/licenses/relationships/tokens_controller.rb
+++ b/app/controllers/api/v1/licenses/relationships/tokens_controller.rb
@@ -53,7 +53,7 @@ module Api::V1::Licenses::Relationships
             param :environment, type: :hash, optional: true do
               param :data, type: :hash, allow_nil: true do
                 param :type, type: :string, inclusion: { in: %w[environment environments] }
-                param :id, type: :string
+                param :id, type: :uuid
               end
             end
           end

--- a/app/controllers/api/v1/licenses/relationships/users_controller.rb
+++ b/app/controllers/api/v1/licenses/relationships/users_controller.rb
@@ -22,7 +22,7 @@ module Api::V1::Licenses::Relationships
 
       param :data, type: :hash, allow_nil: true do
         param :type, type: :string, inclusion: { in: %w[user users] }
-        param :id, type: :string
+        param :id, type: :uuid
       end
     }
     def update

--- a/app/controllers/api/v1/licenses_controller.rb
+++ b/app/controllers/api/v1/licenses_controller.rb
@@ -40,7 +40,7 @@ module Api::V1
 
       param :data, type: :hash do
         param :type, type: :string, inclusion: { in: %w[license licenses] }
-        param :id, type: :string, optional: true, if: -> { current_bearer&.has_role?(:admin, :developer, :sales_agent, :product, :environment) }
+        param :id, type: :uuid, optional: true, if: -> { current_bearer&.has_role?(:admin, :developer, :sales_agent, :product, :environment) }
         param :attributes, type: :hash, optional: true do
           param :name, type: :string, allow_blank: true, allow_nil: true, optional: true
           param :key, type: :string, optional: true
@@ -68,19 +68,19 @@ module Api::V1
           param :policy, type: :hash do
             param :data, type: :hash do
               param :type, type: :string, inclusion: { in: %w[policy policies] }
-              param :id, type: :string
+              param :id, type: :uuid
             end
           end
           param :user, type: :hash, optional: true do
             param :data, type: :hash, allow_nil: true do
               param :type, type: :string, inclusion: { in: %w[user users] }
-              param :id, type: :string
+              param :id, type: :uuid
             end
           end
           param :group, type: :hash, optional: true, if: -> { current_bearer&.has_role?(:admin, :developer, :sales_agent, :support_agent, :product, :environment) } do
             param :data, type: :hash, allow_nil: true do
               param :type, type: :string, inclusion: { in: %w[group groups] }
-              param :id, type: :string
+              param :id, type: :uuid
             end
           end
 
@@ -91,7 +91,7 @@ module Api::V1
             param :environment, type: :hash, optional: true do
               param :data, type: :hash, allow_nil: true do
                 param :type, type: :string, inclusion: { in: %w[environment environments] }
-                param :id, type: :string
+                param :id, type: :uuid
               end
             end
           end
@@ -120,7 +120,7 @@ module Api::V1
 
       param :data, type: :hash do
         param :type, type: :string, inclusion: { in: %w[license licenses] }
-        param :id, type: :string, optional: true, noop: true
+        param :id, type: :uuid, optional: true, noop: true
         param :attributes, type: :hash do
           param :name, type: :string, allow_blank: true, allow_nil: true, optional: true
           with if: -> { current_bearer&.has_role?(:admin, :developer, :sales_agent, :support_agent, :product, :environment) } do

--- a/app/controllers/api/v1/machine_processes_controller.rb
+++ b/app/controllers/api/v1/machine_processes_controller.rb
@@ -31,7 +31,7 @@ module Api::V1
 
       param :data, type: :hash do
         param :type, type: :string, inclusion: { in: %w[process processes] }
-        param :id, type: :string, optional: true
+        param :id, type: :uuid, optional: true
         param :attributes, type: :hash do
           param :pid, type: :string
           param :metadata, type: :metadata, allow_blank: true, optional: true
@@ -40,7 +40,7 @@ module Api::V1
           param :machine, type: :hash do
             param :data, type: :hash do
               param :type, type: :string, inclusion: { in: %w[machine machines] }
-              param :id, type: :string
+              param :id, type: :uuid
             end
           end
 
@@ -51,7 +51,7 @@ module Api::V1
             param :environment, type: :hash, optional: true do
               param :data, type: :hash, allow_nil: true do
                 param :type, type: :string, inclusion: { in: %w[environment environments] }
-                param :id, type: :string
+                param :id, type: :uuid
               end
             end
           end
@@ -89,7 +89,7 @@ module Api::V1
 
       param :data, type: :hash do
         param :type, type: :string, inclusion: { in: %w[process processes] }
-        param :id, type: :string, optional: true, noop: true
+        param :id, type: :uuid, optional: true, noop: true
         param :attributes, type: :hash do
           param :metadata, type: :metadata, allow_blank: true, optional: true, if: -> { current_bearer&.has_role?(:admin, :developer, :sales_agent, :support_agent, :product, :environment) }
         end

--- a/app/controllers/api/v1/machines/relationships/groups_controller.rb
+++ b/app/controllers/api/v1/machines/relationships/groups_controller.rb
@@ -22,7 +22,7 @@ module Api::V1::Machines::Relationships
 
       param :data, type: :hash, allow_nil: true do
         param :type, type: :string, inclusion: { in: %w[group groups] }
-        param :id, type: :string
+        param :id, type: :uuid
       end
     }
     def update

--- a/app/controllers/api/v1/machines_controller.rb
+++ b/app/controllers/api/v1/machines_controller.rb
@@ -37,7 +37,7 @@ module Api::V1
 
       param :data, type: :hash do
         param :type, type: :string, inclusion: { in: %w[machine machines] }
-        param :id, type: :string, optional: true
+        param :id, type: :uuid, optional: true
         param :attributes, type: :hash do
           param :fingerprint, type: :string
           param :name, type: :string, allow_blank: true, allow_nil: true, optional: true
@@ -51,13 +51,13 @@ module Api::V1
           param :license, type: :hash do
             param :data, type: :hash do
               param :type, type: :string, inclusion: { in: %w[license licenses] }
-              param :id, type: :string
+              param :id, type: :uuid
             end
           end
           param :group, type: :hash, optional: true, if: -> { current_bearer&.has_role?(:admin, :developer, :sales_agent, :support_agent, :product, :environment) } do
             param :data, type: :hash, allow_nil: true do
               param :type, type: :string, inclusion: { in: %w[group groups] }
-              param :id, type: :string
+              param :id, type: :uuid
             end
           end
 
@@ -68,7 +68,7 @@ module Api::V1
             param :environment, type: :hash, optional: true do
               param :data, type: :hash, allow_nil: true do
                 param :type, type: :string, inclusion: { in: %w[environment environments] }
-                param :id, type: :string
+                param :id, type: :uuid
               end
             end
           end
@@ -134,7 +134,7 @@ module Api::V1
 
       param :data, type: :hash do
         param :type, type: :string, inclusion: { in: %w[machine machines] }
-        param :id, type: :string, optional: true, noop: true
+        param :id, type: :uuid, optional: true, noop: true
         param :attributes, type: :hash do
           param :name, type: :string, allow_blank: true, allow_nil: true, optional: true
           param :ip, type: :string, allow_blank: true, allow_nil: true, optional: true

--- a/app/controllers/api/v1/policies/relationships/entitlements_controller.rb
+++ b/app/controllers/api/v1/policies/relationships/entitlements_controller.rb
@@ -31,7 +31,7 @@ module Api::V1::Policies::Relationships
       param :data, type: :array, length: { minimum: 1 } do
         items type: :hash do
           param :type, type: :string, inclusion: { in: %w[entitlement entitlements] }
-          param :id, type: :string, as: :entitlement_id
+          param :id, type: :uuid, as: :entitlement_id
         end
       end
     }
@@ -59,7 +59,7 @@ module Api::V1::Policies::Relationships
       param :data, type: :array, length: { minimum: 1 } do
         items type: :hash do
           param :type, type: :string, inclusion: { in: %w[entitlement entitlements] }
-          param :id, type: :string, as: :entitlement_id
+          param :id, type: :uuid, as: :entitlement_id
         end
       end
     }

--- a/app/controllers/api/v1/policies_controller.rb
+++ b/app/controllers/api/v1/policies_controller.rb
@@ -70,7 +70,7 @@ module Api::V1
           param :product, type: :hash do
             param :data, type: :hash do
               param :type, type: :string, inclusion: { in: %w[product products] }
-              param :id, type: :string
+              param :id, type: :uuid
             end
           end
 
@@ -81,7 +81,7 @@ module Api::V1
             param :environment, type: :hash, optional: true do
               param :data, type: :hash, allow_nil: true do
                 param :type, type: :string, inclusion: { in: %w[environment environments] }
-                param :id, type: :string
+                param :id, type: :uuid
               end
             end
           end
@@ -110,7 +110,7 @@ module Api::V1
 
       param :data, type: :hash do
         param :type, type: :string, inclusion: { in: %w[policy policies] }
-        param :id, type: :string, optional: true, noop: true
+        param :id, type: :uuid, optional: true, noop: true
         param :attributes, type: :hash do
           param :name, type: :string, optional: true
           param :duration, type: :integer, allow_nil: true, optional: true

--- a/app/controllers/api/v1/products/relationships/tokens_controller.rb
+++ b/app/controllers/api/v1/products/relationships/tokens_controller.rb
@@ -51,7 +51,7 @@ module Api::V1::Products::Relationships
             param :environment, type: :hash, optional: true do
               param :data, type: :hash, allow_nil: true do
                 param :type, type: :string, inclusion: { in: %w[environment environments] }
-                param :id, type: :string
+                param :id, type: :uuid
               end
             end
           end

--- a/app/controllers/api/v1/products_controller.rb
+++ b/app/controllers/api/v1/products_controller.rb
@@ -51,7 +51,7 @@ module Api::V1
             param :environment, type: :hash, optional: true do
               param :data, type: :hash, allow_nil: true do
                 param :type, type: :string, inclusion: { in: %w[environment environments] }
-                param :id, type: :string
+                param :id, type: :uuid
               end
             end
           end
@@ -80,7 +80,7 @@ module Api::V1
 
       param :data, type: :hash do
         param :type, type: :string, inclusion: { in: %w[product products] }
-        param :id, type: :string, optional: true, noop: true
+        param :id, type: :uuid, optional: true, noop: true
         param :attributes, type: :hash do
           param :name, type: :string, optional: true
           param :distribution_strategy, type: :string, allow_nil: true, optional: true

--- a/app/controllers/api/v1/release_artifacts_controller.rb
+++ b/app/controllers/api/v1/release_artifacts_controller.rb
@@ -78,7 +78,7 @@ module Api::V1
           param :release, type: :hash do
             param :data, type: :hash do
               param :type, type: :string, inclusion: { in: %w[release releases] }
-              param :id, type: :string
+              param :id, type: :uuid
             end
           end
 
@@ -89,7 +89,7 @@ module Api::V1
             param :environment, type: :hash, optional: true do
               param :data, type: :hash, allow_nil: true do
                 param :type, type: :string, inclusion: { in: %w[environment environments] }
-                param :id, type: :string
+                param :id, type: :uuid
               end
             end
           end
@@ -122,7 +122,7 @@ module Api::V1
 
       param :data, type: :hash do
         param :type, type: :string, inclusion: { in: %w[artifact artifacts] }
-        param :id, type: :string, optional: true, noop: true
+        param :id, type: :uuid, optional: true, noop: true
         param :attributes, type: :hash do
           param :filesize, type: :integer, allow_nil: true, optional: true
           param :signature, type: :string, allow_blank: true, allow_nil: true, optional: true

--- a/app/controllers/api/v1/releases/relationships/release_entitlement_constraints_controller.rb
+++ b/app/controllers/api/v1/releases/relationships/release_entitlement_constraints_controller.rb
@@ -35,7 +35,7 @@ module Api::V1::Releases::Relationships
             param :entitlement, type: :hash do
               param :data, type: :hash do
                 param :type, type: :string, inclusion: { in: %w[entitlement entitlements] }
-                param :id, type: :string
+                param :id, type: :uuid
               end
             end
           end
@@ -66,7 +66,7 @@ module Api::V1::Releases::Relationships
       param :data, type: :array do
         items type: :hash do
           param :type, type: :string, inclusion: { in: %w[constraint constraints] }
-          param :id, type: :string
+          param :id, type: :uuid
         end
       end
     }

--- a/app/controllers/api/v1/releases_controller.rb
+++ b/app/controllers/api/v1/releases_controller.rb
@@ -66,7 +66,7 @@ module Api::V1
           param :product, type: :hash do
             param :data, type: :hash do
               param :type, type: :string, inclusion: { in: %w[product products] }
-              param :id, type: :string
+              param :id, type: :uuid
             end
           end
           param :constraints, type: :hash, optional: true do
@@ -77,7 +77,7 @@ module Api::V1
                   param :entitlement, type: :hash do
                     param :data, type: :hash do
                       param :type, type: :string, inclusion: { in: %w[entitlement entitlements] }
-                      param :id, type: :string
+                      param :id, type: :uuid
                     end
                   end
                 end
@@ -92,7 +92,7 @@ module Api::V1
             param :environment, type: :hash, optional: true do
               param :data, type: :hash, allow_nil: true do
                 param :type, type: :string, inclusion: { in: %w[environment environments] }
-                param :id, type: :string
+                param :id, type: :uuid
               end
             end
           end
@@ -121,7 +121,7 @@ module Api::V1
 
       param :data, type: :hash do
         param :type, type: :string, inclusion: { in: %w[release releases] }
-        param :id, type: :string, optional: true, noop: true
+        param :id, type: :uuid, optional: true, noop: true
         param :attributes, type: :hash do
           param :name, type: :string, allow_blank: true, allow_nil: true, optional: true
           param :description, type: :string, allow_blank: true, allow_nil: true, optional: true

--- a/app/controllers/api/v1/tokens_controller.rb
+++ b/app/controllers/api/v1/tokens_controller.rb
@@ -47,7 +47,7 @@ module Api::V1
           param :bearer, type: :hash, optional: true do
             param :data, type: :hash do
               param :type, type: :string, inclusion: { in: %w[environment environments product products user users license licenses] }
-              param :id, type: :string
+              param :id, type: :uuid
             end
           end
           Keygen.ee do |license|
@@ -57,7 +57,7 @@ module Api::V1
             param :environment, type: :hash, optional: true do
               param :data, type: :hash, allow_nil: true do
                 param :type, type: :string, inclusion: { in: %w[environment environments] }
-                param :id, type: :string
+                param :id, type: :uuid
               end
             end
           end

--- a/app/controllers/api/v1/users/relationships/groups_controller.rb
+++ b/app/controllers/api/v1/users/relationships/groups_controller.rb
@@ -22,7 +22,7 @@ module Api::V1::Users::Relationships
 
       param :data, type: :hash, allow_nil: true do
         param :type, type: :string, inclusion: { in: %w[group groups] }
-        param :id, type: :string
+        param :id, type: :uuid
       end
     }
     def update

--- a/app/controllers/api/v1/users/relationships/second_factors_controller.rb
+++ b/app/controllers/api/v1/users/relationships/second_factors_controller.rb
@@ -69,7 +69,7 @@ module Api::V1::Users::Relationships
 
       param :data, type: :hash do
         param :type, type: :string, inclusion: { in: %w[second-factor second-factors secondFactor secondFactors second_factor second_factors] }
-        param :id, type: :string, optional: true, noop: true
+        param :id, type: :uuid, optional: true, noop: true
         param :attributes, type: :hash do
           param :enabled, type: :boolean
         end

--- a/app/controllers/api/v1/users/relationships/tokens_controller.rb
+++ b/app/controllers/api/v1/users/relationships/tokens_controller.rb
@@ -51,7 +51,7 @@ module Api::V1::Users::Relationships
             param :environment, type: :hash, optional: true do
               param :data, type: :hash, allow_nil: true do
                 param :type, type: :string, inclusion: { in: %w[environment environments] }
-                param :id, type: :string
+                param :id, type: :uuid
               end
             end
           end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -64,7 +64,7 @@ module Api::V1
           param :group, type: :hash, optional: true, if: -> { current_bearer&.has_role?(:admin, :developer, :sales_agent, :support_agent, :product, :environment) } do
             param :data, type: :hash, allow_nil: true do
               param :type, type: :string, inclusion: { in: %w[group groups] }
-              param :id, type: :string
+              param :id, type: :uuid
             end
           end
 
@@ -75,7 +75,7 @@ module Api::V1
             param :environment, type: :hash, optional: true do
               param :data, type: :hash, allow_nil: true do
                 param :type, type: :string, inclusion: { in: %w[environment environments] }
-                param :id, type: :string
+                param :id, type: :uuid
               end
             end
           end
@@ -104,7 +104,7 @@ module Api::V1
 
       param :data, type: :hash do
         param :type, type: :string, inclusion: { in: %w[user users] }
-        param :id, type: :string, optional: true, noop: true
+        param :id, type: :uuid, optional: true, noop: true
         param :attributes, type: :hash, optional: true do
           param :first_name, type: :string, allow_blank: true, allow_nil: true, optional: true
           param :last_name, type: :string, allow_blank: true, allow_nil: true, optional: true

--- a/app/controllers/api/v1/webhook_endpoints_controller.rb
+++ b/app/controllers/api/v1/webhook_endpoints_controller.rb
@@ -32,7 +32,7 @@ module Api::V1
           end
           param :signature_algorithm, type: :string, optional: true
         end
-        params :relationships, type: :hash, optional: true do
+        param :relationships, type: :hash, optional: true do
           Keygen.ee do |license|
             next unless
               license.entitled?(:environments)
@@ -40,7 +40,7 @@ module Api::V1
             param :environment, type: :hash, optional: true do
               param :data, type: :hash, allow_nil: true do
                 param :type, type: :string, inclusion: { in: %w[environment environments] }
-                param :id, type: :string
+                param :id, type: :uuid
               end
             end
           end
@@ -63,7 +63,7 @@ module Api::V1
 
       param :data, type: :hash do
         param :type, type: :string, inclusion: { in: %w[webhookEndpoint webhookEndpoints webhook-endpoint webhook-endpoints webhook_endpoint webhook_endpoints] }
-        param :id, type: :string, optional: true, noop: true
+        param :id, type: :uuid, optional: true, noop: true
         param :attributes, type: :hash do
           param :url, type: :string, optional: true
           param :subscriptions, type: :array, optional: true do

--- a/config/initializers/typed_params.rb
+++ b/config/initializers/typed_params.rb
@@ -24,3 +24,11 @@ TypedParams.types.register(:metadata,
     }
   },
 )
+
+TypedParams.types.register(:uuid,
+  archetype: :string,
+  name: 'UUID',
+  match: -> value {
+    value.is_a?(String) && UUID_RE.match?(value)
+  },
+)

--- a/features/api/v1/accounts/create.feature
+++ b/features/api/v1/accounts/create.feature
@@ -1177,8 +1177,18 @@ Feature: Create account
         }
       }
       """
-    Then the response status should be "422"
-    And the response body should be an array of 2 errors
+    Then the response status should be "400"
+    And the response body should be an array of 1 error
+    And the first error should have the following properties:
+      """
+      {
+        "title": "Bad request",
+        "detail": "type mismatch (received string expected UUID string)",
+        "source": {
+          "pointer": "/data/relationships/plan/data/id"
+        }
+      }
+      """
 
   Scenario: Anonymous attempts to create an account with invalid JSON (syntax)
     When I send a POST request to "/accounts" with the following:

--- a/features/api/v1/accounts/relationships/plan.feature
+++ b/features/api/v1/accounts/relationships/plan.feature
@@ -258,13 +258,15 @@ Feature: Account plan relationship
         }
       }
       """
-    Then the response status should be "404"
+    Then the response status should be "400"
     And the first error should have the following properties:
       """
       {
-        "title": "Not found",
-        "detail": "The requested plan 'invalid' was not found",
-        "code": "NOT_FOUND"
+        "title": "Bad request",
+        "detail": "type mismatch (received string expected UUID string)",
+        "source": {
+          "pointer": "/data/id"
+        }
       }
       """
     And sidekiq should have 0 "webhook" jobs

--- a/features/api/v1/licenses/create.feature
+++ b/features/api/v1/licenses/create.feature
@@ -3513,18 +3513,17 @@ Feature: Create license
         }
       }
       """
-    Then the response status should be "422"
+    Then the response status should be "400"
     And the current account should have 0 "licenses"
     And the response body should be an array of 1 error
     And the first error should have the following properties:
       """
       {
-        "title": "Unprocessable resource",
-        "detail": "must be a valid UUID",
+        "title": "Bad request",
+        "detail": "type mismatch (received string expected UUID string)",
         "source": {
           "pointer": "/data/id"
-        },
-        "code": "ID_INVALID"
+        }
       }
       """
     And sidekiq should have 0 "webhook" jobs

--- a/features/api/v1/machines/create.feature
+++ b/features/api/v1/machines/create.feature
@@ -4304,17 +4304,16 @@ Feature: Create machine
         }
       }
       """
-    Then the response status should be "422"
+    Then the response status should be "400"
     And the response body should be an array of 1 error
     And the first error should have the following properties:
       """
       {
-        "title": "Unprocessable resource",
-        "detail": "must be a valid UUID",
+        "title": "Bad request",
+        "detail": "type mismatch (received string expected UUID string)",
         "source": {
           "pointer": "/data/id"
-        },
-        "code": "ID_INVALID"
+        }
       }
       """
     And the current account should have 0 "machines"

--- a/features/api/v1/processes/create.feature
+++ b/features/api/v1/processes/create.feature
@@ -1702,17 +1702,16 @@ Feature: Spawn machine process
         }
       }
       """
-    Then the response status should be "422"
+    Then the response status should be "400"
     And the response body should be an array of 1 error
     And the first error should have the following properties:
       """
       {
-        "title": "Unprocessable resource",
-        "detail": "must be a valid UUID",
+        "title": "Bad request",
+        "detail": "type mismatch (received string expected UUID string)",
         "source": {
           "pointer": "/data/id"
-        },
-        "code": "ID_INVALID"
+        }
       }
       """
     And the current account should have 0 "processes"


### PR DESCRIPTION
Closes #745. Saves a few database hits, and reduces the confusion outlined in the aforementioned issue.