### PR TITLE
Add Tauri release engine

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -122,4 +122,5 @@ group :test do
   gem 'factory_bot_rails', '~> 6.2'
   gem 'database_cleaner', '~> 2.0'
   gem 'webmock', '~> 3.14.0'
+  gem 'elif', '~> 0.1.0'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem 'redis', '~> 4.7.1'
 gem 'request_migrations', '~> 1.1'
 
 # API params
-gem 'typed_params', '~> 1.0.3'
+gem 'typed_params', '~> 1.1'
 
 # JSON API serializers
 gem 'json', '~> 2.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -188,6 +188,7 @@ GEM
       dotenv (= 2.7.6)
       railties (>= 3.2)
     ed25519 (1.3.0)
+    elif (0.1.0)
     erubi (1.12.0)
     erubis (2.7.0)
     et-orbi (1.2.7)
@@ -476,6 +477,7 @@ DEPENDENCIES
   database_cleaner (~> 2.0)
   dotenv-rails
   ed25519
+  elif (~> 0.1.0)
   factory_bot_rails (~> 6.2)
   faker (~> 2.20.0)
   haml-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -439,7 +439,7 @@ GEM
     timecop (0.9.5)
     timeout (0.4.0)
     tracer (0.1.1)
-    typed_params (1.0.3)
+    typed_params (1.1.0)
       rails (>= 6.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
@@ -523,7 +523,7 @@ DEPENDENCIES
   stripe-ruby-mock!
   timecop (~> 0.9.5)
   tracer
-  typed_params (~> 1.0.3)
+  typed_params (~> 1.1)
   uri (>= 0.12.2)
   webmock (~> 3.14.0)
   whacamole

--- a/app/controllers/api/v1/release_engines/tauri/upgrades_controller.rb
+++ b/app/controllers/api/v1/release_engines/tauri/upgrades_controller.rb
@@ -16,8 +16,7 @@ module Api::V1::ReleaseEngines
 
       releases = authorized_scope(package.releases)
       release  = releases.find_by!(version: params[:current_version])
-      authorize! release,
-        to: :upgrade?
+      authorize! release, to: :upgrade?
 
       kwargs  = upgrade_query.slice(:constraint, :channel)
       upgrade = release.upgrade!(**kwargs)

--- a/app/controllers/api/v1/release_engines/tauri/upgrades_controller.rb
+++ b/app/controllers/api/v1/release_engines/tauri/upgrades_controller.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module Api::V1::ReleaseEngines
+  class Tauri::UpgradesController < Api::V1::BaseController
+    before_action :scope_to_current_account!
+    before_action :require_active_subscription!
+    before_action :authenticate_with_token
+    before_action :set_package, only: %i[show]
+
+    typed_query {
+      param :constraint, type: :string, optional: true
+      param :channel, type: :string, optional: true
+    }
+    def show
+      authorize! package
+
+      releases = authorized_scope(package.releases)
+      release  = releases.find_by!(version: params[:current_version])
+      authorize! release,
+        to: :upgrade?
+
+      kwargs  = upgrade_query.slice(:constraint, :channel)
+      upgrade = release.upgrade!(**kwargs)
+      authorize! upgrade
+
+      artifact = upgrade.artifacts.joins(:platform, :arch, :filetype)
+                                  .reorder(filename: :desc) # so that NSIS takes precedence over MSI on conflict
+                                  .find_by!(
+                                    platform: { key: params[:target] },
+                                    arch: { key: params[:arch] },
+                                    filetype: { key: %w[gz zip] },
+                                  )
+      authorize! artifact
+
+      # See: https://tauri.app/v1/guides/distribution/updater
+      render json: {
+        version: upgrade.version,
+        pub_date: upgrade.created_at,
+        url: vanity_v1_account_release_artifact_url(artifact.account, artifact, filename: artifact.filename),
+        signature: artifact.signature,
+        notes: upgrade.description,
+      }
+    rescue ActiveRecord::RecordNotFound
+      render_no_content
+    end
+
+    private
+
+    attr_reader :package
+
+    def set_package
+      Current.resource = @package = FindByAliasService.call(
+        authorized_scope(current_account.release_packages.tauri),
+        id: params[:package],
+        aliases: :key,
+      )
+    end
+  end
+end

--- a/app/controllers/api/v1/release_engines/tauri/upgrades_controller.rb
+++ b/app/controllers/api/v1/release_engines/tauri/upgrades_controller.rb
@@ -10,12 +10,19 @@ module Api::V1::ReleaseEngines
     typed_query {
       param :constraint, type: :string, optional: true
       param :channel, type: :string, optional: true
+      param :platform, type: :string
+      param :arch, type: :string
+      param :version, type: :string
     }
     def show
       authorize! package
 
+      platform = upgrade_query[:platform]
+      arch     = upgrade_query[:arch]
+      version  = upgrade_query[:version]
+
       releases = authorized_scope(package.releases)
-      release  = releases.find_by!(version: params[:current_version])
+      release  = releases.find_by!(version:)
       authorize! release, to: :upgrade?
 
       kwargs  = upgrade_query.slice(:constraint, :channel)
@@ -33,9 +40,9 @@ module Api::V1::ReleaseEngines
                              SQL
                            )
                            .find_by!(
-                             platform: { key: params[:target] },
-                             arch: { key: params[:arch] },
                              filetype: { key: %w[gz zip] },
+                             platform: { key: platform },
+                             arch: { key: arch },
                            )
       authorize! artifact
 

--- a/app/controllers/api/v1/release_engines/tauri/upgrades_controller.rb
+++ b/app/controllers/api/v1/release_engines/tauri/upgrades_controller.rb
@@ -25,13 +25,13 @@ module Api::V1::ReleaseEngines
       artifacts = authorized_scope(upgrade.artifacts)
       artifact  = artifacts.joins(:platform, :arch, :filetype)
                            .reorder(
-                              # NOTE(ezekg) Order so that NSIS always takes precedence
-                              #             over deprecated MSI on conflict.
-                              Arel.sql(<<~SQL.squish)
-                                release_artifacts.filename ILIKE '%.nsis.zip' DESC,
-                                release_artifacts.created_at DESC
-                              SQL
-                            )
+                             # NOTE(ezekg) Order so that NSIS always takes precedence
+                             #             over deprecated MSI on conflict.
+                             Arel.sql(<<~SQL.squish)
+                               release_artifacts.filename ILIKE '%.nsis.zip' DESC,
+                               release_artifacts.created_at DESC
+                             SQL
+                           )
                            .find_by!(
                              platform: { key: params[:target] },
                              arch: { key: params[:arch] },

--- a/app/controllers/api/v1/release_engines/tauri/upgrades_controller.rb
+++ b/app/controllers/api/v1/release_engines/tauri/upgrades_controller.rb
@@ -61,7 +61,7 @@ module Api::V1::ReleaseEngines
         url: vanity_v1_account_release_artifact_url(artifact.account, artifact, filename: artifact.filename),
         signature: artifact.signature,
         version: upgrade.version,
-        pub_date: upgrade.created_at.iso8601(3),
+        pub_date: upgrade.created_at.rfc3339(3),
         notes: upgrade.description,
       }
     rescue ActiveRecord::RecordNotFound

--- a/app/controllers/api/v1/release_engines/tauri/upgrades_controller.rb
+++ b/app/controllers/api/v1/release_engines/tauri/upgrades_controller.rb
@@ -23,13 +23,14 @@ module Api::V1::ReleaseEngines
       upgrade = release.upgrade!(**kwargs)
       authorize! upgrade
 
-      artifact = upgrade.artifacts.joins(:platform, :arch, :filetype)
-                                  .reorder(filename: :desc) # so that NSIS takes precedence over MSI on conflict
-                                  .find_by!(
-                                    platform: { key: params[:target] },
-                                    arch: { key: params[:arch] },
-                                    filetype: { key: %w[gz zip] },
-                                  )
+      artifacts = authorized_scope(upgrade.artifacts)
+      artifact  = artifacts.joins(:platform, :arch, :filetype)
+                           .reorder(filename: :desc) # so that NSIS takes precedence over MSI on conflict
+                           .find_by!(
+                             platform: { key: params[:target] },
+                             arch: { key: params[:arch] },
+                             filetype: { key: %w[gz zip] },
+                           )
       authorize! artifact
 
       # See: https://tauri.app/v1/guides/distribution/updater

--- a/app/controllers/api/v1/release_engines/tauri/upgrades_controller.rb
+++ b/app/controllers/api/v1/release_engines/tauri/upgrades_controller.rb
@@ -34,10 +34,10 @@ module Api::V1::ReleaseEngines
 
       # See: https://tauri.app/v1/guides/distribution/updater
       render json: {
-        version: upgrade.version,
-        pub_date: upgrade.created_at,
         url: vanity_v1_account_release_artifact_url(artifact.account, artifact, filename: artifact.filename),
         signature: artifact.signature,
+        version: upgrade.version,
+        pub_date: upgrade.created_at.iso8601(3),
         notes: upgrade.description,
       }
     rescue ActiveRecord::RecordNotFound

--- a/app/controllers/api/v1/release_engines/tauri/upgrades_controller.rb
+++ b/app/controllers/api/v1/release_engines/tauri/upgrades_controller.rb
@@ -46,6 +46,16 @@ module Api::V1::ReleaseEngines
                            )
       authorize! artifact
 
+      BroadcastEventService.call(
+        event: 'release.upgraded',
+        account: current_account,
+        resource: upgrade,
+        meta: {
+          current: release.version,
+          next: upgrade.version,
+        },
+      )
+
       # See: https://tauri.app/v1/guides/distribution/updater
       render json: {
         url: vanity_v1_account_release_artifact_url(artifact.account, artifact, filename: artifact.filename),

--- a/app/controllers/api/v1/release_engines/tauri/upgrades_controller.rb
+++ b/app/controllers/api/v1/release_engines/tauri/upgrades_controller.rb
@@ -17,9 +17,7 @@ module Api::V1::ReleaseEngines
     def show
       authorize! package
 
-      platform = upgrade_query[:platform]
-      arch     = upgrade_query[:arch]
-      version  = upgrade_query[:version]
+      upgrade_query => platform:, arch:, version:
 
       releases = authorized_scope(package.releases)
       release  = releases.find_by!(version:)

--- a/app/models/release_engine.rb
+++ b/app/models/release_engine.rb
@@ -7,6 +7,7 @@ class ReleaseEngine < ApplicationRecord
 
   ENGINES = %w[
     pypi
+    tauri
   ]
 
   belongs_to :account,
@@ -99,6 +100,4 @@ class ReleaseEngine < ApplicationRecord
   scope :with_releases, -> {
     where_assoc_exists(:releases)
   }
-
-  def self.pypi = find_by(key: 'pypi')
 end

--- a/app/models/release_package.rb
+++ b/app/models/release_package.rb
@@ -93,6 +93,7 @@ class ReleasePackage < ApplicationRecord
 
   scope :for_engine_key, -> key { joins(:engine).where(release_engines: { key: }) }
   scope :pypi,           ->     { for_engine_key('pypi') }
+  scope :tauri,          ->     { for_engine_key('tauri') }
 
   def engine_id? = release_engine_id?
   def engine_id  = release_engine_id

--- a/app/views/api/v1/release_engines/pypi/simple/show.html.haml
+++ b/app/views/api/v1/release_engines/pypi/simple/show.html.haml
@@ -10,7 +10,7 @@
 - artifacts.each do |artifact|
   -# NOTE(ezekg) Even though it's not covered in PEP 503, pip expects the URL path to be a
   -#             filename, not a UUID. Paths without an extension are ignored.
-  - url = v1_account_release_artifact_url(account, artifact.filename, package:, anchor: checksum_for(artifact, delimiter: '='))
+  - url = vanity_v1_account_release_artifact_url(account, artifact, filename: artifact.filename, anchor: checksum_for(artifact, delimiter: '='))
 
   = link_to(artifact.filename, url, data: artifact.metadata)
   %br

--- a/config/initializers/uuid.rb
+++ b/config/initializers/uuid.rb
@@ -3,6 +3,9 @@
 # This is used throughout the app to check if a value is a UUID
 UUID_RE = /\A[0-9A-F]{8}-?[0-9A-F]{4}-?[4][0-9A-F]{3}-?[89AB][0-9A-F]{3}-?[0-9A-F]{12}\z/i
 
+# Above pattern without anchors for URLs
+UUID_URL_RE = /[0-9A-F]{8}-?[0-9A-F]{4}-?[4][0-9A-F]{3}-?[89AB][0-9A-F]{3}-?[0-9A-F]{12}/i
+
 # This is used throughout the app for checking if a value is a partial UUID
 UUID_CHAR_RE = /\A[-0-9A-F]+\z/i
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -65,9 +65,7 @@ Rails.application.routes.draw do
 
   concern :tauri do
     scope module: :tauri, constraints: MimeTypeConstraint.new(:binary, :json, raise_on_no_match: true), defaults: { format: :json } do
-      get ':package/:target/:arch/:current_version', to: 'upgrades#show', as: :tauri_upgrade_package, constraints: {
-        current_version: /[^\/]*/, # allow dots in version
-      }
+      get ':package', to: 'upgrades#show'
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,7 +64,7 @@ Rails.application.routes.draw do
   end
 
   concern :tauri do
-    scope module: :tauri, constraints: MimeTypeConstraint.new(:json, raise_on_no_match: true), defaults: { format: :json } do
+    scope module: :tauri, constraints: MimeTypeConstraint.new(:binary, :json, raise_on_no_match: true), defaults: { format: :json } do
       get ':package/:target/:arch/:current_version', to: 'upgrades#show', as: :tauri_upgrade_package, constraints: {
         current_version: /[^\/]*/, # allow dots in version
       }

--- a/db/seeds/development.rb
+++ b/db/seeds/development.rb
@@ -69,7 +69,7 @@ loop do
 
         package = if rand(0..1).zero?
                     engine = if rand(0..1).zero?
-                               { engine_attributes: { key: 'pypi' } }
+                               { engine_attributes: { key: %w[pypi tauri].sample } }
                              end
 
                     ReleasePackage.create!(

--- a/features/api/v1/engines/pypi/simple/show.feature
+++ b/features/api/v1/engines/pypi/simple/show.feature
@@ -71,8 +71,8 @@ Feature: PyPI simple package files
     Then the response status should be "200"
     And the response body should be an HTML document with the following xpaths:
       """
-      /html/body/a[text()="foo-1.0.0-py3-none-any.whl" and @href="https://api.keygen.sh/v1/accounts/$account/artifacts/foo-1.0.0-py3-none-any.whl?package=46e034fe-2312-40f8-bbeb-7d9957fb6fcf"]
-      /html/body/a[text()="foo-1.0.0.tar.gz" and @href="https://api.keygen.sh/v1/accounts/$account/artifacts/foo-1.0.0.tar.gz?package=46e034fe-2312-40f8-bbeb-7d9957fb6fcf"]
+      /html/body/a[text()="foo-1.0.0-py3-none-any.whl" and @href="https://api.keygen.sh/v1/accounts/$account/artifacts/948f9b83-9e0d-469d-8982-e49213efe85e/foo-1.0.0-py3-none-any.whl"]
+      /html/body/a[text()="foo-1.0.0.tar.gz" and @href="https://api.keygen.sh/v1/accounts/$account/artifacts/1f63d6ec-8147-4bf0-bcd2-5d4f0e5eab8f/foo-1.0.0.tar.gz"]
       """
 
   Scenario: Endpoint should return versions when package exists (npm engine)
@@ -91,8 +91,8 @@ Feature: PyPI simple package files
     Then the response status should be "200"
     And the response body should be an HTML document with the following xpaths:
       """
-      /html/body/a[text()="bar-1.0.0b1-py3-none-any.whl" and @href="https://api.keygen.sh/v1/accounts/$account/artifacts/bar-1.0.0b1-py3-none-any.whl?package=2f8af04a-2424-4ca2-8480-6efe24318d1a"]
-      /html/body/a[text()="bar-1.0.0b1.tar.gz" and @href="https://api.keygen.sh/v1/accounts/$account/artifacts/bar-1.0.0b1.tar.gz?package=2f8af04a-2424-4ca2-8480-6efe24318d1a"]
+      /html/body/a[text()="bar-1.0.0b1-py3-none-any.whl" and @href="https://api.keygen.sh/v1/accounts/$account/artifacts/56277838-ddb5-4c54-a3d2-0fad8bdfefe1/bar-1.0.0b1-py3-none-any.whl"]
+      /html/body/a[text()="bar-1.0.0b1.tar.gz" and @href="https://api.keygen.sh/v1/accounts/$account/artifacts/fa773c2b-1c3a-4bd8-83fe-546480e92098/bar-1.0.0b1.tar.gz"]
       """
 
   Scenario: Endpoint should return versions with artifact metadata
@@ -110,7 +110,7 @@ Feature: PyPI simple package files
     Then the response status should be "200"
     And the response body should be an HTML document with the following xpaths:
       """
-      /html/body/a[@data-requires-python=">=3.0.0" and @href="https://api.keygen.sh/v1/accounts/$account/artifacts/foo-1.0.0.tar.gz?package=46e034fe-2312-40f8-bbeb-7d9957fb6fcf"]
+      /html/body/a[@data-requires-python=">=3.0.0" and @href="https://api.keygen.sh/v1/accounts/$account/artifacts/1f63d6ec-8147-4bf0-bcd2-5d4f0e5eab8f/foo-1.0.0.tar.gz"]
       """
 
   Scenario: Endpoint should return versions with artifact checksum (SHA256)
@@ -124,7 +124,7 @@ Feature: PyPI simple package files
     Then the response status should be "200"
     And the response body should be an HTML document with the following xpaths:
       """
-      /html/body/a[@href="https://api.keygen.sh/v1/accounts/$account/artifacts/foo-1.0.0.tar.gz?package=46e034fe-2312-40f8-bbeb-7d9957fb6fcf#sha256=2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae"]
+      /html/body/a[@href="https://api.keygen.sh/v1/accounts/$account/artifacts/1f63d6ec-8147-4bf0-bcd2-5d4f0e5eab8f/foo-1.0.0.tar.gz#sha256=2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae"]
       """
 
   Scenario: Endpoint should return versions with artifact checksum (SHA512)
@@ -138,7 +138,7 @@ Feature: PyPI simple package files
     Then the response status should be "200"
     And the response body should be an HTML document with the following xpaths:
       """
-      /html/body/a[@href="https://api.keygen.sh/v1/accounts/$account/artifacts/foo-1.0.0.tar.gz?package=46e034fe-2312-40f8-bbeb-7d9957fb6fcf#sha512=f7fbba6e0636f890e56fbbf3283e524c6fa3204ae298382d624741d0dc6638326e282c41be5e4254d8820772c5518a2c5a8c0c7f7eda19594a7eb539453e1ed7"]
+      /html/body/a[@href="https://api.keygen.sh/v1/accounts/$account/artifacts/1f63d6ec-8147-4bf0-bcd2-5d4f0e5eab8f/foo-1.0.0.tar.gz#sha512=f7fbba6e0636f890e56fbbf3283e524c6fa3204ae298382d624741d0dc6638326e282c41be5e4254d8820772c5518a2c5a8c0c7f7eda19594a7eb539453e1ed7"]
       """
 
   Scenario: Endpoint should return versions with artifact checksum (MD5)
@@ -152,7 +152,7 @@ Feature: PyPI simple package files
     Then the response status should be "200"
     And the response body should be an HTML document with the following xpaths:
       """
-      /html/body/a[@href="https://api.keygen.sh/v1/accounts/$account/artifacts/foo-1.0.0.tar.gz?package=46e034fe-2312-40f8-bbeb-7d9957fb6fcf"]
+      /html/body/a[@href="https://api.keygen.sh/v1/accounts/$account/artifacts/1f63d6ec-8147-4bf0-bcd2-5d4f0e5eab8f/foo-1.0.0.tar.gz"]
       """
 
   Scenario: License requests versions for a licensed product

--- a/features/api/v1/engines/tauri/upgrade.feature
+++ b/features/api/v1/engines/tauri/upgrade.feature
@@ -1,0 +1,161 @@
+@api/v1
+Feature: Tauri upgrade package
+  Background:
+    Given the following "accounts" exist:
+      | name   | slug  |
+      | Test 1 | test1 |
+      | Test 2 | test2 |
+    And the current account is "test1"
+    And the current account has the following "product" rows:
+      | id                                   | name |
+      | 6198261a-48b5-4445-a045-9fed4afc7735 | Test |
+    And the current account has the following "package" rows:
+      | id                                   | product_id                           | engine | key  |
+      | 46e034fe-2312-40f8-bbeb-7d9957fb6fcf | 6198261a-48b5-4445-a045-9fed4afc7735 | tauri  | app1 |
+      | 2f8af04a-2424-4ca2-8480-6efe24318d1a | 6198261a-48b5-4445-a045-9fed4afc7735 | tauri  | app2 |
+      | 7b113ac2-ae81-406a-b44e-f356126e2faa | 6198261a-48b5-4445-a045-9fed4afc7735 | pypi   | pkg1 |
+      | 5666d47e-936e-4d48-8dd7-382d32462b4e | 6198261a-48b5-4445-a045-9fed4afc7735 |        | pkg2 |
+    And the current account has the following "release" rows:
+      | id                                   | product_id                           | release_package_id                   | version      | channel  | description | created_at               |
+      | 757e0a41-835e-42ad-bad8-84cabd29c72a | 6198261a-48b5-4445-a045-9fed4afc7735 | 46e034fe-2312-40f8-bbeb-7d9957fb6fcf | 1.0.0        | stable   | foo         | 2023-08-15T16:10:09.000Z |
+      | 028a38a2-0d17-4871-acb8-c5e6f040fc12 | 6198261a-48b5-4445-a045-9fed4afc7735 | 46e034fe-2312-40f8-bbeb-7d9957fb6fcf | 1.1.0        | stable   | bar         | 2023-08-15T16:10:09.000Z |
+      | 2bbb14ae-bb6b-4c57-b6ab-26f7982c967d | 6198261a-48b5-4445-a045-9fed4afc7735 | 46e034fe-2312-40f8-bbeb-7d9957fb6fcf | 1.2.0-beta-1 | beta     |             | 2023-08-15T16:10:09.000Z |
+      | c77ba874-de62-4a17-8368-fc10db1e1c80 | 6198261a-48b5-4445-a045-9fed4afc7735 | 2f8af04a-2424-4ca2-8480-6efe24318d1a | 1.0.0-beta.1 | beta     | baz         | 2023-08-15T16:10:09.000Z |
+      | 972aa5b8-b12c-49f4-8ba4-7c9ae053dfa2 | 6198261a-48b5-4445-a045-9fed4afc7735 | 2f8af04a-2424-4ca2-8480-6efe24318d1a | 2.0.0-beta.1 | beta     | qux         | 2023-08-15T16:10:09.000Z |
+    And the current account has the following "artifact" rows:
+      | id                                   | release_id                           | filename                  | filetype | platform | arch   | signature                                                                                |
+      # 1.0.0
+      | 1f63d6ec-8147-4bf0-bcd2-5d4f0e5eab8f | 757e0a41-835e-42ad-bad8-84cabd29c72a | myapp.AppImage            | appimage | linux    | x86_64 | KhuUa6VkDwE1CxJ37Z2bokP4OCeFDtA457rCoeL3it8zvjlLHw4JB29/OV6mn0cwtcW985kcLxkeD7LmLs7KUw== |
+      | 948f9b83-9e0d-469d-8982-e49213efe85e | 757e0a41-835e-42ad-bad8-84cabd29c72a | myapp.AppImage.tar.gz     | gz       | linux    | x86_64 | /EUsVzHfgst54mhWWb4opT65nre3vL/14sfk8wpxsWiIAc2hLSkWKtnAwxDtO/K/tjXqzoOpKxWNIiXtM9junA== |
+      | c1f8705e-68cd-4312-b2b1-72e19df47bd1 | 757e0a41-835e-42ad-bad8-84cabd29c72a | myapp.AppImage.tar.gz.sig | sig      | linux    | x86_64 | PGXlpwysSCW2qsWXwBHeBWAlUP+s0E3mhUufAHpU9IpIjIufWDVbu9/8GTuxCKvElDcq/b59HnwNSDXx4deOLw== |
+      | 2fd19ae7-e0cf-4de0-ad4a-1ca65db75c87 | 757e0a41-835e-42ad-bad8-84cabd29c72a | myapp.app                 | app      | darwin   | x86_64 | N7XdIjFjUxsaldjvUiPeTqrMZgcvcx9+DTEslA26iouEcMEwP9Wlc90VHzed+f/V47FpDrPQrUsBjPDcSNPsGw== |
+      | a8e49ea6-17df-4798-937f-e4756e331db5 | 757e0a41-835e-42ad-bad8-84cabd29c72a | myapp.app.tar.gz          | gz       | darwin   | x86_64 | d4LD3Wc6/wkAH6ZM+e4a4RYwoCMmsigGDdO8fG8xpywOKtoyE1oE5gJRvaiEpkZ00JsxtJuzfwIov1sQg30KdA== |
+      | adce1d8b-7120-43b6-a42a-a64c24ed2a25 | 757e0a41-835e-42ad-bad8-84cabd29c72a | myapp.app.tar.gz.sig      | sig      | darwin   | x86_64 | YDacBfpcurpkoOrDGhpbguhYlwDC7nTuyevwMJTXnwEHbcdO52SJU6bSKgNYHsU4UpYz3ShDG88eL4QtOITSNA== |
+      | fa773c2b-1c3a-4bd8-83fe-546480e92098 | 757e0a41-835e-42ad-bad8-84cabd29c72a | myapp-setup.exe           | exe      | windows  | x86_64 | /nYfyW4+9j1i+VcJxmq6wlcVc9JnxvC01OuzvNvVyl8GjmFQpZhjHimcjaGSnc1Jg4y99l33kQhF0Ju3ThZtpQ== |
+      | 56277838-ddb5-4c54-a3d2-0fad8bdfefe1 | 757e0a41-835e-42ad-bad8-84cabd29c72a | myapp-setup.nsis.zip      | zip      | windows  | x86_64 | GFnRwU9m6sM7VaoG48wAxFNbAWlSHpG5A8pyiecM6cWVjewJub0Np4uXR3vWQQch5mfRs+C5AITk8PCk5Ns1QQ== |
+      | 1cccff81-8b49-40b2-9453-3456f2ca04ac | 757e0a41-835e-42ad-bad8-84cabd29c72a | myapp-setup.nsis.zip.sig  | sig      | windows  | x86_64 | tOfzZilkppAQWhtT6buV7tZUdzDNOZK1YjNkslSSafzsvsuQmSbk9XfXXQEeF1iSgbM+x8fGlCcTjuBDSZZS1Q== |
+      | ab3f9749-3ea7-4057-92ec-d647784ff097 | 757e0a41-835e-42ad-bad8-84cabd29c72a | myapp.msi                 | msi      | windows  | x86_64 | AvUSjpAijmte0EuiWtfj0iajkKqJn11tiKGEomaQzFEqULaAUsoE/aME9akekNnPC3jQp3gu7mHgJvAlwXZBBA== |
+      | d7e01e53-4f9c-48a5-96cb-13207fc25cfe | 757e0a41-835e-42ad-bad8-84cabd29c72a | myapp.msi.zip             | zip      | windows  | x86_64 | 5N6y+NOpxLwwH0AcOHGfXLJWuVdutLKcqhfAHaRnYQXI1ltPbPu7cp7sewYzixoKRsrylnBonitks18aVCt4Qg== |
+      | a2fd1960-54c6-4624-83d1-84f0c8dd1f1a | 757e0a41-835e-42ad-bad8-84cabd29c72a | myapp.msi.zip.sig         | sig      | windows  | x86_64 | xlHIObWDYsjaYOl1EZEGGfkpi1DlT8/73vkJ2gBdFKQBcPJa4iwI4887vQnfi65fH+s3ptcOjmrtiiRnqTTt4w=  |
+      # 1.1.0
+      | 00aeec65-165c-487c-8e22-7ab454319b0f | 028a38a2-0d17-4871-acb8-c5e6f040fc12 | myapp.AppImage            | appimage | linux    | x86_64 | 93pUF68vzR3QRoGSXHbTQ9XVvXNburu5ofuFFLcrm1C1ZD9C2fr5mcaG06RljftY1HUzlFrpFmk9WVEbwr18tQ== |
+      | 6ce09e8b-26e7-4524-a10e-a410fc6580b0 | 028a38a2-0d17-4871-acb8-c5e6f040fc12 | myapp.AppImage.tar.gz     | gz       | linux    | x86_64 | bTm5t7bH2G9o3NAYgd4MGx7/nwnKCd+q4cdelm20tzcEpRepzto0KNmVl7z+AgiOOW6Cxkqyp0/zR2IntMnN7A== |
+      | 394180bd-4e0d-4d1b-986d-e4befad92101 | 028a38a2-0d17-4871-acb8-c5e6f040fc12 | myapp.AppImage.tar.gz.sig | sig      | linux    | x86_64 | Lc4r8JwhtfB7y9AhQ48uQiITGBXeockeMrsZU6kFk9dSF0dAi6SDWCFUsrJbUYPRhN2eduQdk8fHq0GwRD/dgw== |
+      | 65132a0a-4ca9-4422-b836-0cd39b0a94f7 | 028a38a2-0d17-4871-acb8-c5e6f040fc12 | myapp.app                 | app      | darwin   | x86_64 | DrLt7Nc1tqwsPehg5TxG7OKz2qLaDt0F61xPN6KCZjULc8OWVO2m+WAZdDFnzh+edHWtSawYWgwlIUREnYzKmQ== |
+      | 77aaaf13-cfc3-4339-8350-163efcaf8814 | 028a38a2-0d17-4871-acb8-c5e6f040fc12 | myapp.app.tar.gz          | gz       | darwin   | x86_64 | qjuxG7/3e44SUMRWSc8h3mOMk11L8lMSpKmEujgYmSjc+PnRY/Jedbw74a0+AMWkGSBCXvOISWK3bfylbNkaxw== |
+      | 8bdc0604-6948-4ab7-82bc-2b9a19153367 | 028a38a2-0d17-4871-acb8-c5e6f040fc12 | myapp.app.tar.gz.sig      | sig      | darwin   | x86_64 | AB/jy6vPxiW8grw86W9iDNqV/hrs2NKRakT9shzyJtv6LO9cza5FBoJctzH2B3Z84x5Vq19vwU66QUf5Ac7+lw== |
+      | 2133955c-137f-4422-9290-9a364b1a40a0 | 028a38a2-0d17-4871-acb8-c5e6f040fc12 | myapp-setup.exe           | exe      | windows  | x86_64 | BQfSyTfYWnHrl7LywK/fcioco+6IM4y1ermCGf5MjV1HT9VZ5ZtWRlQUM0UrPEXZct/gFYOf/THLk7mTvLUw1A== |
+      | 8700e88b-17b9-45af-91a7-6f7d1de7038e | 028a38a2-0d17-4871-acb8-c5e6f040fc12 | myapp-setup.nsis.zip      | zip      | windows  | x86_64 | 1lbG9323YV/MyW9t+MbouA1mvWaJQG+Skd3hCFpU44AfTS+jmQGiAyOqbdGa9zyDkEzeeoJeoqR+j3cq06uqBw== |
+      | ba8dd592-2c3e-46bf-afdc-dabc2fed9d8e | 028a38a2-0d17-4871-acb8-c5e6f040fc12 | myapp-setup.nsis.zip.sig  | sig      | windows  | x86_64 | gBbZS6U0bu6lDtfT0ntoATXijot9PwCTj38rSD0Np7Vs6Jh73oL7caa9Td4MFHq/wt1t70gLPPaHoNvOWEN+2w== |
+      | eaa67d65-f596-427a-8f64-80a7125ae299 | 028a38a2-0d17-4871-acb8-c5e6f040fc12 | myapp.msi                 | msi      | windows  | x86_64 | OE7wQq5K4TNsQ2nyZCuJhpOSS45t5/G0S3IbPKhOhVWYUJtwu4a4wwTHr04f6JTas8jiklJPdLS3wuXZ749fEw== |
+      | 6fdd494d-3fec-40a5-80e3-c3e9f71c7aa2 | 028a38a2-0d17-4871-acb8-c5e6f040fc12 | myapp.msi.zip             | zip      | windows  | x86_64 | 2ZnUI98WjokH4p/xu2U9T7Rg0J6byDF33lABy+8G+MkEBt3iKOuu7m25x/o95qYAQQRoG+I6Gi/lpl49xobVGA== |
+      | c185d92b-1232-4bdd-9906-fa4d99e259c7 | 028a38a2-0d17-4871-acb8-c5e6f040fc12 | myapp.msi.zip.sig         | sig      | windows  | x86_64 | DbSIbY2X0YRCySCC+xQeeber/9A45KZxHSyjNh4FSfQRkbK/jTCZ+MpIZ7geWu4Jx0FVq+7R9qj8Gtiz3TaEYg== |
+      # 1.2.0-beta.1
+      | 05f8a823-b80b-4453-a524-82332fc50792 | 2bbb14ae-bb6b-4c57-b6ab-26f7982c967d | myapp.AppImage            | appimage | linux    | x86_64 | Zd9e9c4l6Z1pHJPjFzYSWKLmzaQG1d/80hWMM5QbcnBBdNzObcJFGbmXJzAzrNRI1F9K6npGWlCFLZikvFm4rA== |
+      | 62577251-fbc4-4bb5-bcd8-cf4bac39faaf | 2bbb14ae-bb6b-4c57-b6ab-26f7982c967d | myapp.AppImage.tar.gz     | gz       | linux    | x86_64 | yfz/TKguPCzKru2jnYHqTk40g7sVBlPD00bHQK60iQ2ICG0tsfKq7j0Nc6gouyrtbwoiCUmZQE+xyEmKcyf/Vg== |
+      | 623efc8c-c2c9-46a1-9d1d-ff24e34a3359 | 2bbb14ae-bb6b-4c57-b6ab-26f7982c967d | myapp.AppImage.tar.gz.sig | sig      | linux    | x86_64 | +X5qPRP3+DGO2JcTuakCVyTdCeK9xRrdMHfiqBFRMSiRKOImlhRN8ja5mK9FDtAqGlS0F9MnK2rITLzJh+uYLQ== |
+      | 1eff1d91-02ff-44ec-8b44-1a11c10461ab | 2bbb14ae-bb6b-4c57-b6ab-26f7982c967d | myapp.app                 | app      | darwin   | x86_64 | IFd4DUPeV53K7Ts6XvpT4GrnoZW25w1nYRXsyNEGo0n9yAbx4cs2NTrliHXz+GbPN5OaEadlCAul33WvvthJvA== |
+      | 4502501f-8371-4aa8-acac-fff32c204a41 | 2bbb14ae-bb6b-4c57-b6ab-26f7982c967d | myapp.app.tar.gz          | gz       | darwin   | x86_64 | Dp/hr/+5PfyRzvYgm9CyFVixGeS662piAsKIeO2b/nHrS/XgPExt7l4mqkH1UWpDokC00eY2LbQjaf4c5bWi1w== |
+      | 260b1b8d-bf7e-4738-bad0-5316373da8f5 | 2bbb14ae-bb6b-4c57-b6ab-26f7982c967d | myapp.app.tar.gz.sig      | sig      | darwin   | x86_64 | pwaEooOf8pKsr3VScsXUWjPB202reCD47KbOE0ZG2njOANH7wXifW4CMh6PRISsa08WkO41IGrhISX2C7kVwwQ== |
+      | d5405732-577f-42eb-bd53-3bbc524072f0 | 2bbb14ae-bb6b-4c57-b6ab-26f7982c967d | myapp-setup.exe           | exe      | windows  | x86_64 | HmRBSDpEPZJQThHKOVViieS5xhx8HN9B2xieSp/8CV7FbOVsC62l5KaM27wrG6DFYyCCVUboNaYncB2a7vvOYA== |
+      | 2554c09a-8c0d-42e9-8108-fb5cfe7e4fab | 2bbb14ae-bb6b-4c57-b6ab-26f7982c967d | myapp-setup.nsis.zip      | zip      | windows  | x86_64 | ZItzHtqyMtpKPYTtP5oYKXSaqLazZnOWVMsVxb3zadJLs/OsBFrJ4iM/+RQm5N7RReHLg6uonI6ACQr80PRSTQ== |
+      | 419ba987-9184-4baf-82bf-8ca9baa4e267 | 2bbb14ae-bb6b-4c57-b6ab-26f7982c967d | myapp-setup.nsis.zip.sig  | sig      | windows  | x86_64 | uAAQVTGXau6Y6WNUIHBEzahPFn34E6poG78Ip9Bc9urgLuTzZgyQAaohS6nU4wuQdftUTwZbVxpYpXlAh/fDbg== |
+      | becabe1f-4b3f-4a83-9ab4-27fdb1ba07fe | 2bbb14ae-bb6b-4c57-b6ab-26f7982c967d | myapp.msi                 | msi      | windows  | x86_64 | 167ASeXh6NLamALrvdbIEpuB2PJqLpkrBHpvTy0L7FSvDTQZzGwY7b0zBgFlHyHlSnzJw9y2dC4xQgYAK5EiwA== |
+      | 479cb7f4-5780-402e-8e00-4a9ba4eecfe4 | 2bbb14ae-bb6b-4c57-b6ab-26f7982c967d | myapp.msi.zip             | zip      | windows  | x86_64 | nWkIH+FRn34NTIFZj6F12kOjmoM610thmTuf6lm/i4Hbcx06SYtAotrBaCyTxaqo4bdaBNbyqYLr6i84LZ3vmA== |
+      | d2801d8a-5ce8-4c48-89ee-7177d7dcc84c | 2bbb14ae-bb6b-4c57-b6ab-26f7982c967d | myapp.msi.zip.sig         | sig      | windows  | x86_64 | uUsbx9f9ZGlN/45rBK3ZRy7/QNJNdsyG5f18dIt1FO0caAPr5cBxBIuUAbmIC7FnrECrDLcaL18GQ8MeB86WOA== |
+      # 1.0.0-beta.1
+      | 699a9b1e-6d57-428a-b039-cb387de7d6ff | c77ba874-de62-4a17-8368-fc10db1e1c80 | myapp-setup.exe           | exe      | windows  | i686   | dQj9GEoEqv0jxagPuks0zPCs3RIXi0fBvxsXUEkyeNwt372dRtjyJxHNAzEys9vsWCAI+FcH3erTmzVwtoQkgA== |
+      | f5e7fa7d-7684-4cab-ade6-bdea58fa2d4c | c77ba874-de62-4a17-8368-fc10db1e1c80 | myapp-setup.nsis.zip      | zip      | windows  | i686   | R5vsdOmH+jxZ6Cer0iu2XIbJDed7yWW12nGLnmd+1/m8P/6tVgJKgAuJlbz+VUef3YGWbo0Vq5yDhCcod/R4nQ== |
+      | f36df79d-5952-4d7d-ae13-87198e1cd0f0 | c77ba874-de62-4a17-8368-fc10db1e1c80 | myapp-setup.nsis.zip.sig  | sig      | windows  | i686   | nr20BEyN5xnWX3I+OxDX85GhGoABpvJGevnmo95nBdHdxFxKCQMLRwQaVqCh++RRRAWv22Hq1VZcxpwumOwuLw== |
+      | 375d8a5a-e839-4bc1-a168-e376baf27c78 | c77ba874-de62-4a17-8368-fc10db1e1c80 | myapp.msi                 | msi      | windows  | i686   | foTILz/82kERvo9wdYprCKw/zCq4tA409RSnFAhMbSXbn6Co9MBmSIVjVFaVIP/cy74oXDUAuRHscQVwEUH1rA== |
+      | 23b0c365-1941-4036-b60b-c3f669f1da35 | c77ba874-de62-4a17-8368-fc10db1e1c80 | myapp.msi.zip             | zip      | windows  | i686   | rIZq0l+CqaSuv52Z2VjiXXnbpURrIXoZuZKvTr9TlCb9cikY2egwBWCLBekurbFiNfwzzeWrjZlefb/t14pAnQ== |
+      | ecdb59f6-00c1-4fec-80bd-7fc176f9d1a0 | c77ba874-de62-4a17-8368-fc10db1e1c80 | myapp.msi.zip.sig         | sig      | windows  | i686   | qJ6ij921jgD6yJ3UknE5IFAiSfFPTcUZPkqGj+WwfedTKPz7d7NmiUZRxPoajz/GKLimBoXdEm0a57L+yFEejw== |
+      # 2.0.0-beta.1
+      | 61987e0a-1848-4a04-9b2a-86ff6a7f464b | 972aa5b8-b12c-49f4-8ba4-7c9ae053dfa2 | myapp.msi                 | msi      | windows  | i686   | 3vw5nDxg8qAZ4yPtPvBb0BJf5I+Df7zveGPDWEhOFAfeSfPhUuxbwePy/inD16AQM/K2ovHPpBMsZ9nmpI/r9A== |
+      | 0220fd5b-e35f-452f-980f-6a7447c71163 | 972aa5b8-b12c-49f4-8ba4-7c9ae053dfa2 | myapp.msi.zip             | zip      | windows  | i686   | DM6TUNOgzD11U2bgEEuNfxKOssq5ElscX/AIgd5Oczl4ufIoYViVdT0U/hin5jx7pySy3WW7J5tlS/lt5U5xPg== |
+      | dd61752e-187e-4346-a7df-fda80adb7131 | 972aa5b8-b12c-49f4-8ba4-7c9ae053dfa2 | myapp.msi.zip.sig         | sig      | windows  | i686   | /oBea3DwxhueGOhoKQ9JxTBHamr9cp85WyJI5p50FeRqq9zELjroza7h5/c33CgZGnx1klSo4omAqWgdupx+8g== |
+      | 16b9a3fa-6b12-4d86-b81e-be2757392bae | 972aa5b8-b12c-49f4-8ba4-7c9ae053dfa2 | myapp-setup.exe           | exe      | windows  | i686   | 1/ZheqnqL3OJbQcUa+zmFCENiXqhW1oqrUP2sREyExryaDRcy14lC6nSHg4gt/TfbHkE1ANnsEFizRdno+uZZg== |
+      | 8dbd9795-2b57-436a-863e-26a3e6689f38 | 972aa5b8-b12c-49f4-8ba4-7c9ae053dfa2 | myapp-setup.nsis.zip      | zip      | windows  | i686   | 6vfPB8J8IW1AlSkc7e4XOiLFIPelzQYQyN+nrXMNsBr+Tb7IWjNKRZxDH/rlOhXjAqkY24SxD56suQGY+ELkYA== |
+      | e1a9d063-cd8d-4655-95e5-647c961852eb | 972aa5b8-b12c-49f4-8ba4-7c9ae053dfa2 | myapp-setup.nsis.zip.sig  | sig      | windows  | i686   | Rpvx4kMZlfBr1lM7GwA1tJA7qeRGfNACOIYXwyxqTH6RkqIvcNcB8dl3ZcdEqdF46l1oFDiWYcI5xYE35/NSlA== |
+    And I send the following raw headers:
+      """
+      User-Agent: tauri-updater
+      Accept: application/octet-stream
+      """
+
+  Scenario: Endpoint should be inaccessible when account is disabled
+    Given the account "test1" is canceled
+    And I am an admin of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/engines/tauri/app1/linux/x86_64/1.0.0"
+    Then the response status should be "403"
+    And the response should contain the following headers:
+      """
+      { "Content-Type": "application/json; charset=utf-8" }
+      """
+
+  Scenario: Endpoint should not return an upgrade when an upgrade is not available
+    Given I am an admin of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/engines/tauri/app1/linux/x86_64/1.1.0"
+    Then the response status should be "204"
+
+  Scenario: Endpoint should not return an upgrade when a version does not exist
+    Given I am an admin of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/engines/tauri/app1/linux/x86_64/3.0.0"
+    Then the response status should be "204"
+
+  Scenario: Endpoint should return an upgrade when an upgrade is available
+    Given I am an admin of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/engines/tauri/app1/linux/x86_64/1.0.0"
+    Then the response status should be "200"
+    And the response body should include the following:
+      """
+      {
+        "url": "https://api.keygen.sh/v1/accounts/$account/artifacts/6ce09e8b-26e7-4524-a10e-a410fc6580b0/myapp.AppImage.tar.gz",
+        "signature": "bTm5t7bH2G9o3NAYgd4MGx7/nwnKCd+q4cdelm20tzcEpRepzto0KNmVl7z+AgiOOW6Cxkqyp0/zR2IntMnN7A==",
+        "version": "1.1.0"
+      }
+      """
+
+  Scenario: Endpoint should prefer NSIS over MSI for windows
+    Given I am an admin of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/engines/tauri/app2/windows/i686/1.0.0-beta.1"
+    Then the response status should be "200"
+    And the response body should include the following:
+      """
+      {
+        "url": "https://api.keygen.sh/v1/accounts/$account/artifacts/8dbd9795-2b57-436a-863e-26a3e6689f38/myapp-setup.nsis.zip",
+        "signature": "6vfPB8J8IW1AlSkc7e4XOiLFIPelzQYQyN+nrXMNsBr+Tb7IWjNKRZxDH/rlOhXjAqkY24SxD56suQGY+ELkYA==",
+        "version": "2.0.0-beta.1"
+      }
+      """
+
+  Scenario: Endpoint should include release notes when available
+    Given I am an admin of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/engines/tauri/app1/darwin/x86_64/1.0.0"
+    Then the response status should be "200"
+    And the response body should include the following:
+      """
+      { "notes": "bar" }
+      """
+
+  Scenario: Endpoint should include publish date when available
+    Given I am an admin of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/engines/tauri/app1/darwin/x86_64/1.0.0"
+    Then the response status should be "200"
+    And the response body should include the following:
+      """
+      { "pub_date": "2023-08-15T16:10:09.000Z" }
+      """
+
+  Scenario: Endpoint should return error for non-Tauri packages
+    Given I am an admin of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/engines/tauri/pkg1/darwin/x86_64/1.0.0"
+    Then the response status should be "404"

--- a/features/api/v1/engines/tauri/upgrade.feature
+++ b/features/api/v1/engines/tauri/upgrade.feature
@@ -71,12 +71,12 @@ Feature: Tauri upgrade package
       | 23b0c365-1941-4036-b60b-c3f669f1da35 | c77ba874-de62-4a17-8368-fc10db1e1c80 | myapp.msi.zip             | zip      | windows  | i686   | rIZq0l+CqaSuv52Z2VjiXXnbpURrIXoZuZKvTr9TlCb9cikY2egwBWCLBekurbFiNfwzzeWrjZlefb/t14pAnQ== |
       | ecdb59f6-00c1-4fec-80bd-7fc176f9d1a0 | c77ba874-de62-4a17-8368-fc10db1e1c80 | myapp.msi.zip.sig         | sig      | windows  | i686   | qJ6ij921jgD6yJ3UknE5IFAiSfFPTcUZPkqGj+WwfedTKPz7d7NmiUZRxPoajz/GKLimBoXdEm0a57L+yFEejw== |
       # 2.0.0-beta.1
-      | 61987e0a-1848-4a04-9b2a-86ff6a7f464b | 972aa5b8-b12c-49f4-8ba4-7c9ae053dfa2 | myapp.msi                 | msi      | windows  | i686   | 3vw5nDxg8qAZ4yPtPvBb0BJf5I+Df7zveGPDWEhOFAfeSfPhUuxbwePy/inD16AQM/K2ovHPpBMsZ9nmpI/r9A== |
-      | 0220fd5b-e35f-452f-980f-6a7447c71163 | 972aa5b8-b12c-49f4-8ba4-7c9ae053dfa2 | myapp.msi.zip             | zip      | windows  | i686   | DM6TUNOgzD11U2bgEEuNfxKOssq5ElscX/AIgd5Oczl4ufIoYViVdT0U/hin5jx7pySy3WW7J5tlS/lt5U5xPg== |
-      | dd61752e-187e-4346-a7df-fda80adb7131 | 972aa5b8-b12c-49f4-8ba4-7c9ae053dfa2 | myapp.msi.zip.sig         | sig      | windows  | i686   | /oBea3DwxhueGOhoKQ9JxTBHamr9cp85WyJI5p50FeRqq9zELjroza7h5/c33CgZGnx1klSo4omAqWgdupx+8g== |
       | 16b9a3fa-6b12-4d86-b81e-be2757392bae | 972aa5b8-b12c-49f4-8ba4-7c9ae053dfa2 | myapp-setup.exe           | exe      | windows  | i686   | 1/ZheqnqL3OJbQcUa+zmFCENiXqhW1oqrUP2sREyExryaDRcy14lC6nSHg4gt/TfbHkE1ANnsEFizRdno+uZZg== |
       | 8dbd9795-2b57-436a-863e-26a3e6689f38 | 972aa5b8-b12c-49f4-8ba4-7c9ae053dfa2 | myapp-setup.nsis.zip      | zip      | windows  | i686   | 6vfPB8J8IW1AlSkc7e4XOiLFIPelzQYQyN+nrXMNsBr+Tb7IWjNKRZxDH/rlOhXjAqkY24SxD56suQGY+ELkYA== |
       | e1a9d063-cd8d-4655-95e5-647c961852eb | 972aa5b8-b12c-49f4-8ba4-7c9ae053dfa2 | myapp-setup.nsis.zip.sig  | sig      | windows  | i686   | Rpvx4kMZlfBr1lM7GwA1tJA7qeRGfNACOIYXwyxqTH6RkqIvcNcB8dl3ZcdEqdF46l1oFDiWYcI5xYE35/NSlA== |
+      | 61987e0a-1848-4a04-9b2a-86ff6a7f464b | 972aa5b8-b12c-49f4-8ba4-7c9ae053dfa2 | myapp.msi                 | msi      | windows  | i686   | 3vw5nDxg8qAZ4yPtPvBb0BJf5I+Df7zveGPDWEhOFAfeSfPhUuxbwePy/inD16AQM/K2ovHPpBMsZ9nmpI/r9A== |
+      | 0220fd5b-e35f-452f-980f-6a7447c71163 | 972aa5b8-b12c-49f4-8ba4-7c9ae053dfa2 | myapp.msi.zip             | zip      | windows  | i686   | DM6TUNOgzD11U2bgEEuNfxKOssq5ElscX/AIgd5Oczl4ufIoYViVdT0U/hin5jx7pySy3WW7J5tlS/lt5U5xPg== |
+      | dd61752e-187e-4346-a7df-fda80adb7131 | 972aa5b8-b12c-49f4-8ba4-7c9ae053dfa2 | myapp.msi.zip.sig         | sig      | windows  | i686   | /oBea3DwxhueGOhoKQ9JxTBHamr9cp85WyJI5p50FeRqq9zELjroza7h5/c33CgZGnx1klSo4omAqWgdupx+8g== |
     And I send the following raw headers:
       """
       User-Agent: tauri-updater
@@ -159,3 +159,158 @@ Feature: Tauri upgrade package
     And I use an authentication token
     When I send a GET request to "/accounts/test1/engines/tauri/pkg1/darwin/x86_64/1.0.0"
     Then the response status should be "404"
+
+  Scenario: Product retrieves an upgrade when an upgrade is available
+    Given I am the first product of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/engines/tauri/app1/windows/x86_64/1.0.0"
+    Then the response status should be "200"
+    And the response body should include the following:
+      """
+      {
+        "url": "https://api.keygen.sh/v1/accounts/$account/artifacts/8700e88b-17b9-45af-91a7-6f7d1de7038e/myapp-setup.nsis.zip",
+        "signature": "1lbG9323YV/MyW9t+MbouA1mvWaJQG+Skd3hCFpU44AfTS+jmQGiAyOqbdGa9zyDkEzeeoJeoqR+j3cq06uqBw==",
+        "version": "1.1.0"
+      }
+      """
+
+  Scenario: License retrieves an upgrade when an upgrade is available
+    Given the current account has 1 "policy" for the last "product" with the following:
+      """
+      { "authenticationStrategy": "LICENSE" }
+      """
+    And the current account has 1 "license" for the last "policy"
+    And I am a license of account "test1"
+    And I authenticate with my key
+    When I send a GET request to "/accounts/test1/engines/tauri/app1/darwin/x86_64/1.0.0"
+    Then the response status should be "200"
+    And the response body should include the following:
+      """
+      {
+        "url": "https://api.keygen.sh/v1/accounts/$account/artifacts/77aaaf13-cfc3-4339-8350-163efcaf8814/myapp.app.tar.gz",
+        "signature": "qjuxG7/3e44SUMRWSc8h3mOMk11L8lMSpKmEujgYmSjc+PnRY/Jedbw74a0+AMWkGSBCXvOISWK3bfylbNkaxw==",
+        "version": "1.1.0"
+      }
+      """
+
+  Scenario: License retrieves an upgrade for a release that has entitlement constraints (no entitlements)
+    Given the current account has 3 "entitlements"
+    And the current account has 1 "release-entitlement-constraint" with the following:
+      """
+      {
+        "entitlementId": "$entitlements[0]",
+        "releaseId": "$releases[0]"
+      }
+      """
+    And the current account has 1 "policy" for the last "product" with the following:
+      """
+      { "authenticationStrategy": "LICENSE" }
+      """
+    And the current account has 1 "license" for the last "policy"
+    And I am a license of account "test1"
+    And I authenticate with my key
+    When I send a GET request to "/accounts/test1/engines/tauri/app1/darwin/x86_64/1.0.0"
+    Then the response status should be "204"
+
+  Scenario: License retrieves an upgrade that has entitlement constraints (no entitlements)
+    Given the current account has 3 "entitlements"
+    And the current account has 1 "release-entitlement-constraint" with the following:
+      """
+      {
+        "entitlementId": "$entitlements[0]",
+        "releaseId": "$releases[1]"
+      }
+      """
+    And the current account has 1 "policy" for the last "product" with the following:
+      """
+      { "authenticationStrategy": "LICENSE" }
+      """
+    And the current account has 1 "license" for the last "policy"
+    And I am a license of account "test1"
+    And I authenticate with my key
+    When I send a GET request to "/accounts/test1/engines/tauri/app1/darwin/x86_64/1.0.0"
+    Then the response status should be "403"
+
+  Scenario: License retrieves an upgrade that has entitlement constraints (has entitlements)
+    Given the current account has 3 "entitlements"
+    And the current account has 1 "release-entitlement-constraint" with the following:
+      """
+      {
+        "entitlementId": "$entitlements[0]",
+        "releaseId": "$releases[1]"
+      }
+      """
+    And the current account has 1 "policy" for the last "product" with the following:
+      """
+      { "authenticationStrategy": "LICENSE" }
+      """
+    And the current account has 1 "license" for the last "policy"
+    And the current account has 1 "license-entitlement" with the following:
+      """
+      {
+        "entitlementId": "$entitlements[0]",
+        "licenseId": "$licenses[0]"
+      }
+      """
+    And I am a license of account "test1"
+    And I authenticate with my key
+    When I send a GET request to "/accounts/test1/engines/tauri/app1/darwin/x86_64/1.0.0"
+    Then the response status should be "200"
+    And the response body should include the following:
+      """
+      {
+        "url": "https://api.keygen.sh/v1/accounts/$account/artifacts/77aaaf13-cfc3-4339-8350-163efcaf8814/myapp.app.tar.gz",
+        "signature": "qjuxG7/3e44SUMRWSc8h3mOMk11L8lMSpKmEujgYmSjc+PnRY/Jedbw74a0+AMWkGSBCXvOISWK3bfylbNkaxw==",
+        "version": "1.1.0"
+      }
+      """
+
+  Scenario: User retrieves an upgrade when an upgrade is available
+    Given the current account has 1 "policy" for the last "product"
+    And the current account has 1 "license" for the last "policy"
+    And the current account has 1 "user"
+    And the last "license" belongs to the last "user"
+    And I am a user of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/engines/tauri/app1/darwin/x86_64/1.0.0"
+    Then the response status should be "200"
+    And the response body should include the following:
+      """
+      {
+        "url": "https://api.keygen.sh/v1/accounts/$account/artifacts/77aaaf13-cfc3-4339-8350-163efcaf8814/myapp.app.tar.gz",
+        "signature": "qjuxG7/3e44SUMRWSc8h3mOMk11L8lMSpKmEujgYmSjc+PnRY/Jedbw74a0+AMWkGSBCXvOISWK3bfylbNkaxw==",
+        "version": "1.1.0"
+      }
+      """
+
+  Scenario: Anonymous retrieves an upgrade for a licensed product
+    Given the last "product" has the following attributes:
+      """
+      { "distributionStrategy": "LICENSED" }
+      """
+    When I send a GET request to "/accounts/test1/engines/tauri/app1/darwin/x86_64/1.0.0"
+    Then the response status should be "404"
+
+  Scenario: Anonymous retrieves an upgrade for a closed product
+    Given the last "product" has the following attributes:
+      """
+      { "distributionStrategy": "CLOSED" }
+      """
+    When I send a GET request to "/accounts/test1/engines/tauri/app1/darwin/x86_64/1.0.0"
+    Then the response status should be "404"
+
+  Scenario: Anonymous retrieves an upgrade for an open product
+    Given the last "product" has the following attributes:
+      """
+      { "distributionStrategy": "OPEN" }
+      """
+    When I send a GET request to "/accounts/test1/engines/tauri/app1/darwin/x86_64/1.0.0"
+    Then the response status should be "200"
+    And the response body should include the following:
+      """
+      {
+        "url": "https://api.keygen.sh/v1/accounts/$account/artifacts/77aaaf13-cfc3-4339-8350-163efcaf8814/myapp.app.tar.gz",
+        "signature": "qjuxG7/3e44SUMRWSc8h3mOMk11L8lMSpKmEujgYmSjc+PnRY/Jedbw74a0+AMWkGSBCXvOISWK3bfylbNkaxw==",
+        "version": "1.1.0"
+      }
+      """

--- a/features/api/v1/engines/tauri/upgrade.feature
+++ b/features/api/v1/engines/tauri/upgrade.feature
@@ -19,8 +19,9 @@ Feature: Tauri upgrade package
       | id                                   | product_id                           | release_package_id                   | version      | channel  | description |
       | 757e0a41-835e-42ad-bad8-84cabd29c72a | 6198261a-48b5-4445-a045-9fed4afc7735 | 46e034fe-2312-40f8-bbeb-7d9957fb6fcf | 1.0.0        | stable   | foo         |
       | 028a38a2-0d17-4871-acb8-c5e6f040fc12 | 6198261a-48b5-4445-a045-9fed4afc7735 | 46e034fe-2312-40f8-bbeb-7d9957fb6fcf | 1.1.0        | stable   | bar         |
-      | 2bbb14ae-bb6b-4c57-b6ab-26f7982c967d | 6198261a-48b5-4445-a045-9fed4afc7735 | 46e034fe-2312-40f8-bbeb-7d9957fb6fcf | 1.2.0-beta-1 | beta     |             |
+      | 2bbb14ae-bb6b-4c57-b6ab-26f7982c967d | 6198261a-48b5-4445-a045-9fed4afc7735 | 46e034fe-2312-40f8-bbeb-7d9957fb6fcf | 1.2.0-beta.1 | beta     |             |
       | c77ba874-de62-4a17-8368-fc10db1e1c80 | 6198261a-48b5-4445-a045-9fed4afc7735 | 2f8af04a-2424-4ca2-8480-6efe24318d1a | 1.0.0-beta.1 | beta     | baz         |
+      | 29f74047-265f-452c-9d64-779621682857 | 6198261a-48b5-4445-a045-9fed4afc7735 | 2f8af04a-2424-4ca2-8480-6efe24318d1a | 1.0.1-beta.1 | beta     | baz         |
       | 972aa5b8-b12c-49f4-8ba4-7c9ae053dfa2 | 6198261a-48b5-4445-a045-9fed4afc7735 | 2f8af04a-2424-4ca2-8480-6efe24318d1a | 2.0.0-beta.1 | beta     | qux         |
     And the current account has the following "artifact" rows:
       | id                                   | release_id                           | filename                  | filetype | platform | arch   | signature                                                                                |
@@ -70,6 +71,13 @@ Feature: Tauri upgrade package
       | 375d8a5a-e839-4bc1-a168-e376baf27c78 | c77ba874-de62-4a17-8368-fc10db1e1c80 | myapp.msi                 | msi      | windows  | i686   | foTILz/82kERvo9wdYprCKw/zCq4tA409RSnFAhMbSXbn6Co9MBmSIVjVFaVIP/cy74oXDUAuRHscQVwEUH1rA== |
       | 23b0c365-1941-4036-b60b-c3f669f1da35 | c77ba874-de62-4a17-8368-fc10db1e1c80 | myapp.msi.zip             | zip      | windows  | i686   | rIZq0l+CqaSuv52Z2VjiXXnbpURrIXoZuZKvTr9TlCb9cikY2egwBWCLBekurbFiNfwzzeWrjZlefb/t14pAnQ== |
       | ecdb59f6-00c1-4fec-80bd-7fc176f9d1a0 | c77ba874-de62-4a17-8368-fc10db1e1c80 | myapp.msi.zip.sig         | sig      | windows  | i686   | qJ6ij921jgD6yJ3UknE5IFAiSfFPTcUZPkqGj+WwfedTKPz7d7NmiUZRxPoajz/GKLimBoXdEm0a57L+yFEejw== |
+      # 1.0.1-beta.1
+      | 05b82ab6-ad64-46d4-9885-97a23347eb1c | 29f74047-265f-452c-9d64-779621682857 | myapp-setup.exe           | exe      | windows  | i686   | w3tDl0PCRIBM8t07D8fWpl102zpxiKKYJ8E6oCLBxiXYBB3Zvb52osFgrw6H8nPrqNu3Ax0NV8VKtBmmxxUN3A== |
+      | 2d719642-aec6-4e76-86af-5de76b9c2491 | 29f74047-265f-452c-9d64-779621682857 | myapp-setup.nsis.zip      | zip      | windows  | i686   | JMPKKgalgzGHfQ7TBCRTR4NU6rqWZeQpLDWrkjswTc/mztdShLLPMG0I9tdNFi0qlCtMXAHXYPUR/YQSQFLEOA== |
+      | cefb4032-6e1b-4411-8e85-f5d7d8a269a2 | 29f74047-265f-452c-9d64-779621682857 | myapp-setup.nsis.zip.sig  | sig      | windows  | i686   | dA4En1FgSfi+6O8O+DY5bCchQkVxRGR8w+4pKfGjpug6+/4wwrZgmlhOfs364eKVtf7UcWsZ9vopF0E6HV28UA== |
+      | 1adda3a2-021d-4d76-b715-6907ce7d78c2 | 29f74047-265f-452c-9d64-779621682857 | myapp.msi                 | msi      | windows  | i686   | G0ocYvc2INVNpBcaoDEaAwQhAxX9/xxNv1g44NICAnMU+Z8V6ohUGtoX2Q8adDOo7JE8/picj+i1gwWb5Em1Fw== |
+      | 7cd42443-f93e-4a28-8f7f-57a0aa8b8ac2 | 29f74047-265f-452c-9d64-779621682857 | myapp.msi.zip             | zip      | windows  | i686   | HdjLw2BS/1lBKUtoamPrTQWhdHAMsKhz96Z6OHoQPh8h/9CfFH+JtA+RbPNVSpEidBD9tmYM0SOaHmVHmr/Bwg== |
+      | 2986a294-fc70-4a99-805e-e91b90b4ec2b | 29f74047-265f-452c-9d64-779621682857 | myapp.msi.zip.sig         | sig      | windows  | i686   | CW5imayiWMU50dYJIW1CMDxMW0qr01YUGd97r4IOs2WZlpcl1OIyeYvKgDNAJXkBBSbi9QPG21I3OxJxecsoBw== |
       # 2.0.0-beta.1
       | 16b9a3fa-6b12-4d86-b81e-be2757392bae | 972aa5b8-b12c-49f4-8ba4-7c9ae053dfa2 | myapp-setup.exe           | exe      | windows  | i686   | 1/ZheqnqL3OJbQcUa+zmFCENiXqhW1oqrUP2sREyExryaDRcy14lC6nSHg4gt/TfbHkE1ANnsEFizRdno+uZZg== |
       | 8dbd9795-2b57-436a-863e-26a3e6689f38 | 972aa5b8-b12c-49f4-8ba4-7c9ae053dfa2 | myapp-setup.nsis.zip      | zip      | windows  | i686   | 6vfPB8J8IW1AlSkc7e4XOiLFIPelzQYQyN+nrXMNsBr+Tb7IWjNKRZxDH/rlOhXjAqkY24SxD56suQGY+ELkYA== |
@@ -158,11 +166,95 @@ Feature: Tauri upgrade package
       { "pub_date": "2023-08-15T00:00:00.000Z" }
       """
 
+  Scenario: Endpoint should constrain to a semver constraint
+    Given the second "release" has the following attributes:
+      """
+      { "createdAt": "2023-08-15T00:00:00.000Z" }
+      """
+    And I am an admin of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/engines/tauri/app2?platform=windows&arch=i686&version=1.0.0-beta.1&constraint=1.0"
+    Then the response status should be "200"
+    And the response body should include the following:
+      """
+      {
+        "url": "https://api.keygen.sh/v1/accounts/$account/artifacts/2d719642-aec6-4e76-86af-5de76b9c2491/myapp-setup.nsis.zip",
+        "signature": "JMPKKgalgzGHfQ7TBCRTR4NU6rqWZeQpLDWrkjswTc/mztdShLLPMG0I9tdNFi0qlCtMXAHXYPUR/YQSQFLEOA==",
+        "version": "1.0.1-beta.1"
+      }
+      """
+
+  Scenario: Endpoint should upgrade from stable to beta
+    Given the second "release" has the following attributes:
+      """
+      { "createdAt": "2023-08-15T00:00:00.000Z" }
+      """
+    And I am an admin of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/engines/tauri/app1?platform=linux&arch=x86_64&version=1.1.0&channel=beta"
+    Then the response status should be "200"
+    And the response body should include the following:
+      """
+      {
+        "url": "https://api.keygen.sh/v1/accounts/$account/artifacts/62577251-fbc4-4bb5-bcd8-cf4bac39faaf/myapp.AppImage.tar.gz",
+        "signature": "yfz/TKguPCzKru2jnYHqTk40g7sVBlPD00bHQK60iQ2ICG0tsfKq7j0Nc6gouyrtbwoiCUmZQE+xyEmKcyf/Vg==",
+        "version": "1.2.0-beta.1"
+      }
+      """
+
   Scenario: Endpoint should return error for non-Tauri packages
     Given I am an admin of account "test1"
     And I use an authentication token
     When I send a GET request to "/accounts/test1/engines/tauri/pkg1?platform=darwin&arch=x86_64&version=1.0.0"
     Then the response status should be "404"
+
+  Scenario: Endpoint should return error for missing platform
+    Given I am an admin of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/engines/tauri/app1?arch=x86_64&version=1.0.0"
+    Then the response status should be "400"
+    And the first error should have the following properties:
+      """
+      {
+        "title": "Bad request",
+        "detail": "is missing",
+        "source": {
+          "parameter": "platform"
+        }
+      }
+      """
+
+  Scenario: Endpoint should return error for missing arch
+    Given I am an admin of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/engines/tauri/app1?platform=darwin&version=1.0.0"
+    Then the response status should be "400"
+    And the first error should have the following properties:
+      """
+      {
+        "title": "Bad request",
+        "detail": "is missing",
+        "source": {
+          "parameter": "arch"
+        }
+      }
+      """
+
+  Scenario: Endpoint should return error for missing version
+    Given I am an admin of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/engines/tauri/app1?platform=darwin&arch=x86_64"
+    Then the response status should be "400"
+    And the first error should have the following properties:
+      """
+      {
+        "title": "Bad request",
+        "detail": "is missing",
+        "source": {
+          "parameter": "version"
+        }
+      }
+      """
 
   Scenario: Product retrieves an upgrade when an upgrade is available
     Given I am the first product of account "test1"

--- a/features/api/v1/engines/tauri/upgrade.feature
+++ b/features/api/v1/engines/tauri/upgrade.feature
@@ -87,7 +87,7 @@ Feature: Tauri upgrade package
     Given the account "test1" is canceled
     And I am an admin of account "test1"
     And I use an authentication token
-    When I send a GET request to "/accounts/test1/engines/tauri/app1/linux/x86_64/1.0.0"
+    When I send a GET request to "/accounts/test1/engines/tauri/app1?platform=linux&arch=x86_64&version=1.0.0"
     Then the response status should be "403"
     And the response should contain the following headers:
       """
@@ -97,19 +97,19 @@ Feature: Tauri upgrade package
   Scenario: Endpoint should not return an upgrade when an upgrade is not available
     Given I am an admin of account "test1"
     And I use an authentication token
-    When I send a GET request to "/accounts/test1/engines/tauri/app1/linux/x86_64/1.1.0"
+    When I send a GET request to "/accounts/test1/engines/tauri/app1?platform=linux&arch=x86_64&version=1.1.0"
     Then the response status should be "204"
 
   Scenario: Endpoint should not return an upgrade when a version does not exist
     Given I am an admin of account "test1"
     And I use an authentication token
-    When I send a GET request to "/accounts/test1/engines/tauri/app1/linux/x86_64/3.0.0"
+    When I send a GET request to "/accounts/test1/engines/tauri/app1?platform=linux&arch=x86_64&version=3.0.0"
     Then the response status should be "204"
 
   Scenario: Endpoint should return an upgrade when an upgrade is available
     Given I am an admin of account "test1"
     And I use an authentication token
-    When I send a GET request to "/accounts/test1/engines/tauri/app1/linux/x86_64/1.0.0"
+    When I send a GET request to "/accounts/test1/engines/tauri/app1?platform=linux&arch=x86_64&version=1.0.0"
     Then the response status should be "200"
     And the response body should include the following:
       """
@@ -123,7 +123,7 @@ Feature: Tauri upgrade package
   Scenario: Endpoint should prefer NSIS over MSI for windows
     Given I am an admin of account "test1"
     And I use an authentication token
-    When I send a GET request to "/accounts/test1/engines/tauri/app2/windows/i686/1.0.0-beta.1"
+    When I send a GET request to "/accounts/test1/engines/tauri/app2?platform=windows&arch=i686&version=1.0.0-beta.1"
     Then the response status should be "200"
     And the response body should include the following:
       """
@@ -137,7 +137,7 @@ Feature: Tauri upgrade package
   Scenario: Endpoint should include release notes when available
     Given I am an admin of account "test1"
     And I use an authentication token
-    When I send a GET request to "/accounts/test1/engines/tauri/app1/darwin/x86_64/1.0.0"
+    When I send a GET request to "/accounts/test1/engines/tauri/app1?platform=darwin&arch=x86_64&version=1.0.0"
     Then the response status should be "200"
     And the response body should include the following:
       """
@@ -151,7 +151,7 @@ Feature: Tauri upgrade package
       """
     And I am an admin of account "test1"
     And I use an authentication token
-    When I send a GET request to "/accounts/test1/engines/tauri/app1/darwin/x86_64/1.0.0"
+    When I send a GET request to "/accounts/test1/engines/tauri/app1?platform=darwin&arch=x86_64&version=1.0.0"
     Then the response status should be "200"
     And the response body should include the following:
       """
@@ -161,13 +161,13 @@ Feature: Tauri upgrade package
   Scenario: Endpoint should return error for non-Tauri packages
     Given I am an admin of account "test1"
     And I use an authentication token
-    When I send a GET request to "/accounts/test1/engines/tauri/pkg1/darwin/x86_64/1.0.0"
+    When I send a GET request to "/accounts/test1/engines/tauri/pkg1?platform=darwin&arch=x86_64&version=1.0.0"
     Then the response status should be "404"
 
   Scenario: Product retrieves an upgrade when an upgrade is available
     Given I am the first product of account "test1"
     And I use an authentication token
-    When I send a GET request to "/accounts/test1/engines/tauri/app1/windows/x86_64/1.0.0"
+    When I send a GET request to "/accounts/test1/engines/tauri/app1?platform=windows&arch=x86_64&version=1.0.0"
     Then the response status should be "200"
     And the response body should include the following:
       """
@@ -186,7 +186,7 @@ Feature: Tauri upgrade package
     And the current account has 1 "license" for the last "policy"
     And I am a license of account "test1"
     And I authenticate with my key
-    When I send a GET request to "/accounts/test1/engines/tauri/app1/darwin/x86_64/1.0.0"
+    When I send a GET request to "/accounts/test1/engines/tauri/app1?platform=darwin&arch=x86_64&version=1.0.0"
     Then the response status should be "200"
     And the response body should include the following:
       """
@@ -213,7 +213,7 @@ Feature: Tauri upgrade package
     And the current account has 1 "license" for the last "policy"
     And I am a license of account "test1"
     And I authenticate with my key
-    When I send a GET request to "/accounts/test1/engines/tauri/app1/darwin/x86_64/1.0.0"
+    When I send a GET request to "/accounts/test1/engines/tauri/app1?platform=darwin&arch=x86_64&version=1.0.0"
     Then the response status should be "204"
 
   Scenario: License retrieves an upgrade that has entitlement constraints (no entitlements)
@@ -232,7 +232,7 @@ Feature: Tauri upgrade package
     And the current account has 1 "license" for the last "policy"
     And I am a license of account "test1"
     And I authenticate with my key
-    When I send a GET request to "/accounts/test1/engines/tauri/app1/darwin/x86_64/1.0.0"
+    When I send a GET request to "/accounts/test1/engines/tauri/app1?platform=darwin&arch=x86_64&version=1.0.0"
     Then the response status should be "403"
 
   Scenario: License retrieves an upgrade that has entitlement constraints (has entitlements)
@@ -258,7 +258,7 @@ Feature: Tauri upgrade package
       """
     And I am a license of account "test1"
     And I authenticate with my key
-    When I send a GET request to "/accounts/test1/engines/tauri/app1/darwin/x86_64/1.0.0"
+    When I send a GET request to "/accounts/test1/engines/tauri/app1?platform=darwin&arch=x86_64&version=1.0.0"
     Then the response status should be "200"
     And the response body should include the following:
       """
@@ -276,7 +276,7 @@ Feature: Tauri upgrade package
     And the last "license" belongs to the last "user"
     And I am a user of account "test1"
     And I use an authentication token
-    When I send a GET request to "/accounts/test1/engines/tauri/app1/darwin/x86_64/1.0.0"
+    When I send a GET request to "/accounts/test1/engines/tauri/app1?platform=darwin&arch=x86_64&version=1.0.0"
     Then the response status should be "200"
     And the response body should include the following:
       """
@@ -292,7 +292,7 @@ Feature: Tauri upgrade package
       """
       { "distributionStrategy": "LICENSED" }
       """
-    When I send a GET request to "/accounts/test1/engines/tauri/app1/darwin/x86_64/1.0.0"
+    When I send a GET request to "/accounts/test1/engines/tauri/app1?platform=darwin&arch=x86_64&version=1.0.0"
     Then the response status should be "404"
 
   Scenario: Anonymous retrieves an upgrade for a closed product
@@ -300,7 +300,7 @@ Feature: Tauri upgrade package
       """
       { "distributionStrategy": "CLOSED" }
       """
-    When I send a GET request to "/accounts/test1/engines/tauri/app1/darwin/x86_64/1.0.0"
+    When I send a GET request to "/accounts/test1/engines/tauri/app1?platform=darwin&arch=x86_64&version=1.0.0"
     Then the response status should be "404"
 
   Scenario: Anonymous retrieves an upgrade for an open product
@@ -308,7 +308,7 @@ Feature: Tauri upgrade package
       """
       { "distributionStrategy": "OPEN" }
       """
-    When I send a GET request to "/accounts/test1/engines/tauri/app1/darwin/x86_64/1.0.0"
+    When I send a GET request to "/accounts/test1/engines/tauri/app1?platform=darwin&arch=x86_64&version=1.0.0"
     Then the response status should be "200"
     And the response body should include the following:
       """

--- a/features/api/v1/engines/tauri/upgrade.feature
+++ b/features/api/v1/engines/tauri/upgrade.feature
@@ -103,19 +103,28 @@ Feature: Tauri upgrade package
       """
 
   Scenario: Endpoint should not return an upgrade when an upgrade is not available
-    Given I am an admin of account "test1"
+    Given the current account has 1 "webhook-endpoint"
+    And I am an admin of account "test1"
     And I use an authentication token
     When I send a GET request to "/accounts/test1/engines/tauri/app1?platform=linux&arch=x86_64&version=1.1.0"
     Then the response status should be "204"
+    And sidekiq should have 0 "webhook" jobs
+    And sidekiq should have 0 "metric" jobs
+    And sidekiq should have 1 "request-log" job
 
   Scenario: Endpoint should not return an upgrade when a version does not exist
-    Given I am an admin of account "test1"
+    Given the current account has 1 "webhook-endpoint"
+    And I am an admin of account "test1"
     And I use an authentication token
     When I send a GET request to "/accounts/test1/engines/tauri/app1?platform=linux&arch=x86_64&version=3.0.0"
     Then the response status should be "204"
+    And sidekiq should have 0 "webhook" jobs
+    And sidekiq should have 0 "metric" jobs
+    And sidekiq should have 1 "request-log" job
 
   Scenario: Endpoint should return an upgrade when an upgrade is available
-    Given I am an admin of account "test1"
+    Given the current account has 1 "webhook-endpoint"
+    And I am an admin of account "test1"
     And I use an authentication token
     When I send a GET request to "/accounts/test1/engines/tauri/app1?platform=linux&arch=x86_64&version=1.0.0"
     Then the response status should be "200"
@@ -127,6 +136,9 @@ Feature: Tauri upgrade package
         "version": "1.1.0"
       }
       """
+    And sidekiq should have 1 "webhook" job
+    And sidekiq should have 1 "metric" job
+    And sidekiq should have 1 "request-log" job
 
   Scenario: Endpoint should prefer NSIS over MSI for windows
     Given I am an admin of account "test1"

--- a/features/api/v1/engines/tauri/upgrade.feature
+++ b/features/api/v1/engines/tauri/upgrade.feature
@@ -16,12 +16,12 @@ Feature: Tauri upgrade package
       | 7b113ac2-ae81-406a-b44e-f356126e2faa | 6198261a-48b5-4445-a045-9fed4afc7735 | pypi   | pkg1 |
       | 5666d47e-936e-4d48-8dd7-382d32462b4e | 6198261a-48b5-4445-a045-9fed4afc7735 |        | pkg2 |
     And the current account has the following "release" rows:
-      | id                                   | product_id                           | release_package_id                   | version      | channel  | description | created_at               |
-      | 757e0a41-835e-42ad-bad8-84cabd29c72a | 6198261a-48b5-4445-a045-9fed4afc7735 | 46e034fe-2312-40f8-bbeb-7d9957fb6fcf | 1.0.0        | stable   | foo         | 2023-08-15T16:10:09.000Z |
-      | 028a38a2-0d17-4871-acb8-c5e6f040fc12 | 6198261a-48b5-4445-a045-9fed4afc7735 | 46e034fe-2312-40f8-bbeb-7d9957fb6fcf | 1.1.0        | stable   | bar         | 2023-08-15T16:10:09.000Z |
-      | 2bbb14ae-bb6b-4c57-b6ab-26f7982c967d | 6198261a-48b5-4445-a045-9fed4afc7735 | 46e034fe-2312-40f8-bbeb-7d9957fb6fcf | 1.2.0-beta-1 | beta     |             | 2023-08-15T16:10:09.000Z |
-      | c77ba874-de62-4a17-8368-fc10db1e1c80 | 6198261a-48b5-4445-a045-9fed4afc7735 | 2f8af04a-2424-4ca2-8480-6efe24318d1a | 1.0.0-beta.1 | beta     | baz         | 2023-08-15T16:10:09.000Z |
-      | 972aa5b8-b12c-49f4-8ba4-7c9ae053dfa2 | 6198261a-48b5-4445-a045-9fed4afc7735 | 2f8af04a-2424-4ca2-8480-6efe24318d1a | 2.0.0-beta.1 | beta     | qux         | 2023-08-15T16:10:09.000Z |
+      | id                                   | product_id                           | release_package_id                   | version      | channel  | description |
+      | 757e0a41-835e-42ad-bad8-84cabd29c72a | 6198261a-48b5-4445-a045-9fed4afc7735 | 46e034fe-2312-40f8-bbeb-7d9957fb6fcf | 1.0.0        | stable   | foo         |
+      | 028a38a2-0d17-4871-acb8-c5e6f040fc12 | 6198261a-48b5-4445-a045-9fed4afc7735 | 46e034fe-2312-40f8-bbeb-7d9957fb6fcf | 1.1.0        | stable   | bar         |
+      | 2bbb14ae-bb6b-4c57-b6ab-26f7982c967d | 6198261a-48b5-4445-a045-9fed4afc7735 | 46e034fe-2312-40f8-bbeb-7d9957fb6fcf | 1.2.0-beta-1 | beta     |             |
+      | c77ba874-de62-4a17-8368-fc10db1e1c80 | 6198261a-48b5-4445-a045-9fed4afc7735 | 2f8af04a-2424-4ca2-8480-6efe24318d1a | 1.0.0-beta.1 | beta     | baz         |
+      | 972aa5b8-b12c-49f4-8ba4-7c9ae053dfa2 | 6198261a-48b5-4445-a045-9fed4afc7735 | 2f8af04a-2424-4ca2-8480-6efe24318d1a | 2.0.0-beta.1 | beta     | qux         |
     And the current account has the following "artifact" rows:
       | id                                   | release_id                           | filename                  | filetype | platform | arch   | signature                                                                                |
       # 1.0.0
@@ -145,13 +145,17 @@ Feature: Tauri upgrade package
       """
 
   Scenario: Endpoint should include publish date when available
-    Given I am an admin of account "test1"
+    Given the second "release" has the following attributes:
+      """
+      { "createdAt": "2023-08-15T00:00:00.000Z" }
+      """
+    And I am an admin of account "test1"
     And I use an authentication token
     When I send a GET request to "/accounts/test1/engines/tauri/app1/darwin/x86_64/1.0.0"
     Then the response status should be "200"
     And the response body should include the following:
       """
-      { "pub_date": "2023-08-15T16:10:09.000Z" }
+      { "pub_date": "2023-08-15T00:00:00.000Z" }
       """
 
   Scenario: Endpoint should return error for non-Tauri packages

--- a/features/step_definitions/before_after_steps.rb
+++ b/features/step_definitions/before_after_steps.rb
@@ -81,6 +81,15 @@ After do |scenario|
       },
       debug: {
         env_number: ENV['TEST_ENV_NUMBER'].to_i,
+        query_log: File.open(Rails.root / 'log' / 'test.log') do |log|
+          line_count = ENV.fetch('TEST_DEBUG_QUERY_LOG_LINE_COUNT') { 5 }.to_i
+
+          log.readlines.select { _1 =~ /application:Keygen,pid:#{Process.pid}/ }
+                       .last(line_count)
+                       .map(&:squish)
+        rescue
+          []
+        end
       },
     )
   end

--- a/features/step_definitions/before_after_steps.rb
+++ b/features/step_definitions/before_after_steps.rb
@@ -81,14 +81,21 @@ After do |scenario|
       },
       debug: {
         env_number: ENV['TEST_ENV_NUMBER'].to_i,
-        query_log: File.open(Rails.root / 'log' / 'test.log') do |log|
-          line_count = ENV.fetch('TEST_DEBUG_QUERY_LOG_LINE_COUNT') { 5 }.to_i
+        query_log: Elif.open(Rails.root / 'log' / 'test.log') do |log|
+          count = ENV.fetch('TEST_DEBUG_QUERY_LOG_LINE_COUNT') { 5 }.to_i
+          lines = []
 
-          log.readlines.select { _1 =~ /application:Keygen,pid:#{Process.pid}/ }
-                       .last(line_count)
-                       .map(&:squish)
+          log.each do |line|
+            break if lines.count >= count
+
+            if line =~ /application:Keygen,pid:#{Process.pid}/
+              lines << line.squish
+            end
+          end
+
+          lines
         rescue
-          []
+          lines
         end
       },
     )

--- a/features/step_definitions/before_after_steps.rb
+++ b/features/step_definitions/before_after_steps.rb
@@ -85,6 +85,7 @@ After do |scenario|
           count = ENV.fetch('TEST_DEBUG_QUERY_LOG_LINE_COUNT') { 5 }.to_i
           lines = []
 
+          # Read the last n SQL lines from the log file (useful when debugging CI)
           log.each do |line|
             break if lines.count >= count
 

--- a/lib/keygen/console.rb
+++ b/lib/keygen/console.rb
@@ -86,14 +86,14 @@ module Keygen
           puts
         end
       end
-
-      # This will raise if either the license or license file are expired
-      # and past the expiry grace period, or otherwise tampered with.
-      #
-      # FIXME(ezekg) Eventually move this out into a boot/lifecycle
-      #              system on the Keygen module?
-      def err! = Keygen.ee { |key, lic| key.valid? && lic.valid? }
     end
+
+    # This will raise if either the license or license file are expired
+    # and past the expiry grace period, or otherwise tampered with.
+    #
+    # FIXME(ezekg) Eventually move this out into a boot/lifecycle
+    #              system on the Keygen module?
+    def err! = Keygen.ee { |key, lic| key.valid? && lic.valid? }
 
     private
 

--- a/spec/factories/release.rb
+++ b/spec/factories/release.rb
@@ -26,7 +26,7 @@ FactoryBot.define do
 
       # Make sure channel matches semver prerelease channel
       if (semver = Semverse::Version.coerce(release.version)).pre_release?
-        key = semver.pre_release[/([^\.]+)/, 1]
+        key = semver.pre_release[/([^-\.]+)/, 1]
 
         release.channel.assign_attributes(
           name: key.capitalize,
@@ -54,6 +54,30 @@ FactoryBot.define do
 
     trait :pypi do
       package { build(:package, :pypi, account:, product:, environment:) }
+    end
+
+    trait :tauri do
+      package { build(:package, :tauri, account:, product:, environment:) }
+    end
+
+    trait :stable do
+      channel { build(:channel, :beta, account:) }
+    end
+
+    trait :rc do
+      channel { build(:channel, :rc, account:) }
+    end
+
+    trait :beta do
+      channel { build(:channel, :beta, account:) }
+    end
+
+    trait :alpha do
+      channel { build(:channel, :alpha, account:) }
+    end
+
+    trait :dev do
+      channel { build(:channel, :dev, account:) }
     end
 
     trait :licensed do

--- a/spec/factories/release_channel.rb
+++ b/spec/factories/release_channel.rb
@@ -2,10 +2,30 @@
 
 FactoryBot.define do
   factory :release_channel, aliases: %i[channel] do
-    initialize_with { new(**attributes) }
+    initialize_with { ReleaseChannel.find_by(key:) || new(**attributes) }
 
     sequence :key, %w[stable rc beta alpha dev].cycle
 
     account { nil }
+
+    trait :stable do
+      key { 'stable' }
+    end
+
+    trait :rc do
+      key { 'rc' }
+    end
+
+    trait :beta do
+      key { 'beta' }
+    end
+
+    trait :alpha do
+      key { 'alpha' }
+    end
+
+    trait :dev do
+      key { 'dev' }
+    end
   end
 end

--- a/spec/factories/release_engine.rb
+++ b/spec/factories/release_engine.rb
@@ -4,13 +4,18 @@ FactoryBot.define do
   factory :release_engine, aliases: %i[engine] do
     initialize_with { new(**attributes) }
 
-    sequence :key, %w[pypi].cycle
+    sequence :key, %w[pypi tauri].cycle
 
     account { nil }
 
     trait :pypi do
       name { 'PyPI' }
       key  { 'pypi' }
+    end
+
+    trait :tauri do
+      name { 'Tauri' }
+      key  { 'tairi' }
     end
   end
 end

--- a/spec/factories/release_package.rb
+++ b/spec/factories/release_package.rb
@@ -16,6 +16,10 @@ FactoryBot.define do
       engine { build(:engine, :pypi, account:) }
     end
 
+    trait :tauri do
+      engine { build(:engine, :tauri, account:) }
+    end
+
     trait :licensed do
       product { build(:product, :licensed, account:, environment:) }
     end

--- a/spec/models/release_spec.rb
+++ b/spec/models/release_spec.rb
@@ -125,6 +125,22 @@ describe Release, type: :model do
     end
   end
 
+  describe '#channel=' do
+    context 'channel does not exist' do
+      it 'should create channel' do
+        expect { create(:release, :beta, account:) }.to change { account.release_channels.count }
+      end
+    end
+
+    context 'channel does exist' do
+      before { create(:channel, :beta, account:) }
+
+      it 'should not create channel' do
+        expect { create(:release, :beta, account:) }.to_not change { account.release_channels.count }
+      end
+    end
+  end
+
   describe '.without_constraints' do
     let(:releases) { described_class.where(account:) }
 


### PR DESCRIPTION
Related to #493. Adds support for Tauri's auto-updater via a new `tauri` engine.