### PR TITLE
Add machine components

### DIFF
--- a/app/controllers/api/v1/licenses/actions/validations_controller.rb
+++ b/app/controllers/api/v1/licenses/actions/validations_controller.rb
@@ -44,6 +44,9 @@ module Api::V1::Licenses::Actions
           param :fingerprints, type: :array, optional: true do
             items type: :string
           end
+          param :components, type: :array, optional: true do
+            items type: :string
+          end
           param :entitlements, type: :array, optional: true do
             items type: :string
           end
@@ -110,6 +113,9 @@ module Api::V1::Licenses::Actions
           param :machine, type: :string, optional: true
           param :fingerprint, type: :string, optional: true
           param :fingerprints, type: :array, optional: true do
+            items type: :string
+          end
+          param :components, type: :array, optional: true do
             items type: :string
           end
           param :entitlements, type: :array, optional: true do

--- a/app/controllers/api/v1/machine_components/relationships/licenses_controller.rb
+++ b/app/controllers/api/v1/machine_components/relationships/licenses_controller.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Api::V1::MachineComponents::Relationships
+  class LicensesController < Api::V1::BaseController
+    before_action :scope_to_current_account!
+    before_action :require_active_subscription!
+    before_action :authenticate_with_token!
+    before_action :set_machine_component
+
+    authorize :machine_component
+
+    def show
+      license = machine_component.license
+      authorize! license,
+        with: MachineComponents::LicensePolicy
+
+      render jsonapi: license
+    end
+
+    private
+
+    attr_reader :machine_component
+
+    def set_machine_component
+      scoped_machine_components = authorized_scope(current_account.machine_components)
+
+      @machine_component = scoped_machine_components.find(params[:machine_component_id])
+
+      Current.resource = machine_component
+    end
+  end
+end

--- a/app/controllers/api/v1/machine_components/relationships/machines_controller.rb
+++ b/app/controllers/api/v1/machine_components/relationships/machines_controller.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Api::V1::MachineComponents::Relationships
+  class MachinesController < Api::V1::BaseController
+    before_action :scope_to_current_account!
+    before_action :require_active_subscription!
+    before_action :authenticate_with_token!
+    before_action :set_machine_component
+
+    authorize :machine_component
+
+    def show
+      machine = machine_component.machine
+      authorize! machine,
+        with: MachineComponents::MachinePolicy
+
+      render jsonapi: machine
+    end
+
+    private
+
+    attr_reader :machine_component
+
+    def set_machine_component
+      scoped_machine_components = authorized_scope(current_account.machine_components)
+
+      @machine_component = scoped_machine_components.find(params[:machine_component_id])
+
+      Current.resource = machine_component
+    end
+  end
+end

--- a/app/controllers/api/v1/machine_components/relationships/products_controller.rb
+++ b/app/controllers/api/v1/machine_components/relationships/products_controller.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Api::V1::MachineComponents::Relationships
+  class ProductsController < Api::V1::BaseController
+    before_action :scope_to_current_account!
+    before_action :require_active_subscription!
+    before_action :authenticate_with_token!
+    before_action :set_machine_component
+
+    authorize :machine_component
+
+    def show
+      product = machine_component.product
+      authorize! product,
+        with: MachineComponents::ProductPolicy
+
+      render jsonapi: product
+    end
+
+    private
+
+    attr_reader :machine_component
+
+    def set_machine_component
+      scoped_machine_components = authorized_scope(current_account.machine_components)
+
+      @machine_component = scoped_machine_components.find(params[:machine_component_id])
+
+      Current.resource = machine_component
+    end
+  end
+end

--- a/app/controllers/api/v1/machine_components_controller.rb
+++ b/app/controllers/api/v1/machine_components_controller.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+module Api::V1
+  class MachineComponentsController < Api::V1::BaseController
+    has_scope(:product) { |c, s, v| s.for_product(v) }
+    has_scope(:machine) { |c, s, v| s.for_machine(v) }
+    has_scope(:license) { |c, s, v| s.for_license(v) }
+    has_scope(:user) { |c, s, v| s.for_user(v) }
+    has_scope(:status) { |c, s, v| s.with_status(v) }
+
+    before_action :scope_to_current_account!
+    before_action :require_active_subscription!
+    before_action :authenticate_with_token!
+    before_action :set_machine_component, only: %i[show update destroy]
+
+    def index
+      machine_components = apply_pagination(authorized_scope(apply_scopes(current_account.machine_components)).preload(:machine, :license, :policy, :product, :group, :user))
+      authorize! machine_components
+
+      render jsonapi: machine_components
+    end
+
+    def show
+      authorize! machine_component
+
+      render jsonapi: machine_component
+    end
+
+    typed_params {
+      format :jsonapi
+
+      param :data, type: :hash do
+        param :type, type: :string, inclusion: { in: %w[component components] }
+        param :id, type: :uuid, optional: true
+        param :attributes, type: :hash do
+          param :fingerprint, type: :string
+          param :name, type: :string
+          param :metadata, type: :metadata, allow_blank: true, optional: true
+        end
+        param :relationships, type: :hash do
+          param :machine, type: :hash do
+            param :data, type: :hash do
+              param :type, type: :string, inclusion: { in: %w[machine machines] }
+              param :id, type: :uuid
+            end
+          end
+
+          Keygen.ee do |license|
+            next unless
+              license.entitled?(:environments)
+
+            param :environment, type: :hash, optional: true do
+              param :data, type: :hash, allow_nil: true do
+                param :type, type: :string, inclusion: { in: %w[environment environments] }
+                param :id, type: :uuid
+              end
+            end
+          end
+        end
+      end
+    }
+    def create
+      machine_component = current_account.machine_components.new(machine_component_params)
+      authorize! machine_component
+
+      if machine_component.save
+        BroadcastEventService.call(
+          event: 'component.created',
+          account: current_account,
+          resource: machine_component,
+        )
+
+        render jsonapi: machine_component, status: :created, location: v1_account_machine_component_url(machine_component.account, machine_component)
+      else
+        render_uncomponentable_resource(machine_component)
+      end
+    end
+
+    typed_params {
+      format :jsonapi
+
+      param :data, type: :hash do
+        param :type, type: :string, inclusion: { in: %w[component components] }
+        param :id, type: :string, optional: true, noop: true
+        param :attributes, type: :hash do
+          param :name, type: :string, optional: true
+          param :metadata, type: :metadata, allow_blank: true, optional: true, if: -> { current_bearer&.has_role?(:admin, :developer, :sales_agent, :support_agent, :product, :environment) }
+        end
+      end
+    }
+    def update
+      authorize! machine_component
+
+      if machine_component.update(machine_component_params)
+        BroadcastEventService.call(
+          event: 'component.updated',
+          account: current_account,
+          resource: machine_component,
+        )
+
+        render jsonapi: machine_component
+      else
+        render_uncomponentable_resource(machine_component)
+      end
+    end
+
+    def destroy
+      authorize! machine_component
+
+      BroadcastEventService.call(
+        event: 'component.deleted',
+        account: current_account,
+        resource: machine_component,
+      )
+
+      machine_component.destroy
+    end
+
+    private
+
+    attr_reader :machine_component
+
+    def set_machine_component
+      scoped_components = authorized_scope(current_account.machine_components)
+
+      @machine_component = scoped_components.find(params[:id])
+
+      Current.resource = machine_component
+    end
+  end
+end

--- a/app/controllers/api/v1/machine_components_controller.rb
+++ b/app/controllers/api/v1/machine_components_controller.rb
@@ -6,7 +6,6 @@ module Api::V1
     has_scope(:machine) { |c, s, v| s.for_machine(v) }
     has_scope(:license) { |c, s, v| s.for_license(v) }
     has_scope(:user) { |c, s, v| s.for_user(v) }
-    has_scope(:status) { |c, s, v| s.with_status(v) }
 
     before_action :scope_to_current_account!
     before_action :require_active_subscription!

--- a/app/controllers/api/v1/machine_components_controller.rb
+++ b/app/controllers/api/v1/machine_components_controller.rb
@@ -31,7 +31,6 @@ module Api::V1
 
       param :data, type: :hash do
         param :type, type: :string, inclusion: { in: %w[component components] }
-        param :id, type: :uuid, optional: true
         param :attributes, type: :hash do
           param :fingerprint, type: :string
           param :name, type: :string
@@ -72,7 +71,7 @@ module Api::V1
 
         render jsonapi: machine_component, status: :created, location: v1_account_machine_component_url(machine_component.account, machine_component)
       else
-        render_uncomponentable_resource(machine_component)
+        render_unprocessable_resource(machine_component)
       end
     end
 
@@ -100,7 +99,7 @@ module Api::V1
 
         render jsonapi: machine_component
       else
-        render_uncomponentable_resource(machine_component)
+        render_unprocessable_resource(machine_component)
       end
     end
 

--- a/app/controllers/api/v1/machines/actions/checkouts_controller.rb
+++ b/app/controllers/api/v1/machines/actions/checkouts_controller.rb
@@ -73,7 +73,9 @@ module Api::V1::Machines::Actions
     attr_reader :machine
 
     def set_machine
-      scoped_machines = authorized_scope(current_account.machines)
+      scoped_machines = authorized_scope(current_account.machines).preload(
+        components: %i[product license],
+      )
 
       @machine = FindByAliasService.call(scoped_machines, id: params[:id], aliases: :fingerprint)
 

--- a/app/controllers/api/v1/machines/relationships/machine_components_controller.rb
+++ b/app/controllers/api/v1/machines/relationships/machine_components_controller.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Api::V1::Machines::Relationships
+  class MachineComponentsController < Api::V1::BaseController
+    has_scope(:status) { |c, s, v| s.with_status(v) }
+
+    before_action :scope_to_current_account!
+    before_action :require_active_subscription!
+    before_action :authenticate_with_token!
+    before_action :set_machine
+
+    authorize :machine
+
+    def index
+      machine_components = apply_pagination(authorized_scope(apply_scopes(machine.components)).preload(:machine, :license, :policy, :product, :group))
+      authorize! machine_components,
+        with: Machines::MachineComponentPolicy
+
+      render jsonapi: machine_components
+    end
+
+    def show
+      machine_component = machine.components.find(params[:id])
+      authorize! machine_component,
+        with: Machines::MachineComponentPolicy
+
+      render jsonapi: machine_component
+    end
+
+    private
+
+    attr_reader :machine
+
+    def set_machine
+      scoped_machines = authorized_scope(current_account.machines)
+
+      @machine = FindByAliasService.call(scoped_machines, id: params[:machine_id], aliases: :fingerprint)
+
+      Current.resource = machine
+    end
+  end
+end

--- a/app/controllers/api/v1/policies_controller.rb
+++ b/app/controllers/api/v1/policies_controller.rb
@@ -53,6 +53,7 @@ module Api::V1
           param :require_policy_scope, type: :boolean, optional: true
           param :require_machine_scope, type: :boolean, optional: true
           param :require_fingerprint_scope, type: :boolean, optional: true
+          param :require_components_scope, type: :boolean, optional: true
           param :require_user_scope, type: :boolean, optional: true
           param :require_checksum_scope, type: :boolean, optional: true
           param :require_version_scope, type: :boolean, optional: true
@@ -134,6 +135,7 @@ module Api::V1
           param :require_policy_scope, type: :boolean, optional: true
           param :require_machine_scope, type: :boolean, optional: true
           param :require_fingerprint_scope, type: :boolean, optional: true
+          param :require_components_scope, type: :boolean, optional: true
           param :require_user_scope, type: :boolean, optional: true
           param :require_checksum_scope, type: :boolean, optional: true
           param :require_version_scope, type: :boolean, optional: true

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -24,6 +24,7 @@ class Account < ApplicationRecord
   has_many :keys
   has_many :licenses
   has_many :machines
+  has_many :machine_components
   has_many :machine_processes
   has_many :entitlements
   has_many :policy_entitlements

--- a/app/models/license.rb
+++ b/app/models/license.rb
@@ -21,6 +21,7 @@ class License < ApplicationRecord
   has_many :policy_entitlements, through: :policy
   has_many :tokens, as: :bearer, dependent: :destroy_async
   has_many :machines, dependent: :destroy_async
+  has_many :components, through: :machines
   has_many :processes, through: :machines
   has_many :releases, -> l { distinct.reorder(created_at: DEFAULT_SORT_ORDER) },
     through: :product

--- a/app/models/machine_component.rb
+++ b/app/models/machine_component.rb
@@ -8,6 +8,8 @@ class MachineComponent < ApplicationRecord
 
   belongs_to :account
   belongs_to :machine
+  has_one :group,
+    through: :machine
   has_one :license,
     through: :machine
   has_one :product,

--- a/app/models/machine_component.rb
+++ b/app/models/machine_component.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+class MachineComponent < ApplicationRecord
+  include Environmental
+  include Limitable
+  include Orderable
+  include Pageable
+
+  belongs_to :account
+  belongs_to :machine
+  has_one :license,
+    through: :machine
+  has_one :product,
+    through: :license
+  has_one :policy,
+    through: :license
+  has_one :user,
+    through: :license
+
+  has_environment default: -> { machine&.environment_id }
+
+  validates :machine,
+    scope: { by: :account_id }
+
+  validates :fingerprint,
+    uniqueness: { message: 'has already been taken', scope: %i[machine_id] },
+    exclusion: { in: EXCLUDED_ALIASES, message: 'is reserved' },
+    presence: true
+
+  validates :name,
+    presence: true
+
+  # Fingerprint uniqueness on create
+  validate on: :create do |component|
+    case
+    when uniq_per_account?
+      errors.add :fingerprint, :taken, message: "has already been taken for this account" if account.machine_components.exists?(fingerprint:)
+    when uniq_per_product?
+      errors.add :fingerprint, :taken, message: "has already been taken for this product" if account.machine_components.joins(:product).exists?(fingerprint:, products: { id: product.id })
+    when uniq_per_policy?
+      errors.add :fingerprint, :taken, message: "has already been taken for this policy" if account.machine_components.joins(:policy).exists?(fingerprint:, policies: { id: policy.id })
+    when uniq_per_license?
+      errors.add :fingerprint, :taken, message: "has already been taken for this license" if license.components.exists?(fingerprint:)
+    when uniq_per_machine?
+      errors.add :fingerprint, :taken, message: "has already been taken" if machine.components.exists?(fingerprint:)
+    end
+  end
+
+  scope :for_product, -> id { joins(:product).where(product: { id: }) }
+  scope :for_license, -> id { joins(:license).where(license: { id: }) }
+  scope :for_machine, -> id { joins(:machine).where(machine: { id: }) }
+  scope :for_user,    -> id { joins(:user).where(user: { id: }) }
+
+  scope :with_fingerprint, -> fingerprint { where(fingerprint:) }
+
+  delegate :uniq_per_account?, :uniq_per_product?, :uniq_per_policy?, :uniq_per_license?, :uniq_per_machine?,
+    allow_nil: true,
+    to: :machine
+end

--- a/app/models/permission.rb
+++ b/app/models/permission.rb
@@ -33,6 +33,11 @@ class Permission < ApplicationRecord
     artifact.read
     artifact.update
 
+    component.create
+    component.delete
+    component.read
+    component.update
+
     channel.read
 
     constraint.read
@@ -184,6 +189,11 @@ class Permission < ApplicationRecord
     artifact.delete
     artifact.read
     artifact.update
+
+    component.create
+    component.delete
+    component.read
+    component.update
 
     channel.read
 
@@ -338,6 +348,8 @@ class Permission < ApplicationRecord
 
     artifact.read
 
+    component.read
+
     channel.read
 
     constraint.read
@@ -403,6 +415,11 @@ class Permission < ApplicationRecord
     artifact.delete
     artifact.read
     artifact.update
+
+    component.create
+    component.delete
+    component.read
+    component.update
 
     channel.read
 
@@ -524,6 +541,11 @@ class Permission < ApplicationRecord
 
     artifact.read
 
+    component.create
+    component.delete
+    component.read
+    component.update
+
     channel.read
 
     constraint.read
@@ -597,6 +619,11 @@ class Permission < ApplicationRecord
     arch.read
 
     artifact.read
+
+    component.create
+    component.delete
+    component.read
+    component.update
 
     channel.read
 

--- a/app/models/policy.rb
+++ b/app/models/policy.rb
@@ -34,7 +34,7 @@ class Policy < ApplicationRecord
     UNIQUE_PER_PRODUCT: 3,
     UNIQUE_PER_POLICY:  2,
     UNIQUE_PER_LICENSE: 1,
-    UNIQUE_PER_LICENSE: 0,
+    UNIQUE_PER_MACHINE: 0,
   }.with_indifferent_access
    .freeze
 

--- a/app/models/policy.rb
+++ b/app/models/policy.rb
@@ -26,18 +26,21 @@ class Policy < ApplicationRecord
     UNIQUE_PER_PRODUCT
     UNIQUE_PER_POLICY
     UNIQUE_PER_LICENSE
+    UNIQUE_PER_MACHINE
   ].freeze
 
   FINGERPRINT_UNIQUENESS_RANKS = {
-    UNIQUE_PER_ACCOUNT: 3,
-    UNIQUE_PER_PRODUCT: 2,
-    UNIQUE_PER_POLICY:  1,
+    UNIQUE_PER_ACCOUNT: 4,
+    UNIQUE_PER_PRODUCT: 3,
+    UNIQUE_PER_POLICY:  2,
+    UNIQUE_PER_LICENSE: 1,
     UNIQUE_PER_LICENSE: 0,
   }.with_indifferent_access
    .freeze
 
   FINGERPRINT_MATCHING_STRATEGIES = %w[
     MATCH_ANY
+    MATCH_TWO
     MATCH_MOST
     MATCH_ALL
   ].freeze
@@ -427,6 +430,10 @@ class Policy < ApplicationRecord
     fingerprint_uniqueness_strategy == 'UNIQUE_PER_LICENSE'
   end
 
+  def fingerprint_uniq_per_machine?
+    fingerprint_uniqueness_strategy == 'UNIQUE_PER_MACHINE'
+  end
+
   def fingerprint_uniq_rank
     FINGERPRINT_UNIQUENESS_RANKS.fetch(fingerprint_uniqueness_strategy) { -1 }
   end
@@ -435,6 +442,10 @@ class Policy < ApplicationRecord
     return true if fingerprint_matching_strategy.nil? # NOTE(ezekg) Backwards compat
 
     fingerprint_matching_strategy == 'MATCH_ANY'
+  end
+
+  def fingerprint_match_two?
+    fingerprint_matching_strategy == 'MATCH_TWO'
   end
 
   def fingerprint_match_most?

--- a/app/policies/machine_component_policy.rb
+++ b/app/policies/machine_component_policy.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+class MachineComponentPolicy < ApplicationPolicy
+  def index?
+    verify_permissions!('component.read')
+    verify_environment!(
+      strict: false,
+    )
+
+    case bearer
+    in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
+      allow!
+    in role: Role(:product) if record.all? { _1.product == bearer }
+      allow!
+    in role: Role(:user) if record.all? { _1.user == bearer }
+      allow!
+    in role: Role(:license) if record.all? { _1.license == bearer }
+      allow!
+    else
+      deny!
+    end
+  end
+
+  def show?
+    verify_permissions!('component.read')
+    verify_environment!(
+      strict: false,
+    )
+
+    case bearer
+    in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
+      allow!
+    in role: Role(:product) if record.product == bearer
+      allow!
+    in role: Role(:user) if record.user == bearer
+      allow!
+    in role: Role(:license) if record.license == bearer
+      allow!
+    else
+      deny!
+    end
+  end
+
+  def create?
+    verify_permissions!('component.create')
+    verify_environment!
+
+    case bearer
+    in role: Role(:admin | :developer | :sales_agent | :environment)
+      allow!
+    in role: Role(:product) if record.product == bearer
+      allow!
+    in role: Role(:user) if record.user == bearer
+      !record.license&.protected?
+    in role: Role(:license) if record.license == bearer
+      allow!
+    else
+      deny!
+    end
+  end
+
+  def update?
+    verify_permissions!('component.update')
+    verify_environment!
+
+    case bearer
+    in role: Role(:admin | :developer | :sales_agent | :support_agent | :environment)
+      allow!
+    in role: Role(:product) if record.product == bearer
+      allow!
+    in role: Role(:user) if record.user == bearer
+      !record.license.protected?
+    in role: Role(:license) if record.license == bearer
+      allow!
+    else
+      deny!
+    end
+  end
+
+  def destroy?
+    verify_permissions!('component.delete')
+    verify_environment!
+
+    case bearer
+    in role: Role(:admin | :developer | :sales_agent | :environment)
+      allow!
+    in role: Role(:product) if record.product == bearer
+      allow!
+    in role: Role(:user) if record.user == bearer
+      !record.license.protected?
+    in role: Role(:license) if record.license == bearer
+      allow!
+    else
+      deny!
+    end
+  end
+end

--- a/app/policies/machine_components/license_policy.rb
+++ b/app/policies/machine_components/license_policy.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module MachineComponents
+  class LicensePolicy < ApplicationPolicy
+    authorize :machine_component
+
+    def show?
+      verify_permissions!('license.read')
+      verify_environment!(
+        strict: false,
+      )
+
+      case bearer
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
+        allow!
+      in role: Role(:product) if machine_component.product == bearer
+        allow!
+      in role: Role(:user) if machine_component.user == bearer
+        allow!
+      in role: Role(:license) if machine_component.license == bearer
+        allow!
+      else
+        deny!
+      end
+    end
+  end
+end

--- a/app/policies/machine_components/machine_policy.rb
+++ b/app/policies/machine_components/machine_policy.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module MachineComponents
+  class MachinePolicy < ApplicationPolicy
+    authorize :machine_component
+
+    def show?
+      verify_permissions!('machine.read')
+      verify_environment!(
+        strict: false,
+      )
+
+      case bearer
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
+        allow!
+      in role: Role(:product) if machine_component.product == bearer
+        allow!
+      in role: Role(:user) if machine_component.user == bearer
+        allow!
+      in role: Role(:license) if machine_component.license == bearer
+        allow!
+      else
+        deny!
+      end
+    end
+  end
+end

--- a/app/policies/machine_components/product_policy.rb
+++ b/app/policies/machine_components/product_policy.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module MachineComponents
+  class ProductPolicy < ApplicationPolicy
+    authorize :machine_component
+
+    def show?
+      verify_permissions!('product.read')
+      verify_environment!(
+        strict: false,
+      )
+
+      case bearer
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
+        allow!
+      in role: Role(:product) if machine_component.product == bearer
+        allow!
+      in role: Role(:user) if machine_component.user == bearer
+        allow!
+      in role: Role(:license) if machine_component.license == bearer
+        allow!
+      else
+        deny!
+      end
+    end
+  end
+end

--- a/app/policies/machine_file_policy.rb
+++ b/app/policies/machine_file_policy.rb
@@ -34,6 +34,7 @@ class MachineFilePolicy < ApplicationPolicy
     perms << 'policy.read'      if record.includes.include?('license.policy')
     perms << 'environment.read' if record.includes.include?('environment')
     perms << 'license.read'     if record.includes.include?('license')
+    perms << 'component.read'   if record.includes.include?('components')
     perms << 'group.read'       if record.includes.include?('group')
 
     perms

--- a/app/policies/machines/machine_component_policy.rb
+++ b/app/policies/machines/machine_component_policy.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Machines
+  class MachineComponentPolicy < ApplicationPolicy
+    authorize :machine
+
+    def index?
+      verify_permissions!('component.read')
+      verify_environment!(
+        strict: false,
+      )
+
+      case bearer
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
+        allow!
+      in role: Role(:product) if machine.product == bearer
+        allow!
+      in role: Role(:user) if machine.user == bearer
+        allow!
+      in role: Role(:license) if machine.license == bearer
+        allow!
+      else
+        deny!
+      end
+    end
+
+    def show?
+      verify_permissions!('component.read')
+      verify_environment!(
+        strict: false,
+      )
+
+      case bearer
+      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
+        allow!
+      in role: Role(:product) if machine.product == bearer
+        allow!
+      in role: Role(:user) if machine.user == bearer
+        allow!
+      in role: Role(:license) if machine.license == bearer
+        allow!
+      else
+        deny!
+      end
+    end
+  end
+end

--- a/app/serializers/machine_component_serializer.rb
+++ b/app/serializers/machine_component_serializer.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+class MachineComponentSerializer < BaseSerializer
+  type 'components'
+
+  attribute :fingerprint
+  attribute :name
+  attribute :created do
+    @object.created_at
+  end
+  attribute :updated do
+    @object.updated_at
+  end
+  attribute :metadata do
+    @object.metadata&.transform_keys { |k| k.to_s.camelize :lower } or {}
+  end
+
+  relationship :account do
+    linkage always: true do
+      { type: :accounts, id: @object.account_id }
+    end
+    link :related do
+      @url_helpers.v1_account_path @object.account_id
+    end
+  end
+
+  ee do
+    relationship :environment do
+      linkage always: true do
+        if @object.environment_id.present?
+          { type: :environments, id: @object.environment_id }
+        else
+          nil
+        end
+      end
+      link :related do
+        if @object.environment_id.present?
+          @url_helpers.v1_account_environment_path @object.account_id, @object.environment_id
+        else
+          nil
+        end
+      end
+    end
+  end
+
+  relationship :machine do
+    linkage always: true do
+      { type: :machines, id: @object.machine_id }
+    end
+    link :related do
+      @url_helpers.v1_account_machine_component_machine_path @object.account_id, @object
+    end
+  end
+
+  link :self do
+    @url_helpers.v1_account_machine_component_path @object.account_id, @object
+  end
+end

--- a/app/serializers/machine_component_serializer.rb
+++ b/app/serializers/machine_component_serializer.rb
@@ -43,6 +43,24 @@ class MachineComponentSerializer < BaseSerializer
     end
   end
 
+  relationship :product do
+    linkage always: true do
+      { type: :products, id: @object.product&.id }
+    end
+    link :related do
+      @url_helpers.v1_account_machine_component_product_path @object.account_id, @object
+    end
+  end
+
+  relationship :license do
+    linkage always: true do
+      { type: :licenses, id: @object.license&.id }
+    end
+    link :related do
+      @url_helpers.v1_account_machine_component_license_path @object.account_id, @object
+    end
+  end
+
   relationship :machine do
     linkage always: true do
       { type: :machines, id: @object.machine_id }

--- a/app/serializers/machine_serializer.rb
+++ b/app/serializers/machine_serializer.rb
@@ -106,6 +106,12 @@ class MachineSerializer < BaseSerializer
     end
   end
 
+  relationship :components do
+    link :related do
+      @url_helpers.v1_account_machine_machine_components_path @object.account_id, @object
+    end
+  end
+
   relationship :processes do
     link :related do
       @url_helpers.v1_account_machine_machine_processes_path @object.account_id, @object

--- a/app/serializers/policy_serializer.rb
+++ b/app/serializers/policy_serializer.rb
@@ -27,6 +27,7 @@ class PolicySerializer < BaseSerializer
   attribute :require_policy_scope
   attribute :require_machine_scope
   attribute :require_fingerprint_scope
+  attribute :require_components_scope
   attribute :require_user_scope
   attribute :require_checksum_scope
   attribute :require_version_scope

--- a/app/services/license_validation_service.rb
+++ b/app/services/license_validation_service.rb
@@ -144,7 +144,7 @@ class LicenseValidationService < BaseService
             return [false, "one or more fingerprint is not activated (does not match enough associated machines)", :FINGERPRINT_SCOPE_MISMATCH] if
               machines.count < (fingerprints.size / 2.0).ceil
           when fingerprints.size > 1 && license.policy.fingerprint_match_two?
-            return [false, "one or more fingerprint is not activated (does not match 2 associated machines)", :FINGERPRINT_SCOPE_MISMATCH] if
+            return [false, "one or more fingerprint is not activated (does not match at least 2 associated machines)", :FINGERPRINT_SCOPE_MISMATCH] if
               machines.count < 2
           when fingerprints.size > 1 && license.policy.fingerprint_match_all?
             return [false, "one or more fingerprint is not activated (does not match all associated machines)", :FINGERPRINT_SCOPE_MISMATCH] if
@@ -189,7 +189,7 @@ class LicenseValidationService < BaseService
           return [false, "one or more component is not activated (does not match enough associated components)", :COMPONENTS_SCOPE_MISMATCH] if
             components.count < (fingerprints.size / 2.0).ceil
         when license.policy.fingerprint_match_two?
-          return [false, "one or more component is not activated (does not match 2 associated components)", :COMPONENTS_SCOPE_MISMATCH] if
+          return [false, "one or more component is not activated (does not match at least 2 associated components)", :COMPONENTS_SCOPE_MISMATCH] if
             components.count < 2
         when license.policy.fingerprint_match_all?
           return [false, "one or more component is not activated (does not match all associated components)", :COMPONENTS_SCOPE_MISMATCH] if

--- a/app/services/machine_checkout_service.rb
+++ b/app/services/machine_checkout_service.rb
@@ -12,6 +12,7 @@ class MachineCheckoutService < AbstractCheckoutService
     license.policy
     license.user
     license
+    components
     environment
     group
   ].freeze

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -130,6 +130,8 @@ Rails.application.routes.draw do
 
       resources :machine_components, path: 'components' do
         scope module: 'machine_components/relationships' do
+          resource :product, only: %i[show]
+          resource :license, only: %i[show]
           resource :machine, only: %i[show]
         end
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -103,7 +103,8 @@ Rails.application.routes.draw do
       #             their fingerprint attr, which can be an arbitrary string.
       resources :machines, constraints: { id: /[^\/]*/ } do
         scope module: 'machines/relationships' do
-          resources :machine_processes, only: %i[index show], path: 'processes'
+          resources :machine_components, only: %i[index show], path: 'components'
+          resources :machine_processes,  only: %i[index show], path: 'processes'
 
           resource :product, only: %i[show]
           resource :group,   only: %i[show update]
@@ -124,6 +125,12 @@ Rails.application.routes.draw do
               post :generate_offline_proof, path: 'generate-offline-proof', to: 'proofs#create'
             end
           end
+        end
+      end
+
+      resources :machine_components, path: 'components' do
+        scope module: 'machine_components/relationships' do
+          resource :machine, only: %i[show]
         end
       end
 

--- a/db/migrate/20230823154013_create_machine_components.rb
+++ b/db/migrate/20230823154013_create_machine_components.rb
@@ -1,0 +1,20 @@
+class CreateMachineComponents < ActiveRecord::Migration[7.0]
+  def change
+    create_table :machine_components, id: :uuid, default: -> { 'uuid_generate_v4()' } do |t|
+      t.uuid :account_id,        null: false
+      t.uuid :machine_id,        null: false
+      t.uuid :environment_id,    null: true
+
+      t.string :fingerprint, null: false
+      t.string :name,        null: false
+      t.jsonb :metadata
+
+      t.timestamps
+
+      t.index %i[account_id created_at], order: { created_at: :desc }
+      t.index %i[machine_id fingerprint], unique: true
+      t.index %i[environment_id]
+      t.index %i[fingerprint]
+    end
+  end
+end

--- a/db/migrate/20230823164814_add_require_components_scope_to_policies.rb
+++ b/db/migrate/20230823164814_add_require_components_scope_to_policies.rb
@@ -1,0 +1,5 @@
+class AddRequireComponentsScopeToPolicies < ActiveRecord::Migration[7.0]
+  def change
+    add_column :policies, :require_components_scope, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_17_204249) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_23_164814) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_stat_statements"
@@ -237,6 +237,21 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_17_204249) do
     t.index ["user_id", "created_at"], name: "index_licenses_on_user_id_and_created_at"
   end
 
+  create_table "machine_components", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
+    t.uuid "account_id", null: false
+    t.uuid "machine_id", null: false
+    t.uuid "environment_id"
+    t.string "fingerprint", null: false
+    t.string "name", null: false
+    t.jsonb "metadata"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["account_id", "created_at"], name: "index_machine_components_on_account_id_and_created_at", order: { created_at: :desc }
+    t.index ["environment_id"], name: "index_machine_components_on_environment_id"
+    t.index ["fingerprint"], name: "index_machine_components_on_fingerprint"
+    t.index ["machine_id", "fingerprint"], name: "index_machine_components_on_machine_id_and_fingerprint", unique: true
+  end
+
   create_table "machine_processes", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
     t.uuid "account_id", null: false
     t.uuid "machine_id", null: false
@@ -377,6 +392,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_17_204249) do
     t.boolean "require_environment_scope", default: false, null: false
     t.boolean "require_checksum_scope", default: false, null: false
     t.boolean "require_version_scope", default: false, null: false
+    t.boolean "require_components_scope", default: false, null: false
     t.index "to_tsvector('simple'::regconfig, COALESCE((id)::text, ''::text))", name: "policies_tsv_id_idx", using: :gist
     t.index "to_tsvector('simple'::regconfig, COALESCE((metadata)::text, ''::text))", name: "policies_tsv_metadata_idx", using: :gist
     t.index "to_tsvector('simple'::regconfig, COALESCE((name)::text, ''::text))", name: "policies_tsv_name_idx", using: :gist

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -26,6 +26,11 @@ permissions = %w[
   artifact.read
   artifact.update
 
+  component.create
+  component.delete
+  component.read
+  component.update
+
   channel.read
 
   constraint.read
@@ -183,6 +188,10 @@ events = %w[
   artifact.downloaded
   artifact.updated
   artifact.uploaded
+
+  component.created
+  component.deleted
+  component.updated
 
   entitlement.created
   entitlement.deleted

--- a/features/api/v1/components/create.feature
+++ b/features/api/v1/components/create.feature
@@ -20,8 +20,7 @@ Feature: Create machine component
     And sidekiq should have 1 "request-log" job
 
   Scenario: Admin creates a component for their account
-    Given time is frozen at "2022-10-16T14:52:48.000Z"
-    And the current account is "test1"
+    Given the current account is "test1"
     And the current account has 2 "webhook-endpoints"
     And the current account has 1 "machine"
     And I am an admin of account "test1"
@@ -72,7 +71,6 @@ Feature: Create machine component
     And sidekiq should have 2 "webhook" jobs
     And sidekiq should have 1 "metric" job
     And sidekiq should have 1 "request-log" job
-    And time is unfrozen
 
   Scenario: Developer creates a component for their account
     Given the current account is "test1"
@@ -971,8 +969,7 @@ Feature: Create machine component
 
   @ee
   Scenario: Environment creates an isolated component for their account
-    Given time is frozen at "2022-10-16T14:52:48.000Z"
-    And the current account is "test1"
+    Given the current account is "test1"
     And the current account has 1 isolated "environment"
     And the current account has 2 isolated "webhook-endpoints"
     And the current account has 1 isolated "machine"
@@ -1014,7 +1011,6 @@ Feature: Create machine component
     And sidekiq should have 2 "webhook" jobs
     And sidekiq should have 1 "metric" job
     And sidekiq should have 1 "request-log" job
-    And time is unfrozen
 
   Scenario: User creates a component for their machine
     Given the current account is "test1"

--- a/features/api/v1/components/create.feature
+++ b/features/api/v1/components/create.feature
@@ -1,0 +1,1411 @@
+@api/v1
+Feature: Create machine component
+  Background:
+    Given the following "accounts" exist:
+      | Name    | Slug  |
+      | Test 1  | test1 |
+      | Test 2  | test2 |
+    And I send and accept JSON
+
+  Scenario: Endpoint should be inaccessible when account is disabled
+    Given the account "test1" is canceled
+    And the current account is "test1"
+    And I am an admin of account "test1"
+    And I use an authentication token
+    When I send a POST request to "/accounts/test1/components"
+    Then the response status should be "403"
+    And the current account should have 0 "components"
+    And sidekiq should have 0 "webhook" jobs
+    And sidekiq should have 0 "metric" jobs
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: Admin creates a component for their account
+    Given time is frozen at "2022-10-16T14:52:48.000Z"
+    And the current account is "test1"
+    And the current account has 2 "webhook-endpoints"
+    And the current account has 1 "machine"
+    And I am an admin of account "test1"
+    And I use an authentication token
+    When I send a POST request to "/accounts/test1/components" with the following:
+      """
+      {
+        "data": {
+          "type": "components",
+          "attributes": {
+            "fingerprint": "0af831cd3c2f494aa8311ab13f2b6ec1",
+            "name": "CPU"
+          },
+          "relationships": {
+            "machine": {
+              "data": {
+                "type": "machines",
+                "id": "$machines[0]"
+              }
+            }
+          }
+        }
+      }
+      """
+    Then the response status should be "201"
+    And the response body should be a "component" with the following relationships:
+      """
+      {
+        "machine": {
+          "data": {
+            "type": "machines",
+            "id": "$machines[0]"
+          },
+          "links": {
+            "related": "/v1/accounts/$account/components/$components[0]/machine"
+          }
+        }
+      }
+      """
+    And the response body should be a "component" with the following attributes:
+      """
+      {
+        "fingerprint": "0af831cd3c2f494aa8311ab13f2b6ec1",
+        "name": "CPU"
+      }
+      """
+    And the response should contain a valid signature header for "test1"
+    And sidekiq should have 2 "webhook" jobs
+    And sidekiq should have 1 "metric" job
+    And sidekiq should have 1 "request-log" job
+    And time is unfrozen
+
+  Scenario: Developer creates a component for their account
+    Given the current account is "test1"
+    And the current account has 1 "developer"
+    And I am a developer of account "test1"
+    And the current account has 1 "machine"
+    And I use an authentication token
+    When I send a POST request to "/accounts/test1/components" with the following:
+      """
+      {
+        "data": {
+          "type": "components",
+          "attributes": {
+            "fingerprint": "47aac935086a472282ed7218730d8e89",
+            "name": "GPU"
+          },
+          "relationships": {
+            "machine": {
+              "data": {
+                "type": "machines",
+                "id": "$machines[0]"
+              }
+            }
+          }
+        }
+      }
+      """
+    Then the response status should be "201"
+
+  Scenario: Sales creates a component for their account
+    Given the current account is "test1"
+    And the current account has 1 "sales-agent"
+    And I am a sales agent of account "test1"
+    And the current account has 1 "machine"
+    And I use an authentication token
+    When I send a POST request to "/accounts/test1/components" with the following:
+      """
+      {
+        "data": {
+          "type": "components",
+          "attributes": {
+            "fingerprint": "192.168.1.1",
+            "name": "IP"
+          },
+          "relationships": {
+            "machine": {
+              "data": {
+                "type": "machines",
+                "id": "$machines[0]"
+              }
+            }
+          }
+        }
+      }
+      """
+    Then the response status should be "201"
+
+  Scenario: Support attempts to create a component for their account
+    Given the current account is "test1"
+    And the current account has 1 "support-agent"
+    And I am a support agent of account "test1"
+    And the current account has 1 "machine"
+    And I use an authentication token
+    When I send a POST request to "/accounts/test1/components" with the following:
+      """
+      {
+        "data": {
+          "type": "components",
+          "attributes": {
+            "fingerprint": "005322acdf11488faa5dc0d69b11e576",
+            "name": "MOBO"
+          },
+          "relationships": {
+            "machine": {
+              "data": {
+                "type": "machines",
+                "id": "$machines[0]"
+              }
+            }
+          }
+        }
+      }
+      """
+    Then the response status should be "403"
+
+  Scenario: Read-only attempts to create a component for their account
+    Given the current account is "test1"
+    And the current account has 1 "read-only"
+    And I am a read only of account "test1"
+    And the current account has 1 "machine"
+    And I use an authentication token
+    When I send a POST request to "/accounts/test1/components" with the following:
+      """
+      {
+        "data": {
+          "type": "components",
+          "attributes": {
+            "fingerprint": "af:5f:db:75:f4:51:41:b7:bf:1f:77:bd:4a:8f:4d:a0",
+            "name": "MAC"
+          },
+          "relationships": {
+            "machine": {
+              "data": {
+                "type": "machines",
+                "id": "$machines[0]"
+              }
+            }
+          }
+        }
+      }
+      """
+    Then the response status should be "403"
+
+  Scenario: Admin creates a component with a fingerprint matching another component for a different machine (UNIQUE_PER_MACHINE)
+    Given I am an admin of account "test1"
+    And the current account is "test1"
+    And the current account has 2 "webhook-endpoints"
+    And the current account has 2 "products"
+    And the current account has 1 "policy" for each "product" with the following:
+      """
+      { "fingerprintUniquenessStrategy": "UNIQUE_PER_MACHINE" }
+      """
+    And the current account has 1 "license" for each "policy"
+    And the current account has 2 "machines" for each "license"
+    And the current account has 1 "component" for the last "machine" with the following:
+      """
+      { "fingerprint": "5f28e8a43bcd402082190b48d0048100" }
+      """
+    And I use an authentication token
+    When I send a POST request to "/accounts/test1/components" with the following:
+      """
+      {
+        "data": {
+          "type": "components",
+          "attributes": {
+            "fingerprint": "5f28e8a43bcd402082190b48d0048100",
+            "name": "SSD"
+          },
+          "relationships": {
+            "machine": {
+              "data": {
+                "type": "machines",
+                "id": "$machines[0]"
+              }
+            }
+          }
+        }
+      }
+      """
+    Then the response status should be "201"
+    And sidekiq should have 2 "webhook" jobs
+    And sidekiq should have 1 "metric" job
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: Admin creates a component with a fingerprint matching another component for the same machine (UNIQUE_PER_MACHINE)
+    Given I am an admin of account "test1"
+    And the current account is "test1"
+    And the current account has 2 "webhook-endpoints"
+    And the current account has 2 "products"
+    And the current account has 1 "policy" for each "product" with the following:
+      """
+      { "fingerprintUniquenessStrategy": "UNIQUE_PER_MACHINE" }
+      """
+    And the current account has 1 "license" for each "policy"
+    And the current account has 2 "machines" for each "license"
+    And the current account has 1 "component" for the first "machine" with the following:
+      """
+      { "fingerprint": "5f28e8a43bcd402082190b48d0048100" }
+      """
+    And I use an authentication token
+    When I send a POST request to "/accounts/test1/components" with the following:
+      """
+      {
+        "data": {
+          "type": "components",
+          "attributes": {
+            "fingerprint": "5f28e8a43bcd402082190b48d0048100",
+            "name": "SSD"
+          },
+          "relationships": {
+            "machine": {
+              "data": {
+                "type": "machines",
+                "id": "$machines[0]"
+              }
+            }
+          }
+        }
+      }
+      """
+    Then the response status should be "422"
+    And the first error should have the following properties:
+      """
+      {
+        "title": "Unprocessable resource",
+        "detail": "has already been taken",
+        "code": "FINGERPRINT_TAKEN",
+        "source": {
+          "pointer": "/data/attributes/fingerprint"
+        }
+      }
+      """
+    And sidekiq should have 0 "webhook" jobs
+    And sidekiq should have 0 "metric" jobs
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: Admin creates a component with a fingerprint matching another component for a different license (UNIQUE_PER_LICENSE)
+    Given I am an admin of account "test1"
+    And the current account is "test1"
+    And the current account has 2 "webhook-endpoints"
+    And the current account has 2 "products"
+    And the current account has 1 "policy" for each "product" with the following:
+      """
+      { "fingerprintUniquenessStrategy": "UNIQUE_PER_LICENSE" }
+      """
+    And the current account has 2 "licenses" for each "policy"
+    And the current account has 1 "machine" for each "license"
+    And the current account has 1 "component" for the last "machine" with the following:
+      """
+      { "fingerprint": "5f28e8a43bcd402082190b48d0048100" }
+      """
+    And I use an authentication token
+    When I send a POST request to "/accounts/test1/components" with the following:
+      """
+      {
+        "data": {
+          "type": "components",
+          "attributes": {
+            "fingerprint": "5f28e8a43bcd402082190b48d0048100",
+            "name": "SSD"
+          },
+          "relationships": {
+            "machine": {
+              "data": {
+                "type": "machines",
+                "id": "$machines[0]"
+              }
+            }
+          }
+        }
+      }
+      """
+    Then the response status should be "201"
+    And sidekiq should have 2 "webhook" jobs
+    And sidekiq should have 1 "metric" job
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: Admin creates a component with a fingerprint matching another component for the same license (UNIQUE_PER_LICENSE)
+    Given I am an admin of account "test1"
+    And the current account is "test1"
+    And the current account has 2 "webhook-endpoints"
+    And the current account has 2 "products"
+    And the current account has 1 "policy" for each "product" with the following:
+      """
+      { "fingerprintUniquenessStrategy": "UNIQUE_PER_LICENSE" }
+      """
+    And the current account has 2 "licenses" for each "policy"
+    And the current account has 2 "machines" for each "license"
+    And the current account has 1 "component" for the second "machine" with the following:
+      """
+      { "fingerprint": "5f28e8a43bcd402082190b48d0048100" }
+      """
+    And I use an authentication token
+    When I send a POST request to "/accounts/test1/components" with the following:
+      """
+      {
+        "data": {
+          "type": "components",
+          "attributes": {
+            "fingerprint": "5f28e8a43bcd402082190b48d0048100",
+            "name": "SSD"
+          },
+          "relationships": {
+            "machine": {
+              "data": {
+                "type": "machines",
+                "id": "$machines[0]"
+              }
+            }
+          }
+        }
+      }
+      """
+    Then the response status should be "422"
+    And the first error should have the following properties:
+      """
+      {
+        "title": "Unprocessable resource",
+        "detail": "has already been taken for this license",
+        "code": "FINGERPRINT_TAKEN",
+        "source": {
+          "pointer": "/data/attributes/fingerprint"
+        }
+      }
+      """
+    And sidekiq should have 0 "webhook" jobs
+    And sidekiq should have 0 "metric" jobs
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: Admin creates a component with a fingerprint matching another component for a different policy (UNIQUE_PER_POLICY)
+    Given I am an admin of account "test1"
+    And the current account is "test1"
+    And the current account has 2 "webhook-endpoints"
+    And the current account has 2 "products"
+    And the current account has 2 "policies" for each "product" with the following:
+      """
+      { "fingerprintUniquenessStrategy": "UNIQUE_PER_POLICY" }
+      """
+    And the current account has 2 "licenses" for each "policy"
+    And the current account has 2 "machines" for each "license"
+    And the current account has 1 "component" for the last "machine" with the following:
+      """
+      { "fingerprint": "5f28e8a43bcd402082190b48d0048100" }
+      """
+    And I use an authentication token
+    When I send a POST request to "/accounts/test1/components" with the following:
+      """
+      {
+        "data": {
+          "type": "components",
+          "attributes": {
+            "fingerprint": "5f28e8a43bcd402082190b48d0048100",
+            "name": "SSD"
+          },
+          "relationships": {
+            "machine": {
+              "data": {
+                "type": "machines",
+                "id": "$machines[0]"
+              }
+            }
+          }
+        }
+      }
+      """
+    Then the response status should be "201"
+    And sidekiq should have 2 "webhook" jobs
+    And sidekiq should have 1 "metric" job
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: Admin creates a component with a fingerprint matching another component for the same policy (UNIQUE_PER_POLICY)
+    Given I am an admin of account "test1"
+    And the current account is "test1"
+    And the current account has 2 "webhook-endpoints"
+    And the current account has 2 "products"
+    And the current account has 2 "policies" for each "product" with the following:
+      """
+      { "fingerprintUniquenessStrategy": "UNIQUE_PER_POLICY" }
+      """
+    And the current account has 2 "licenses" for each "policy"
+    And the current account has 2 "machines" for each "license"
+    And the current account has 1 "component" for the third "machine" with the following:
+      """
+      { "fingerprint": "5f28e8a43bcd402082190b48d0048100" }
+      """
+    And I use an authentication token
+    When I send a POST request to "/accounts/test1/components" with the following:
+      """
+      {
+        "data": {
+          "type": "components",
+          "attributes": {
+            "fingerprint": "5f28e8a43bcd402082190b48d0048100",
+            "name": "SSD"
+          },
+          "relationships": {
+            "machine": {
+              "data": {
+                "type": "machines",
+                "id": "$machines[0]"
+              }
+            }
+          }
+        }
+      }
+      """
+    Then the response status should be "422"
+    And the first error should have the following properties:
+      """
+      {
+        "title": "Unprocessable resource",
+        "detail": "has already been taken for this policy",
+        "code": "FINGERPRINT_TAKEN",
+        "source": {
+          "pointer": "/data/attributes/fingerprint"
+        }
+      }
+      """
+    And sidekiq should have 0 "webhook" jobs
+    And sidekiq should have 0 "metric" jobs
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: Admin creates a component with a fingerprint matching another component for a different product (UNIQUE_PER_PRODUCT)
+    Given I am an admin of account "test1"
+    And the current account is "test1"
+    And the current account has 2 "webhook-endpoints"
+    And the current account has 2 "products"
+    And the current account has 1 "policy" for each "product" with the following:
+      """
+      { "fingerprintUniquenessStrategy": "UNIQUE_PER_PRODUCT" }
+      """
+    And the current account has 2 "licenses" for each "policy"
+    And the current account has 1 "machine" for each "license"
+    And the current account has 1 "component" for the third "machine" with the following:
+      """
+      { "fingerprint": "5f28e8a43bcd402082190b48d0048100" }
+      """
+    And I use an authentication token
+    When I send a POST request to "/accounts/test1/components" with the following:
+      """
+      {
+        "data": {
+          "type": "components",
+          "attributes": {
+            "fingerprint": "5f28e8a43bcd402082190b48d0048100",
+            "name": "SSD"
+          },
+          "relationships": {
+            "machine": {
+              "data": {
+                "type": "machines",
+                "id": "$machines[0]"
+              }
+            }
+          }
+        }
+      }
+      """
+    Then the response status should be "201"
+    And sidekiq should have 2 "webhook" jobs
+    And sidekiq should have 1 "metric" job
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: Admin creates a component with a fingerprint matching another component for the same product (UNIQUE_PER_PRODUCT)
+    Given I am an admin of account "test1"
+    And the current account is "test1"
+    And the current account has 2 "webhook-endpoints"
+    And the current account has 2 "products"
+    And the current account has 1 "policy" for each "product" with the following:
+      """
+      { "fingerprintUniquenessStrategy": "UNIQUE_PER_PRODUCT" }
+      """
+    And the current account has 2 "licenses" for each "policy"
+    And the current account has 1 "machine" for each "license"
+    And the current account has 1 "component" for the second "machine" with the following:
+      """
+      { "fingerprint": "5f28e8a43bcd402082190b48d0048100" }
+      """
+    And I use an authentication token
+    When I send a POST request to "/accounts/test1/components" with the following:
+      """
+      {
+        "data": {
+          "type": "components",
+          "attributes": {
+            "fingerprint": "5f28e8a43bcd402082190b48d0048100",
+            "name": "SSD"
+          },
+          "relationships": {
+            "machine": {
+              "data": {
+                "type": "machines",
+                "id": "$machines[0]"
+              }
+            }
+          }
+        }
+      }
+      """
+    Then the response status should be "422"
+    And the first error should have the following properties:
+      """
+      {
+        "title": "Unprocessable resource",
+        "detail": "has already been taken for this product",
+        "code": "FINGERPRINT_TAKEN",
+        "source": {
+          "pointer": "/data/attributes/fingerprint"
+        }
+      }
+      """
+    And sidekiq should have 0 "webhook" jobs
+    And sidekiq should have 0 "metric" jobs
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: Admin creates a component for their account with a fingerprint matching a reserved word
+    Given I am an admin of account "test1"
+    And the current account is "test1"
+    And the current account has 2 "webhook-endpoints"
+    And the current account has 1 "machine"
+    And the current account has 1 "component"
+    And I use an authentication token
+    When I send a POST request to "/accounts/test1/components" with the following:
+      """
+      {
+        "data": {
+          "type": "components",
+          "attributes": {
+            "fingerprint": "actions",
+            "name": "reserved"
+          },
+          "relationships": {
+            "machine": {
+              "data": {
+                "type": "machines",
+                "id": "$machines[0]"
+              }
+            }
+          }
+        }
+      }
+      """
+    Then the response status should be "422"
+    And the first error should have the following properties:
+      """
+      {
+        "title": "Unprocessable resource",
+        "detail": "is reserved",
+        "code": "FINGERPRINT_NOT_ALLOWED",
+        "source": {
+          "pointer": "/data/attributes/fingerprint"
+        }
+      }
+      """
+    And sidekiq should have 0 "webhook" jobs
+    And sidekiq should have 0 "metric" jobs
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: Admin creates a component with missing attributes
+    Given I am an admin of account "test1"
+    And the current account is "test1"
+    And the current account has 2 "webhook-endpoints"
+    And the current account has 1 "machine"
+    And I use an authentication token
+    When I send a POST request to "/accounts/test1/components" with the following:
+      """
+      {
+        "data": {
+          "type": "components",
+          "relationships": {
+            "machine": {
+              "data": {
+                "type": "machines",
+                "id": "$machines[0]"
+              }
+            }
+          }
+        }
+      }
+      """
+    Then the response status should be "400"
+    And the first error should have the following properties:
+      """
+      {
+        "title": "Bad request",
+        "detail": "is missing",
+        "source": {
+          "pointer": "/data/attributes"
+        }
+      }
+      """
+    And sidekiq should have 0 "webhook" jobs
+    And sidekiq should have 0 "metric" jobs
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: Admin creates a component with missing fingerprint
+    Given I am an admin of account "test1"
+    And the current account is "test1"
+    And the current account has 2 "webhook-endpoints"
+    And the current account has 1 "machine"
+    And I use an authentication token
+    When I send a POST request to "/accounts/test1/components" with the following:
+      """
+      {
+        "data": {
+          "type": "components",
+          "attributes": {
+            "name": "test"
+          },
+          "relationships": {
+            "machine": {
+              "data": {
+                "type": "machines",
+                "id": "$machines[0]"
+              }
+            }
+          }
+        }
+      }
+      """
+    Then the response status should be "400"
+    And the first error should have the following properties:
+      """
+      {
+        "title": "Bad request",
+        "detail": "is missing",
+        "source": {
+          "pointer": "/data/attributes/fingerprint"
+        }
+      }
+      """
+    And sidekiq should have 0 "webhook" jobs
+    And sidekiq should have 0 "metric" jobs
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: Admin creates a component with missing name
+    Given I am an admin of account "test1"
+    And the current account is "test1"
+    And the current account has 2 "webhook-endpoints"
+    And the current account has 1 "machine"
+    And I use an authentication token
+    When I send a POST request to "/accounts/test1/components" with the following:
+      """
+      {
+        "data": {
+          "type": "components",
+          "attributes": {
+            "fingerprint": "test"
+          },
+          "relationships": {
+            "machine": {
+              "data": {
+                "type": "machines",
+                "id": "$machines[0]"
+              }
+            }
+          }
+        }
+      }
+      """
+    Then the response status should be "400"
+    And the first error should have the following properties:
+      """
+      {
+        "title": "Bad request",
+        "detail": "is missing",
+        "source": {
+          "pointer": "/data/attributes/name"
+        }
+      }
+      """
+    And sidekiq should have 0 "webhook" jobs
+    And sidekiq should have 0 "metric" jobs
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: Admin creates a component with missing relationships
+    Given I am an admin of account "test1"
+    And the current account is "test1"
+    And the current account has 2 "webhook-endpoints"
+    And the current account has 1 "machine"
+    And I use an authentication token
+    When I send a POST request to "/accounts/test1/components" with the following:
+      """
+      {
+        "data": {
+          "type": "components",
+          "attributes": {
+            "fingerprint": "42",
+            "name": "life"
+          }
+        }
+      }
+      """
+    Then the response status should be "400"
+    And the first error should have the following properties:
+      """
+      {
+        "title": "Bad request",
+        "detail": "is missing",
+        "source": {
+          "pointer": "/data/relationships"
+        }
+      }
+      """
+    And sidekiq should have 0 "webhook" jobs
+    And sidekiq should have 0 "metric" jobs
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: Admin creates a component with missing machine
+    Given I am an admin of account "test1"
+    And the current account is "test1"
+    And the current account has 2 "webhook-endpoints"
+    And the current account has 1 "machine"
+    And I use an authentication token
+    When I send a POST request to "/accounts/test1/components" with the following:
+      """
+      {
+        "data": {
+          "type": "components",
+          "attributes": {
+            "fingerprint": "42",
+            "name": "life"
+          },
+          "relationships": {
+          }
+        }
+      }
+      """
+    Then the response status should be "400"
+    And the first error should have the following properties:
+      """
+      {
+        "title": "Bad request",
+        "detail": "is missing",
+        "source": {
+          "pointer": "/data/relationships/machine"
+        }
+      }
+      """
+    And sidekiq should have 0 "webhook" jobs
+    And sidekiq should have 0 "metric" jobs
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: Admin creates a component with an invalid machine UUID
+    Given I am an admin of account "test1"
+    And the current account is "test1"
+    And the current account has 2 "webhook-endpoints"
+    And the current account has 1 "machine"
+    And I use an authentication token
+    When I send a POST request to "/accounts/test1/components" with the following:
+      """
+      {
+        "data": {
+          "type": "components",
+          "attributes": {
+            "fingerprint": "7E038967-9FAA-41C6-B018-539E601A133B",
+            "name": "SystemGUID"
+          },
+          "relationships": {
+            "machine": {
+              "data": {
+                "type": "machines",
+                "id": "16896379-73ae-4d92-a458-6e7841c9ad08"
+              }
+            }
+          }
+        }
+      }
+      """
+    Then the response status should be "422"
+     And the first error should have the following properties:
+      """
+      {
+        "title": "Unprocessable resource",
+        "detail": "must exist",
+        "code": "MACHINE_NOT_FOUND",
+        "source": {
+          "pointer": "/data/relationships/machine"
+        }
+      }
+    """
+    And sidekiq should have 0 "webhook" jobs
+    And sidekiq should have 0 "metric" jobs
+    And sidekiq should have 1 "request-log" job
+
+  @ee
+  Scenario: Environment creates an isolated component for their account
+    Given time is frozen at "2022-10-16T14:52:48.000Z"
+    And the current account is "test1"
+    And the current account has 1 isolated "environment"
+    And the current account has 2 isolated "webhook-endpoints"
+    And the current account has 1 isolated "machine"
+    And I am an environment of account "test1"
+    And I use an authentication token
+    And I send the following headers:
+      """
+      { "Keygen-Environment": "isolated" }
+      """
+    When I send a POST request to "/accounts/test1/components" with the following:
+      """
+      {
+        "data": {
+          "type": "components",
+          "attributes": {
+            "fingerprint": "26f93d8e-e7e0-4078-93af-9132886799c5",
+            "name": "HDD"
+          },
+          "relationships": {
+            "machine": {
+              "data": {
+                "type": "machines",
+                "id": "$machines[0]"
+              }
+            }
+          }
+        }
+      }
+      """
+    Then the response status should be "201"
+    And the response body should be a "component" with the following attributes:
+      """
+      {
+        "fingerprint": "26f93d8e-e7e0-4078-93af-9132886799c5",
+        "name": "HDD"
+      }
+      """
+    And the response should contain a valid signature header for "test1"
+    And sidekiq should have 2 "webhook" jobs
+    And sidekiq should have 1 "metric" job
+    And sidekiq should have 1 "request-log" job
+    And time is unfrozen
+
+  Scenario: User creates a component for their machine
+    Given the current account is "test1"
+    And the current account has 2 "webhook-endpoints"
+    And the current account has 1 "user"
+    And the current account has 1 "license" for the last "user"
+    And the current account has 1 "machine" for the last "license"
+    And I am a user of account "test1"
+    And I use an authentication token
+    When I send a POST request to "/accounts/test1/components" with the following:
+      """
+      {
+        "data": {
+          "type": "components",
+          "attributes": {
+            "fingerprint": "26f93d8e-e7e0-4078-93af-9132886799c5",
+            "name": "HDD"
+          },
+          "relationships": {
+            "machine": {
+              "data": {
+                "type": "machines",
+                "id": "$machines[0]"
+              }
+            }
+          }
+        }
+      }
+      """
+    Then the response status should be "201"
+    And the response body should be a "component" with the following attributes:
+      """
+      {
+        "fingerprint": "26f93d8e-e7e0-4078-93af-9132886799c5",
+        "name": "HDD"
+      }
+      """
+    And sidekiq should have 2 "webhook" jobs
+    And sidekiq should have 1 "metric" job
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: User creates a component for their machine with a protected policy
+    Given the current account is "test1"
+    And the current account has 2 "webhook-endpoints"
+    And the current account has 1 "policy"
+    And the first "policy" has the following attributes:
+      """
+      { "protected": true }
+      """
+    And the current account has 1 "user"
+    And the current account has 1 "license" for the last "policy"
+    And the first "license" has the following attributes:
+      """
+      { "userId": "$users[1]" }
+      """
+    And the current account has 1 "machine" for the last "license"
+    And I am a user of account "test1"
+    And I use an authentication token
+    When I send a POST request to "/accounts/test1/components" with the following:
+      """
+      {
+        "data": {
+          "type": "components",
+          "attributes": {
+            "fingerprint": "08:a6:49:ee:2c:fd:48:bd:a0:f4:68:30:fb:47:6b:69",
+            "name": "drive"
+          },
+          "relationships": {
+            "machine": {
+              "data": {
+                "type": "machines",
+                "id": "$machines[0]"
+              }
+            }
+          }
+        }
+      }
+      """
+    Then the response status should be "403"
+    And sidekiq should have 0 "webhook" jobs
+    And sidekiq should have 0 "metric" jobs
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: User creates a component for an unprotected machine
+    Given the current account is "test1"
+    And the current account has 2 "webhook-endpoints"
+    And the current account has 1 "policy"
+    And the first "policy" has the following attributes:
+      """
+      { "protected": false }
+      """
+    And the current account has 1 "user"
+    And the current account has 1 "license" for the last "policy"
+    And the first "license" has the following attributes:
+      """
+      { "userId": "$users[1]" }
+      """
+    And the current account has 1 "machine" for the last "license"
+    And I am a user of account "test1"
+    And I use an authentication token
+    When I send a POST request to "/accounts/test1/components" with the following:
+      """
+      {
+        "data": {
+          "type": "components",
+          "attributes": {
+            "fingerprint": "26f93d8e-e7e0-4078-93af-9132886799c5",
+            "name": "HDD"
+          },
+          "relationships": {
+            "machine": {
+              "data": {
+                "type": "machines",
+                "id": "$machines[0]"
+              }
+            }
+          }
+        }
+      }
+      """
+    Then the response status should be "201"
+    And the response body should be a "component" with the following attributes:
+      """
+      {
+        "fingerprint": "26f93d8e-e7e0-4078-93af-9132886799c5",
+        "name": "HDD"
+      }
+      """
+    And sidekiq should have 2 "webhook" jobs
+    And sidekiq should have 1 "metric" job
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: License creates a component for their machine
+    Given the current account is "test1"
+    And the current account has 2 "webhook-endpoints"
+    And the current account has 1 floating "policy"
+    And the current account has 1 "license" for the last "policy"
+    And the current account has 3 "machines" for the last "license"
+    And I am a license of account "test1"
+    And I use an authentication token
+    When I send a POST request to "/accounts/test1/components" with the following:
+      """
+      {
+        "data": {
+          "type": "components",
+          "attributes": {
+            "fingerprint": "26f93d8e-e7e0-4078-93af-9132886799c5",
+            "name": "HDD"
+          },
+          "relationships": {
+            "machine": {
+              "data": {
+                "type": "machines",
+                "id": "$machines[0]"
+              }
+            }
+          }
+        }
+      }
+      """
+    Then the response status should be "201"
+    And the response body should be a "component" with the following attributes:
+      """
+      {
+        "fingerprint": "26f93d8e-e7e0-4078-93af-9132886799c5",
+        "name": "HDD"
+      }
+      """
+    And sidekiq should have 2 "webhook" jobs
+    And sidekiq should have 1 "metric" job
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: License creates a component for a protected machine
+    Given the current account is "test1"
+    And the current account has 2 "webhook-endpoints"
+    And the current account has 1 "policy"
+    And the first "policy" has the following attributes:
+      """
+      { "protected": true }
+      """
+    And the current account has 1 "license" for the last "policy"
+    And the current account has 1 "machine" for the last "license"
+    And I am a license of account "test1"
+    And I use an authentication token
+    When I send a POST request to "/accounts/test1/components" with the following:
+      """
+      {
+        "data": {
+          "type": "components",
+          "attributes": {
+            "fingerprint": "26f93d8e-e7e0-4078-93af-9132886799c5",
+            "name": "HDD"
+          },
+          "relationships": {
+            "machine": {
+              "data": {
+                "type": "machines",
+                "id": "$machines[0]"
+              }
+            }
+          }
+        }
+      }
+      """
+    Then the response status should be "201"
+    And the response body should be a "component" with the following attributes:
+      """
+      {
+        "fingerprint": "26f93d8e-e7e0-4078-93af-9132886799c5",
+        "name": "HDD"
+      }
+      """
+    And sidekiq should have 2 "webhook" jobs
+    And sidekiq should have 1 "metric" job
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: License creates a component for their machine with a duplicate fingerprint
+    Given the current account is "test1"
+    And the current account has 2 "webhook-endpoints"
+    And the current account has 1 "license"
+    And the current account has 1 "machine" for the last "license"
+    And the current account has 1 "component" for the last "machine"
+    And the first "component" has the following attributes:
+      """
+      { "fingerprint": "26f93d8e-e7e0-4078-93af-9132886799c5" }
+      """
+    And I am a license of account "test1"
+    And I use an authentication token
+    When I send a POST request to "/accounts/test1/components" with the following:
+      """
+      {
+        "data": {
+          "type": "components",
+          "attributes": {
+            "fingerprint": "26f93d8e-e7e0-4078-93af-9132886799c5",
+            "name": "HDD"
+          },
+          "relationships": {
+            "machine": {
+              "data": {
+                "type": "machines",
+                "id": "$machines[0]"
+              }
+            }
+          }
+        }
+      }
+      """
+    Then the response status should be "422"
+    And the first error should have the following properties:
+      """
+      {
+        "title": "Unprocessable resource",
+        "detail": "has already been taken",
+        "code": "FINGERPRINT_TAKEN",
+        "source": {
+          "pointer": "/data/attributes/fingerprint"
+        }
+      }
+      """
+    And the current account should have 1 "component"
+    And sidekiq should have 0 "webhook" jobs
+    And sidekiq should have 0 "metric" jobs
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: License creates a component for their machine with a blank fingerprint
+    Given the current account is "test1"
+    And the current account has 2 "webhook-endpoints"
+    And the current account has 1 "license"
+    And the current account has 1 "machine" for the last "license"
+    And I am a license of account "test1"
+    And I use an authentication token
+    When I send a POST request to "/accounts/test1/components" with the following:
+      """
+      {
+        "data": {
+          "type": "components",
+          "attributes": {
+            "fingerprint": "",
+            "name": "HDD"
+          },
+          "relationships": {
+            "machine": {
+              "data": {
+                "type": "machines",
+                "id": "$machines[0]"
+              }
+            }
+          }
+        }
+      }
+      """
+    Then the response status should be "400"
+    And the first error should have the following properties:
+      """
+      {
+        "title": "Bad request",
+        "detail": "cannot be blank",
+        "source": {
+          "pointer": "/data/attributes/fingerprint"
+        }
+      }
+      """
+    And the current account should have 0 "components"
+    And sidekiq should have 0 "webhook" jobs
+    And sidekiq should have 0 "metric" jobs
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: License creates a component for their machine with a blank name
+    Given the current account is "test1"
+    And the current account has 2 "webhook-endpoints"
+    And the current account has 1 "license"
+    And the current account has 1 "machine" for the last "license"
+    And I am a license of account "test1"
+    And I use an authentication token
+    When I send a POST request to "/accounts/test1/components" with the following:
+      """
+      {
+        "data": {
+          "type": "components",
+          "attributes": {
+            "fingerprint": "94619120-910b-47aa-9c9c-7cb9474a5a15",
+            "name": ""
+          },
+          "relationships": {
+            "machine": {
+              "data": {
+                "type": "machines",
+                "id": "$machines[0]"
+              }
+            }
+          }
+        }
+      }
+      """
+    Then the response status should be "400"
+    And the first error should have the following properties:
+      """
+      {
+        "title": "Bad request",
+        "detail": "cannot be blank",
+        "source": {
+          "pointer": "/data/attributes/name"
+        }
+      }
+      """
+    And the current account should have 0 "components"
+    And sidekiq should have 0 "webhook" jobs
+    And sidekiq should have 0 "metric" jobs
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: License creates a component for another license's machine
+    Given the current account is "test1"
+    And the current account has 1 "webhook-endpoint"
+    And the current account has 3 "machines"
+    And I am a license of account "test1"
+    And I use an authentication token
+    When I send a POST request to "/accounts/test1/components" with the following:
+      """
+      {
+        "data": {
+          "type": "components",
+          "attributes": {
+            "fingerprint": "23daa04a-badc-4808-ae52-7b1ba987fa90",
+            "name": "GPU"
+          },
+          "relationships": {
+            "machine": {
+              "data": {
+                "type": "machines",
+                "id": "$machines[1]"
+              }
+            }
+          }
+        }
+      }
+      """
+    Then the response status should be "403"
+    And sidekiq should have 0 "webhook" jobs
+    And sidekiq should have 0 "metric" jobs
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: Product creates a component for another product's machine
+    Given the current account is "test1"
+    And the current account has 1 "webhook-endpoint"
+    And the current account has 2 "products"
+    And the current account has 1 "policy" for the second "product"
+    And the current account has 1 "license" for the last "policy"
+    And the current account has 1 "machine" for the last "license"
+    And I am a product of account "test1"
+    And I use an authentication token
+    When I send a POST request to "/accounts/test1/components" with the following:
+      """
+      {
+        "data": {
+          "type": "components",
+          "attributes": {
+            "fingerprint": "89cadd7c-4f50-45b7-8975-30041e403131",
+            "name": "GPU"
+          },
+          "relationships": {
+            "machine": {
+              "data": {
+                "type": "machines",
+                "id": "$machines[0]"
+              }
+            }
+          }
+        }
+      }
+      """
+    Then the response status should be "403"
+    And sidekiq should have 0 "webhook" jobs
+    And sidekiq should have 0 "metric" jobs
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: User creates a component for another user's machine
+    Given the current account is "test1"
+    And the current account has 1 "webhook-endpoint"
+    And the current account has 1 "user"
+    And the current account has 1 "machine"
+    And I am a user of account "test1"
+    And I use an authentication token
+    When I send a POST request to "/accounts/test1/components" with the following:
+      """
+      {
+        "data": {
+          "type": "components",
+          "attributes": {
+            "fingerprint": "01a7c6dc-74af-4445-89a0-d360ad705948",
+            "name": "GPU"
+          },
+          "relationships": {
+            "machine": {
+              "data": {
+                "type": "machines",
+                "id": "$machines[0]"
+              }
+            }
+          }
+        }
+      }
+      """
+    Then the response status should be "403"
+    And sidekiq should have 0 "webhook" jobs
+    And sidekiq should have 0 "metric" jobs
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: Anonymous attempts to create a component
+    Given the current account is "test1"
+    And the current account has 2 "webhook-endpoints"
+    And the current account has 1 "machine"
+    When I send a POST request to "/accounts/test1/components" with the following:
+      """
+      {
+        "data": {
+          "type": "components",
+          "attributes": {
+            "fingerprint": "44a03eb5-9b6c-4ddb-8113-9f70d72bd890",
+            "name": "chip"
+          },
+          "relationships": {
+            "machine": {
+              "data": {
+                "type": "machines",
+                "id": "$machines[0]"
+              }
+            }
+          }
+        }
+      }
+      """
+    Then the response status should be "401"
+    And sidekiq should have 0 "webhook" jobs
+    And sidekiq should have 0 "metric" jobs
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: Admin of another account attempts to create a component
+    Given the current account is "test1"
+    And the current account has 10 "webhook-endpoints"
+    And the current account has 1 "machine"
+    And I am an admin of account "test2"
+    And I use an authentication token
+    When I send a POST request to "/accounts/test1/components" with the following:
+      """
+      {
+        "data": {
+          "type": "components",
+          "attributes": {
+            "fingerprint": "aebbb996-ddf5-43c4-a99d-c1ce1ec445bd",
+            "name": "motherboard"
+          },
+          "relationships": {
+            "machine": {
+              "data": {
+                "type": "machines",
+                "id": "$machines[0]"
+              }
+            }
+          }
+        }
+      }
+      """
+    Then the response status should be "401"
+    And sidekiq should have 0 "webhook" jobs
+    And sidekiq should have 0 "metric" jobs
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: License activates a component with a pre-determined ID
+    Given the current account is "test1"
+    And the current account has 1 "machine"
+    And I am a license of account "test1"
+    And I use an authentication token
+    When I send a POST request to "/accounts/test1/components" with the following:
+      """
+      {
+        "data": {
+          "type": "components",
+          "id": "00000000-2521-4033-9f4f-3675387016f7",
+          "attributes": {
+            "fingerprint": "04745910-2bc4-44f5-b116-6d11e0b73791",
+            "name": "network"
+          },
+          "relationships": {
+            "machine": {
+              "data": {
+                "type": "machines",
+                "id": "$machines[0]"
+              }
+            }
+          }
+        }
+      }
+      """
+    Then the response status should be "400"

--- a/features/api/v1/components/create.feature
+++ b/features/api/v1/components/create.feature
@@ -1000,6 +1000,20 @@ Feature: Create machine component
       }
       """
     Then the response status should be "201"
+    And the response body should be a "component" with the following relationships:
+      """
+      {
+        "environment": {
+          "data": {
+            "type": "environments",
+            "id": "$environments[0]"
+          },
+          "links": {
+            "related": "/v1/accounts/$account/environments/$environments[0]"
+          }
+        }
+      }
+      """
     And the response body should be a "component" with the following attributes:
       """
       {

--- a/features/api/v1/components/destroy.feature
+++ b/features/api/v1/components/destroy.feature
@@ -1,0 +1,237 @@
+@api/v1
+Feature: Delete machine component
+  Background:
+    Given the following "accounts" exist:
+      | Name    | Slug  |
+      | Test 1  | test1 |
+      | Test 2  | test2 |
+    And I send and accept JSON
+
+  Scenario: Endpoint should be inaccessible when account is disabled
+    Given the account "test1" is canceled
+    Given I am an admin of account "test1"
+    And the current account is "test1"
+    And the current account has 1 "component"
+    And I use an authentication token
+    When I send a DELETE request to "/accounts/test1/components/$0"
+    Then the response status should be "403"
+
+  Scenario: Admin deletes one of their components
+    Given I am an admin of account "test1"
+    And the current account is "test1"
+    And the current account has 2 "webhook-endpoints"
+    And the current account has 3 "components"
+    And I use an authentication token
+    When I send a DELETE request to "/accounts/test1/components/$2"
+    Then the response status should be "204"
+    And the response should contain a valid signature header for "test1"
+    And the current account should have 2 "components"
+    And sidekiq should have 2 "webhook" jobs
+    And sidekiq should have 1 "metric" job
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: Developer deletes one of their components
+    Given the current account is "test1"
+    And the current account has 1 "developer"
+    And I am a developer of account "test1"
+    And the current account has 3 "components"
+    And I use an authentication token
+    When I send a DELETE request to "/accounts/test1/components/$2"
+    Then the response status should be "204"
+    And the current account should have 2 "components"
+
+  Scenario: Sales deletes one of their components
+    Given the current account is "test1"
+    And the current account has 1 "sales-agent"
+    And I am a sales agent of account "test1"
+    And the current account has 3 "components"
+    And I use an authentication token
+    When I send a DELETE request to "/accounts/test1/components/$2"
+    Then the response status should be "204"
+    And the current account should have 2 "components"
+
+  Scenario: Support deletes one of their components
+    Given the current account is "test1"
+    And the current account has 1 "support-agent"
+    And I am a support agent of account "test1"
+    And the current account has 3 "components"
+    And I use an authentication token
+    When I send a DELETE request to "/accounts/test1/components/$2"
+    Then the response status should be "403"
+    And the current account should have 3 "components"
+
+  Scenario: Read-only deletes one of their components
+    Given the current account is "test1"
+    And the current account has 1 "read-only"
+    And I am a read only of account "test1"
+    And the current account has 3 "components"
+    And I use an authentication token
+    When I send a DELETE request to "/accounts/test1/components/$2"
+    Then the response status should be "403"
+    And the current account should have 3 "components"
+
+  @ee
+  Scenario: Environment deletes one of their components
+    Given the current account is "test1"
+    And the current account has 2 isolated "webhook-endpoints"
+    And the current account has 1 isolated "environment"
+    And the current account has 1 isolated "component"
+    And I am an environment of account "test1"
+    And I use an authentication token
+    When I send a DELETE request to "/accounts/test1/components/$0?environment=isolated"
+    Then the response status should be "204"
+    And sidekiq should have 2 "webhook" jobs
+    And sidekiq should have 1 "metric" job
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: Product deletes one of their components
+    Given the current account is "test1"
+    And the current account has 2 "webhook-endpoints"
+    And the current account has 1 "product"
+    And the current account has 1 "policy" for the last "product"
+    And the current account has 1 "license" for the last "policy"
+    And the current account has 1 "machine" for the last "license"
+    And the current account has 1 "component" for the last "machine"
+    And I am a product of account "test1"
+    And I use an authentication token
+    When I send a DELETE request to "/accounts/test1/components/$0"
+    Then the response status should be "204"
+    And sidekiq should have 2 "webhook" jobs
+    And sidekiq should have 1 "metric" job
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: Product deletes a component for a different product
+    Given the current account is "test1"
+    And the current account has 2 "webhook-endpoints"
+    And the current account has 2 "products"
+    And the current account has 1 "policy" for the second "product"
+    And the current account has 1 "license" for the last "policy"
+    And the current account has 1 "machine" for the last "license"
+    And the current account has 1 "component" for the last "machine"
+    And I am a product of account "test1"
+    And I use an authentication token
+    When I send a DELETE request to "/accounts/test1/components/$0"
+    Then the response status should be "404"
+    And sidekiq should have 0 "webhook" jobs
+    And sidekiq should have 0 "metric" jobs
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: User attempts to delete a component that belongs to another user
+    Given the current account is "test1"
+    And the current account has 2 "webhook-endpoints"
+    And the current account has 3 "components"
+    And the current account has 1 "user"
+    And I am a user of account "test1"
+    And I use an authentication token
+    When I send a DELETE request to "/accounts/test1/components/$1"
+    Then the response status should be "404"
+    And the response body should be an array of 1 error
+    And the current account should have 3 "components"
+    And sidekiq should have 0 "webhook" jobs
+    And sidekiq should have 0 "metric" jobs
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: User deletes a component for their unprotected license
+    Given the current account is "test1"
+    And the current account has 1 "webhook-endpoint"
+    And the current account has 1 "policy"
+    And the first "policy" has the following attributes:
+      """
+      { "protected": false }
+      """
+    And the current account has 1 "user"
+    And the current account has 1 "license" for the last "policy"
+    And the first "license" has the following attributes:
+      """
+      { "userId": "$users[1]" }
+      """
+    And the current account has 1 "machine" for the last "license"
+    And the current account has 1 "component" for the last "machine"
+    And I am a user of account "test1"
+    And I use an authentication token
+    When I send a DELETE request to "/accounts/test1/components/$0"
+    Then the response status should be "204"
+    And the current account should have 0 "components"
+    And sidekiq should have 1 "webhook" job
+    And sidekiq should have 1 "metric" job
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: User deletes a component for their protected license
+    Given the current account is "test1"
+    And the current account has 1 "webhook-endpoint"
+    And the current account has 1 "policy"
+    And the first "policy" has the following attributes:
+      """
+      { "protected": true }
+      """
+    And the current account has 1 "user"
+    And the current account has 1 "license" for the last "policy"
+    And the first "license" has the following attributes:
+      """
+      { "userId": "$users[1]" }
+      """
+    And the current account has 1 "machine" for the last "license"
+    And the current account has 1 "component" for the last "machine"
+    And I am a user of account "test1"
+    And I use an authentication token
+    When I send a DELETE request to "/accounts/test1/components/$0"
+    Then the response status should be "403"
+    And the current account should have 1 "component"
+    And sidekiq should have 0 "webhook" jobs
+    And sidekiq should have 0 "metric" jobs
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: License deletes a component for one of their machines
+    Given the current account is "test1"
+    And the current account has 1 "webhook-endpoint"
+    And the current account has 1 "license"
+    And the current account has 3 "machines" for the last "license"
+    And the current account has 2 "components" for the last "machine"
+    And I am a license of account "test1"
+    And I use an authentication token
+    When I send a DELETE request to "/accounts/test1/components/$0"
+    Then the response status should be "204"
+    And the current account should have 1 "component"
+    And sidekiq should have 1 "webhook" job
+    And sidekiq should have 1 "metric" job
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: License deletes a component for a different license
+    Given the current account is "test1"
+    And the current account has 1 "webhook-endpoint"
+    And the current account has 1 "license"
+    And the current account has 1 "component"
+    And I am a license of account "test1"
+    And I use an authentication token
+    When I send a DELETE request to "/accounts/test1/components/$0"
+    Then the response status should be "404"
+    And the current account should have 1 "component"
+    And sidekiq should have 0 "webhook" jobs
+    And sidekiq should have 0 "metric" jobs
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: Anonymous user attempts to delete a component for their account
+    Given the current account is "test1"
+    And the current account has 2 "webhook-endpoints"
+    And the current account has 3 "components"
+    When I send a DELETE request to "/accounts/test1/components/$1"
+    Then the response status should be "401"
+    And the response body should be an array of 1 error
+    And the current account should have 3 "components"
+    And sidekiq should have 0 "webhook" jobs
+    And sidekiq should have 0 "metric" jobs
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: Admin attempts to delete a component for another account
+    Given I am an admin of account "test2"
+    But the current account is "test1"
+    And the current account has 2 "webhook-endpoints"
+    And the current account has 3 "components"
+    And I use an authentication token
+    When I send a DELETE request to "/accounts/test1/components/$1"
+    Then the response status should be "401"
+    And the response body should be an array of 1 error
+    And the current account should have 3 "components"
+    And sidekiq should have 0 "webhook" jobs
+    And sidekiq should have 0 "metric" jobs
+    And sidekiq should have 1 "request-log" job

--- a/features/api/v1/components/index.feature
+++ b/features/api/v1/components/index.feature
@@ -1,0 +1,391 @@
+@api/v1
+Feature: List machine components
+  Background:
+    Given the following "accounts" exist:
+      | Name    | Slug  |
+      | Test 1  | test1 |
+      | Test 2  | test2 |
+    And I send and accept JSON
+
+  Scenario: Endpoint should be inaccessible when account is disabled
+    Given the account "test1" is canceled
+    Given I am an admin of account "test1"
+    And the current account is "test1"
+    And the current account has 2 "components"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/components"
+    Then the response status should be "403"
+
+  Scenario: Admin retrieves all components for their account
+    Given I am an admin of account "test1"
+    And the current account is "test1"
+    And the current account has 3 "components"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/components"
+    Then the response status should be "200"
+    And the response body should be an array with 3 "components"
+    And the response should contain a valid signature header for "test1"
+
+  Scenario: Developer retrieves all components for their account
+    Given the current account is "test1"
+    And the current account has 1 "developer"
+    And I am a developer of account "test1"
+    And the current account has 3 "components"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/components"
+    Then the response status should be "200"
+
+  Scenario: Sales retrieves all components for their account
+    Given the current account is "test1"
+    And the current account has 1 "sales-agent"
+    And I am a sales agent of account "test1"
+    And the current account has 3 "components"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/components"
+    Then the response status should be "200"
+
+  Scenario: Support retrieves all components for their account
+    Given the current account is "test1"
+    And the current account has 1 "support-agent"
+    And I am a support agent of account "test1"
+    And the current account has 3 "components"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/components"
+    Then the response status should be "200"
+
+  Scenario: Read-only retrieves all components for their account
+    Given the current account is "test1"
+    And the current account has 1 "read-only"
+    And I am a read only of account "test1"
+    And the current account has 3 "components"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/components"
+    Then the response status should be "200"
+
+  Scenario: Admin retrieves a paginated list of components
+    Given I am an admin of account "test1"
+    And the current account is "test1"
+    And the current account has 20 "components"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/components?page[number]=2&page[size]=5"
+    Then the response status should be "200"
+    And the response body should be an array with 5 "components"
+
+  Scenario: Admin retrieves a paginated list of components scoped to product
+    Given I am an admin of account "test1"
+    And the current account is "test1"
+    And the current account has 2 "products"
+    And the current account has 1 "policy" for the first "product"
+    And the current account has 1 "policy" for the second "product"
+    And the current account has 1 "license" for the first "policy"
+    And the current account has 1 "license" for the second "policy"
+    And the current account has 1 "machine" for the first "license"
+    And the current account has 1 "machine" for the second "license"
+    And the current account has 9 "components" for the first "machine"
+    And the current account has 6 "components" for the second "machine"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/components?page[number]=1&page[size]=100&product=$products[1]"
+    Then the response status should be "200"
+    And the response body should be an array with 6 "components"
+    And the response body should contain the following links:
+      """
+      {
+        "self": "/v1/accounts/test1/components?page[number]=1&page[size]=100&product=$products[1]",
+        "prev": null,
+        "next": null,
+        "first": "/v1/accounts/test1/components?page[number]=1&page[size]=100&product=$products[1]",
+        "last": "/v1/accounts/test1/components?page[number]=1&page[size]=100&product=$products[1]",
+        "meta": {
+          "pages": 1,
+          "count": 6
+        }
+      }
+      """
+
+  Scenario: Admin retrieves a paginated list of components scoped to license
+    Given I am an admin of account "test1"
+    And the current account is "test1"
+    And the current account has 2 "products"
+    And the current account has 1 "policy" for the first "product"
+    And the current account has 1 "policy" for the second "product"
+    And the current account has 1 "license" for the first "policy"
+    And the current account has 1 "license" for the second "policy"
+    And the current account has 1 "machine" for the first "license"
+    And the current account has 1 "machine" for the second "license"
+    And the current account has 13 "components" for the first "machine"
+    And the current account has 4 "components" for the second "machine"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/components?page[number]=1&page[size]=100&license=$licenses[0]"
+    Then the response status should be "200"
+    And the response body should be an array with 13 "components"
+    And the response body should contain the following links:
+      """
+      {
+        "self": "/v1/accounts/test1/components?license=$licenses[0]&page[number]=1&page[size]=100",
+        "prev": null,
+        "next": null,
+        "first": "/v1/accounts/test1/components?license=$licenses[0]&page[number]=1&page[size]=100",
+        "last": "/v1/accounts/test1/components?license=$licenses[0]&page[number]=1&page[size]=100",
+        "meta": {
+          "pages": 1,
+          "count": 13
+        }
+      }
+      """
+
+  Scenario: Admin retrieves a paginated list of components scoped to machine
+    Given I am an admin of account "test1"
+    And the current account is "test1"
+    And the current account has 2 "products"
+    And the current account has 1 "policy" for the first "product"
+    And the current account has 1 "policy" for the second "product"
+    And the current account has 1 "license" for the first "policy"
+    And the current account has 1 "license" for the second "policy"
+    And the current account has 1 "machine" for the first "license"
+    And the current account has 1 "machine" for the second "license"
+    And the current account has 2 "components" for the first "machine"
+    And the current account has 14 "components" for the second "machine"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/components?page[number]=1&page[size]=10&machine=$machines[1]"
+    Then the response status should be "200"
+    And the response body should be an array with 10 "components"
+    And the response body should contain the following links:
+      """
+      {
+        "self": "/v1/accounts/test1/components?machine=$machines[1]&page[number]=1&page[size]=10",
+        "prev": null,
+        "next": "/v1/accounts/test1/components?machine=$machines[1]&page[number]=2&page[size]=10",
+        "first": "/v1/accounts/test1/components?machine=$machines[1]&page[number]=1&page[size]=10",
+        "last": "/v1/accounts/test1/components?machine=$machines[1]&page[number]=2&page[size]=10",
+        "meta": {
+          "pages": 2,
+          "count": 14
+        }
+      }
+      """
+
+  Scenario: Admin retrieves a paginated list of components scoped to user
+    Given I am an admin of account "test1"
+    And the current account is "test1"
+    And the current account has 2 "products"
+    And the current account has 1 "policy" for the first "product"
+    And the current account has 1 "policy" for the second "product"
+    And the current account has 1 "user"
+    And the current account has 1 "license" for the first "policy"
+    And the current account has 1 "license" for the second "policy"
+    And the current account has 1 "license" for the second "policy"
+    And the first "license" has the following attributes:
+      """
+      { "userId": "$users[1]" }
+      """
+    And the second "license" has the following attributes:
+      """
+      { "userId": "$users[1]" }
+      """
+    And the current account has 1 "machine" for the first "license"
+    And the current account has 1 "machine" for the second "license"
+    And the current account has 1 "machine" for the third "license"
+    And the current account has 7 "components" for the first "machine"
+    And the current account has 14 "components" for the second "machine"
+    And the current account has 4 "components" for the third "machine"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/components?page[number]=1&page[size]=10&user=$users[1]"
+    Then the response status should be "200"
+    And the response body should be an array with 10 "components"
+    And the response body should contain the following links:
+      """
+      {
+        "self": "/v1/accounts/test1/components?page[number]=1&page[size]=10&user=$users[1]",
+        "prev": null,
+        "next": "/v1/accounts/test1/components?page[number]=2&page[size]=10&user=$users[1]",
+        "first": "/v1/accounts/test1/components?page[number]=1&page[size]=10&user=$users[1]",
+        "last": "/v1/accounts/test1/components?page[number]=3&page[size]=10&user=$users[1]",
+        "meta": {
+          "pages": 3,
+          "count": 21
+        }
+      }
+      """
+
+  Scenario: Admin retrieves a paginated list of components with a page size that is too high
+    Given I am an admin of account "test1"
+    And the current account is "test1"
+    And the current account has 20 "components"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/components?page[number]=1&page[size]=250"
+    Then the response status should be "400"
+
+  Scenario: Admin retrieves a paginated list of components with a page size that is too low
+    Given I am an admin of account "test1"
+    And the current account is "test1"
+    And the current account has 20 "components"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/components?page[number]=1&page[size]=0"
+    Then the response status should be "400"
+
+  Scenario: Admin retrieves a paginated list of components with an invalid page number
+    Given I am an admin of account "test1"
+    And the current account is "test1"
+    And the current account has 20 "components"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/components?page[number]=-1&page[size]=10"
+    Then the response status should be "400"
+
+  Scenario: Admin retrieves a paginated list of components with an invalid page param
+    Given I am an admin of account "test1"
+    And the current account is "test1"
+    And the current account has 20 "components"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/components?page=1&size=100"
+    Then the response status should be "400"
+
+  Scenario: Admin retrieves all components without a limit for their account
+    Given I am an admin of account "test1"
+    And the current account is "test1"
+    And the current account has 20 "components"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/components"
+    Then the response status should be "200"
+    And the response body should be an array with 10 "components"
+
+  Scenario: Admin retrieves all components with a low limit for their account
+    Given I am an admin of account "test1"
+    And the current account is "test1"
+    And the current account has 10 "components"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/components?limit=5"
+    Then the response status should be "200"
+    And the response body should be an array with 5 "components"
+
+  Scenario: Admin retrieves all components with a high limit for their account
+    Given I am an admin of account "test1"
+    And the current account is "test1"
+    And the current account has 20 "components"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/components?limit=20"
+    Then the response status should be "200"
+    And the response body should be an array with 20 "components"
+
+  Scenario: Admin retrieves all components with a limit that is too high
+    Given I am an admin of account "test1"
+    And the current account is "test1"
+    And the current account has 2 "components"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/components?limit=900"
+    Then the response status should be "400"
+
+  Scenario: Admin retrieves all components with a limit that is too low
+    Given I am an admin of account "test1"
+    And the current account is "test1"
+    And the current account has 2 "components"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/components?limit=0"
+    Then the response status should be "400"
+
+  @ee
+  Scenario: Product retrieves all isolated components
+    Given the current account is "test1"
+    And the current account has 1 isolated "environment"
+    And the current account has 3 isolated "components"
+    And the current account has 1 shared "components"
+    And the current account has 1 global "components"
+    And I am an environment of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/components?environment=isolated"
+    Then the response status should be "200"
+    And the response body should be an array with 3 "components"
+
+  @ee
+  Scenario: Product retrieves all shared components
+    Given the current account is "test1"
+    And the current account has 1 shared "environment"
+    And the current account has 3 isolated "components"
+    And the current account has 1 shared "components"
+    And the current account has 1 global "components"
+    And I am an environment of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/components?environment=shared"
+    Then the response status should be "200"
+    And the response body should be an array with 2 "components"
+
+  Scenario: Product retrieves all components for their product
+    Given the current account is "test1"
+    And the current account has 1 "product"
+    And the current account has 1 "policy" for the last "product"
+    And the current account has 1 "license" for the last "policy"
+    And the current account has 1 "machine" for the last "license"
+    And the current account has 1 "component" for the last "machine"
+    And the current account has 5 "components"
+    And I am a product of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/components"
+    Then the response status should be "200"
+    And the response body should be an array with 1 "component"
+
+  Scenario: Admin attempts to retrieve all components for another account
+    Given I am an admin of account "test2"
+    But the current account is "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/components"
+    Then the response status should be "401"
+    And the response body should be an array of 1 error
+
+  Scenario: User attempts to retrieve all components for their group
+    Given the current account is "test1"
+    And the current account has 2 "groups"
+    And the current account has 1 "user"
+    And the current account has 1 "group-owner"
+    And the last "group-owner" has the following attributes:
+      """
+      {
+        "groupId": "$groups[0]",
+        "userId": "$users[1]"
+      }
+      """
+    And the current account has 2 "machines" for the first "group"
+    And the current account has 2 "machines" for the second "group"
+    And the current account has 3 "components" for the first "machine"
+    And the current account has 1 "component" for the second "machine"
+    And the current account has 7 "components" for the third "machine"
+    And the current account has 2 "components" for the fourth "machine"
+    And the current account has 5 "components"
+    And I am a user of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/components"
+    Then the response status should be "200"
+    And the response body should be an array with 0 "components"
+
+  Scenario: User attempts to retrieve all components for their account
+    Given the current account is "test1"
+    And the current account has 1 "user"
+    And the current account has 1 "license" for the last "user"
+    And the current account has 1 "machine" for the last "license"
+    And the current account has 3 "components" for the last "machine"
+    And the current account has 2 "components"
+    And I am a user of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/components"
+    Then the response status should be "200"
+    And the response body should be an array with 3 "components"
+
+  Scenario: License retrieves all components for their license with matches
+    Given the current account is "test1"
+    And the current account has 1 "license"
+    And the current account has 1 "machine" for the last "license"
+    And the current account has 3 "components" for the last "machine"
+    And the current account has 2 "components"
+    And I am a license of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/components"
+    Then the response status should be "200"
+    And the response body should be an array with 3 "components"
+
+  Scenario: License retrieves all components for their license with no matches
+    Given the current account is "test1"
+    And the current account has 1 "license"
+    And the current account has 5 "components"
+    And I am a license of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/components"
+    Then the response status should be "200"
+    And the response body should be an array with 0 "components"

--- a/features/api/v1/components/relationships/license.feature
+++ b/features/api/v1/components/relationships/license.feature
@@ -1,0 +1,147 @@
+@api/v1
+Feature: Component license relationship
+  Background:
+    Given the following "accounts" exist:
+      | Name    | Slug  |
+      | Test 1  | test1 |
+      | Test 2  | test2 |
+    And I send and accept JSON
+
+  Scenario: Endpoint should be inaccessible when account is disabled
+    Given the account "test1" is canceled
+    And the current account is "test1"
+    And the current account has 1 "component"
+    And I am an admin of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/components/$0/license"
+    Then the response status should be "403"
+
+  Scenario: Admin retrieves the license for a component
+    Given the current account is "test1"
+    And the current account has 3 "components"
+    And I am an admin of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/components/$0/license"
+    Then the response status should be "200"
+    And the response body should be a "license"
+    And the response should contain a valid signature header for "test1"
+
+  @ee
+  Scenario: Isolated environment retrieves the license for an isolated component
+    Given the current account is "test1"
+    And the current account has 1 isolated "environment"
+    And the current account has 1 isolated "component"
+    And I am an environment of account "test1"
+    And I use an authentication token
+    And I send the following headers:
+      """
+      { "Keygen-Environment": "isolated" }
+      """
+    When I send a GET request to "/accounts/test1/components/$0/license"
+    Then the response status should be "200"
+    And the response body should be a "license"
+
+  @ee
+  Scenario: Shared environment retrieves the license for a shared component
+    Given the current account is "test1"
+    And the current account has 1 shared "environment"
+    And the current account has 1 shared "component"
+    And I am an environment of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/components/$0/license?environment=shared"
+    Then the response status should be "200"
+    And the response body should be a "license"
+
+  @ee
+  Scenario: Shared environment retrieves the license for a global component
+    Given the current account is "test1"
+    And the current account has 1 shared "environment"
+    And the current account has 1 global "component"
+    And I am an environment of account "test1"
+    And I use an authentication token
+    And I send the following headers:
+      """
+      { "Keygen-Environment": "shared" }
+      """
+    When I send a GET request to "/accounts/test1/components/$0/license"
+    Then the response status should be "200"
+    And the response body should be a "license"
+
+  Scenario: Product retrieves the license for a component
+    Given the current account is "test1"
+    And the current account has 2 "webhook-endpoints"
+    And the current account has 1 "product"
+    And the current account has 1 "policy" for the last "product"
+    And the current account has 1 "license" for the last "policy"
+    And the current account has 1 "machine" for the last "license"
+    And the current account has 1 "component" for the last "machine"
+    And I am a product of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/components/$0/license"
+    Then the response status should be "200"
+    And the response body should be a "license"
+
+  Scenario: Product retrieves the license for a component of different product
+    Given the current account is "test1"
+    And the current account has 2 "webhook-endpoints"
+    And the current account has 1 "product"
+    And the current account has 1 "component"
+    And I am a product of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/components/$0/license"
+    Then the response status should be "404"
+
+  Scenario: User attempts to retrieve the license for a component they own
+    Given the current account is "test1"
+    And the current account has 1 "user"
+    And the current account has 1 "license" for the last "user"
+    And the current account has 1 "machine" for the last "license"
+    And the current account has 3 "components" for the last "machine"
+    And I am a user of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/components/$0/license"
+    Then the response status should be "200"
+    And the response body should be a "license"
+
+  Scenario: User attempts to retrieve the license for a component they don't own
+    Given the current account is "test1"
+    And the current account has 1 "user"
+    And the current account has 3 "components"
+    And I am a user of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/components/$0/license"
+    Then the response status should be "404"
+
+  Scenario: License attempts to retrieves the license of a component
+    Given the current account is "test1"
+    And the current account has 1 "license"
+    And the current account has 1 "machine" for the first "license"
+    And the current account has 2 "components" for the first "machine"
+    And I am a license of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/components/$1/license"
+    Then the response status should be "200"
+    And the response body should be a "license"
+
+  Scenario: License attempts to retrieve the license for a component they don't own
+    Given the current account is "test1"
+    And the current account has 1 "license"
+    And the current account has 2 "components"
+    And I am a license of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/components/$1/license"
+    Then the response status should be "404"
+
+  Scenario: Anonymous attempts to retrieve a components's license
+    Given the current account is "test1"
+    And the current account has 1 "component"
+    When I send a GET request to "/accounts/test1/components/$0/license"
+    Then the response status should be "401"
+
+  Scenario: Admin attempts to retrieve the license for a component of another account
+    Given I am an admin of account "test2"
+    And the current account is "test1"
+    And the current account has 3 "components"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/components/$0/license"
+    Then the response status should be "401"

--- a/features/api/v1/components/relationships/machine.feature
+++ b/features/api/v1/components/relationships/machine.feature
@@ -1,0 +1,147 @@
+@api/v1
+Feature: Component machine relationship
+  Background:
+    Given the following "accounts" exist:
+      | Name    | Slug  |
+      | Test 1  | test1 |
+      | Test 2  | test2 |
+    And I send and accept JSON
+
+  Scenario: Endpoint should be inaccessible when account is disabled
+    Given the account "test1" is canceled
+    Given I am an admin of account "test1"
+    And the current account is "test1"
+    And the current account has 1 "component"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/components/$0/machine"
+    Then the response status should be "403"
+
+  Scenario: Admin retrieves the machine for a component
+    Given I am an admin of account "test1"
+    And the current account is "test1"
+    And the current account has 3 "components"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/components/$0/machine"
+    Then the response status should be "200"
+    And the response body should be a "machine"
+    And the response should contain a valid signature header for "test1"
+
+  @ee
+  Scenario: Isolated environment retrieves the machine for an isolated component
+    Given the current account is "test1"
+    And the current account has 1 isolated "environment"
+    And the current account has 1 isolated "component"
+    And I am an environment of account "test1"
+    And I use an authentication token
+    And I send the following headers:
+      """
+      { "Keygen-Environment": "isolated" }
+      """
+    When I send a GET request to "/accounts/test1/components/$0/machine"
+    Then the response status should be "200"
+    And the response body should be a "machine"
+
+  @ee
+  Scenario: Shared environment retrieves the machine for a shared component
+    Given the current account is "test1"
+    And the current account has 1 shared "environment"
+    And the current account has 1 shared "component"
+    And I am an environment of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/components/$0/machine?environment=shared"
+    Then the response status should be "200"
+    And the response body should be a "machine"
+
+  @ee
+  Scenario: Shared environment retrieves the machine for a global component
+    Given the current account is "test1"
+    And the current account has 1 shared "environment"
+    And the current account has 1 global "component"
+    And I am an environment of account "test1"
+    And I use an authentication token
+    And I send the following headers:
+      """
+      { "Keygen-Environment": "shared" }
+      """
+    When I send a GET request to "/accounts/test1/components/$0/machine"
+    Then the response status should be "200"
+    And the response body should be a "machine"
+
+  Scenario: Product retrieves the machine for a component
+    Given the current account is "test1"
+    And the current account has 2 "webhook-endpoints"
+    And the current account has 1 "product"
+    And the current account has 1 "policy" for the last "product"
+    And the current account has 1 "license" for the last "policy"
+    And the current account has 1 "machine" for the last "license"
+    And the current account has 1 "component" for the last "machine"
+    And I am a product of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/components/$0/machine"
+    Then the response status should be "200"
+    And the response body should be a "machine"
+
+  Scenario: Product retrieves the machine for a component of different product
+    Given the current account is "test1"
+    And the current account has 2 "webhook-endpoints"
+    And the current account has 1 "product"
+    And the current account has 1 "component"
+    And I am a product of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/components/$0/machine"
+    Then the response status should be "404"
+
+  Scenario: User attempts to retrieve the machine for a component they own
+    Given the current account is "test1"
+    And the current account has 1 "user"
+    And the current account has 1 "license" for the last "user"
+    And the current account has 1 "machine" for the last "license"
+    And the current account has 3 "components" for the last "machine"
+    And I am a user of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/components/$0/machine"
+    Then the response status should be "200"
+    And the response body should be a "machine"
+
+  Scenario: User attempts to retrieve the machine for a component they don't own
+    Given the current account is "test1"
+    And the current account has 1 "user"
+    And the current account has 3 "components"
+    And I am a user of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/components/$0/machine"
+    Then the response status should be "404"
+
+  Scenario: License attempts to retrieves the machine of a component
+    Given the current account is "test1"
+    And the current account has 1 "license"
+    And the current account has 1 "machine" for the first "license"
+    And the current account has 2 "components" for the first "machine"
+    And I am a license of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/components/$1/machine"
+    Then the response status should be "200"
+    And the response body should be a "machine"
+
+  Scenario: License attempts to retrieve the machine for a component they don't own
+    Given the current account is "test1"
+    And the current account has 1 "license"
+    And the current account has 2 "components"
+    And I am a license of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/components/$1/machine"
+    Then the response status should be "404"
+
+  Scenario: Anonymous attempts to retrieve a components's license
+    Given the current account is "test1"
+    And the current account has 1 "component"
+    When I send a GET request to "/accounts/test1/components/$0/machine"
+    Then the response status should be "401"
+
+  Scenario: Admin attempts to retrieve the machine for a component of another account
+    Given I am an admin of account "test2"
+    And the current account is "test1"
+    And the current account has 3 "components"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/components/$0/machine"
+    Then the response status should be "401"

--- a/features/api/v1/components/relationships/product.feature
+++ b/features/api/v1/components/relationships/product.feature
@@ -1,0 +1,205 @@
+@api/v1
+Feature: Component product relationship
+  Background:
+    Given the following "accounts" exist:
+      | Name    | Slug  |
+      | Test 1  | test1 |
+      | Test 2  | test2 |
+    And I send and accept JSON
+
+  Scenario: Endpoint should be inaccessible when account is disabled
+    Given the account "test1" is canceled
+    Given I am an admin of account "test1"
+    And the current account is "test1"
+    And the current account has 1 "component"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/components/$0/product"
+    Then the response status should be "403"
+
+  Scenario: Admin retrieves the product for a component
+    Given I am an admin of account "test1"
+    And the current account is "test1"
+    And the current account has 3 "components"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/components/$0/product"
+    Then the response status should be "200"
+    And the response body should be a "product"
+    And the response should contain a valid signature header for "test1"
+
+  @ee
+  Scenario: Isolated environment retrieves the product for an isolated component
+    Given the current account is "test1"
+    And the current account has 1 isolated "environment"
+    And the current account has 1 isolated "component"
+    And I am an environment of account "test1"
+    And I use an authentication token
+    And I send the following headers:
+      """
+      { "Keygen-Environment": "isolated" }
+      """
+    When I send a GET request to "/accounts/test1/components/$0/product"
+    Then the response status should be "200"
+    And the response body should be a "product"
+
+  @ee
+  Scenario: Shared environment retrieves the product for a shared component
+    Given the current account is "test1"
+    And the current account has 1 shared "environment"
+    And the current account has 1 shared "component"
+    And I am an environment of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/components/$0/product?environment=shared"
+    Then the response status should be "200"
+    And the response body should be a "product"
+
+  @ee
+  Scenario: Shared environment retrieves the product for a global component
+    Given the current account is "test1"
+    And the current account has 1 shared "environment"
+    And the current account has 1 global "component"
+    And I am an environment of account "test1"
+    And I use an authentication token
+    And I send the following headers:
+      """
+      { "Keygen-Environment": "shared" }
+      """
+    When I send a GET request to "/accounts/test1/components/$0/product"
+    Then the response status should be "200"
+    And the response body should be a "product"
+
+  Scenario: Product retrieves the product for a component
+    Given the current account is "test1"
+    And the current account has 2 "webhook-endpoints"
+    And the current account has 1 "product"
+    And the current account has 1 "policy" for the last "product"
+    And the current account has 1 "license" for the last "policy"
+    And the current account has 1 "machine" for the last "license"
+    And the current account has 1 "component" for the last "machine"
+    And I am a product of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/components/$0/product"
+    Then the response status should be "200"
+    And the response body should be a "product"
+
+  Scenario: Product retrieves the product for a component of different product
+    Given the current account is "test1"
+    And the current account has 2 "webhook-endpoints"
+    And the current account has 1 "product"
+    And the current account has 1 "component"
+    And I am a product of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/components/$0/product"
+    Then the response status should be "404"
+
+  Scenario: User attempts to retrieve the product for a component they own (default permission)
+    Given the current account is "test1"
+    And the current account has 1 "user"
+    And the current account has 1 "license" for the last "user"
+    And the current account has 1 "machine" for the last "license"
+    And the current account has 3 "components" for the last "machine"
+    And I am a user of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/components/$0/product"
+    Then the response status should be "403"
+
+  Scenario: User attempts to retrieve the product for a component they own (has permission)
+    Given the current account is "test1"
+    And the current account has 1 "user"
+    And the current account has 1 "license" for the last "user"
+    And the current account has 1 "machine" for the last "license"
+    And the current account has 3 "components" for the last "machine"
+    And the last "user" has the following attributes:
+      """
+      { "permissions": ["product.read"] }
+      """
+    And I am a user of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/components/$0/product"
+    Then the response status should be "200"
+    And the response body should be a "product"
+
+  Scenario: User attempts to retrieve the product for a component they own (no permission)
+    Given the current account is "test1"
+    And the current account has 1 "user"
+    And the current account has 1 "license" for the last "user"
+    And the current account has 1 "machine" for the last "license"
+    And the current account has 3 "components" for the last "machine"
+    And the last "user" has the following attributes:
+      """
+      { "permissions": [] }
+      """
+    And I am a user of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/components/$0/product"
+    Then the response status should be "403"
+
+  Scenario: User attempts to retrieve the product for a component they don't own
+    Given the current account is "test1"
+    And the current account has 1 "user"
+    And the current account has 3 "components"
+    And I am a user of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/components/$0/product"
+    Then the response status should be "404"
+
+  Scenario: License attempts to retrieves the product of a component (default permission)
+    Given the current account is "test1"
+    And the current account has 1 "license"
+    And the current account has 1 "machine" for the first "license"
+    And the current account has 2 "components" for the first "machine"
+    And I am a license of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/components/$1/product"
+    Then the response status should be "403"
+
+  Scenario: License attempts to retrieves the product of a component (has permission)
+    Given the current account is "test1"
+    And the current account has 1 "license"
+    And the current account has 1 "machine" for the first "license"
+    And the current account has 2 "components" for the first "machine"
+    And the last "license" has the following attributes:
+      """
+      { "permissions": ["product.read"] }
+      """
+    And I am a license of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/components/$1/product"
+    Then the response status should be "200"
+    And the response body should be a "product"
+
+  Scenario: License attempts to retrieves the product of a component (no permission)
+    Given the current account is "test1"
+    And the current account has 1 "license"
+    And the current account has 1 "machine" for the first "license"
+    And the current account has 2 "components" for the first "machine"
+    And the last "license" has the following attributes:
+      """
+      { "permissions": [] }
+      """
+    And I am a license of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/components/$1/product"
+    Then the response status should be "403"
+
+  Scenario: License attempts to retrieve the product for a component they don't own
+    Given the current account is "test1"
+    And the current account has 1 "license"
+    And the current account has 2 "components"
+    And I am a license of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/components/$1/product"
+    Then the response status should be "404"
+
+  Scenario: Anonymous attempts to retrieve a components's license
+    Given the current account is "test1"
+    And the current account has 1 "component"
+    When I send a GET request to "/accounts/test1/components/$0/product"
+    Then the response status should be "401"
+
+  Scenario: Admin attempts to retrieve the product for a component of another account
+    Given I am an admin of account "test2"
+    And the current account is "test1"
+    And the current account has 3 "components"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/components/$0/product"
+    Then the response status should be "401"

--- a/features/api/v1/components/show.feature
+++ b/features/api/v1/components/show.feature
@@ -1,0 +1,198 @@
+@api/v1
+Feature: Show machine component
+  Background:
+    Given the following "accounts" exist:
+      | Name    | Slug  |
+      | Test 1  | test1 |
+      | Test 2  | test2 |
+    And I send and accept JSON
+
+  Scenario: Endpoint should be inaccessible when account is disabled
+    Given the account "test1" is canceled
+    Given I am an admin of account "test1"
+    And the current account is "test1"
+    And the current account has 1 "component"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/components/$0"
+    Then the response status should be "403"
+
+  Scenario: Admin retrieves a component for their account
+    Given time is frozen at "2022-10-16T14:52:48.000Z"
+    And I am an admin of account "test1"
+    And the current account is "test1"
+    And the current account has 1 "component" with the following:
+      """
+      {
+        "fingerprint": "8151c161b1f6aa75e66646ba73dbdba0",
+        "name": "CPU"
+      }
+      """
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/components/$0"
+    Then the response status should be "200"
+    And the response body should be a "component"
+    And the response should contain a valid signature header for "test1"
+    And the response body should be a "component" with the following attributes:
+      """
+      {
+        "fingerprint": "8151c161b1f6aa75e66646ba73dbdba0",
+        "name": "CPU"
+      }
+      """
+    And time is unfrozen
+
+  Scenario: Developer retrieves a component for their account
+    Given the current account is "test1"
+    And the current account has 1 "developer"
+    And I am a developer of account "test1"
+    And the current account has 3 "components"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/components/$0"
+    Then the response status should be "200"
+
+  Scenario: Sales retrieves a component for their account
+    Given the current account is "test1"
+    And the current account has 1 "sales-agent"
+    And I am a sales agent of account "test1"
+    And the current account has 3 "components"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/components/$0"
+    Then the response status should be "200"
+
+  Scenario: Support retrieves a component for their account
+    Given the current account is "test1"
+    And the current account has 1 "support-agent"
+    And I am a support agent of account "test1"
+    And the current account has 3 "components"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/components/$0"
+    Then the response status should be "200"
+
+  Scenario: Read-only retrieves a component for their account
+    Given the current account is "test1"
+    And the current account has 1 "read-only"
+    And I am a read only of account "test1"
+    And the current account has 3 "components"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/components/$0"
+    Then the response status should be "200"
+
+  Scenario: Admin retrieves an invalid component for their account
+    Given I am an admin of account "test1"
+    And the current account is "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/components/invalid"
+    Then the response status should be "404"
+    And the first error should have the following properties:
+      """
+      {
+        "title": "Not found",
+        "detail": "The requested machine component 'invalid' was not found",
+        "code": "NOT_FOUND"
+      }
+      """
+
+  @ee
+  Scenario: Environment retrieves an isolated component
+    Given the current account is "test1"
+    And the current account has 1 isolated "environment"
+    And the current account has 1 isolated "component"
+    And I am an environment of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/components/$0?environment=isolated"
+    Then the response status should be "200"
+    And the response body should be a "component"
+
+  @ee
+  Scenario: Environment retrieves a shared component
+    Given the current account is "test1"
+    And the current account has 1 shared "environment"
+    And the current account has 1 shared "component"
+    And I am an environment of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/components/$0?environment=shared"
+    Then the response status should be "200"
+    And the response body should be a "component"
+
+  @ee
+  Scenario: Environment retrieves a global component
+    Given the current account is "test1"
+    And the current account has 1 shared "environment"
+    And the current account has 1 global "component"
+    And I am an environment of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/components/$0?environment=shared"
+    Then the response status should be "200"
+    And the response body should be a "component"
+
+  Scenario: Product retrieves a component for their product
+    Given the current account is "test1"
+    And the current account has 1 "product"
+    And the current account has 1 "policy" for the last "product"
+    And the current account has 1 "license" for the last "policy"
+    And the current account has 1 "machine" for the last "license"
+    And the current account has 1 "component" for the last "machine"
+    And I am a product of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/components/$0"
+    Then the response status should be "200"
+    And the response body should be a "component"
+
+  Scenario: Product attempts to retrieve a component for another product
+    Given the current account is "test1"
+    And the current account has 1 "product"
+    And the current account has 1 "component"
+    And I am a product of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/components/$0"
+    Then the response status should be "404"
+
+  Scenario: User retrieves a component for their license
+    Given the current account is "test1"
+    And the current account has 1 "user"
+    And the current account has 1 "license" for the last "user"
+    And the current account has 1 "machine" for the last "license"
+    And the current account has 3 "components" for the last "machine"
+    And I am a user of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/components/$0"
+    Then the response status should be "200"
+    And the response body should be a "component"
+
+  Scenario: User retrieves a component for a license they don't own
+    Given the current account is "test1"
+    And the current account has 1 "user"
+    And the current account has 3 "components"
+    And I am a user of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/components/$0"
+    Then the response status should be "404"
+
+  Scenario: License retrieves a component for their license
+    Given the current account is "test1"
+    And the current account has 1 "license"
+    And the current account has 1 "machine" for the last "license"
+    And the current account has 3 "components" for the last "machine"
+    And I am a license of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/components/$0"
+    Then the response status should be "200"
+    And the response body should be a "component"
+
+  Scenario: License retrieves a component for another license
+    Given the current account is "test1"
+    And the current account has 1 "license"
+    And the current account has 1 "component"
+    And I am a license of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/components/$0"
+    Then the response status should be "404"
+
+  Scenario: Admin attempts to retrieve a component for another account
+    Given I am an admin of account "test2"
+    But the current account is "test1"
+    And the account "test1" has 3 "components"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/components/$0"
+    Then the response status should be "401"
+    And the response body should be an array of 1 error

--- a/features/api/v1/components/update.feature
+++ b/features/api/v1/components/update.feature
@@ -1,0 +1,520 @@
+@api/v1
+Feature: Update machine component
+  Background:
+    Given the following "accounts" exist:
+      | Name    | Slug  |
+      | Test 1  | test1 |
+      | Test 2  | test2 |
+    And I send and accept JSON
+
+  Scenario: Endpoint should be inaccessible when account is disabled
+    Given the account "test1" is canceled
+    And the current account is "test1"
+    And the current account has 1 "component"
+    And I am an admin of account "test1"
+    And I use an authentication token
+    When I send a PATCH request to "/accounts/test1/components/$0"
+    Then the response status should be "403"
+
+  Scenario: Admin updates a component's fingerprint
+    Given the current account is "test1"
+    And the current account has 2 "webhook-endpoints"
+    And the current account has 1 "component"
+    And I am an admin of account "test1"
+    And I use an authentication token
+    When I send a PATCH request to "/accounts/test1/components/$0" with the following:
+      """
+      {
+        "data": {
+          "type": "components",
+          "id": "$components[0].id",
+          "attributes": {
+            "fingerprint": "1bac629c32f688919eb8f81d2232a04b"
+          }
+        }
+      }
+      """
+    Then the response status should be "400"
+    And the response should contain a valid signature header for "test1"
+    And the first error should have the following properties:
+      """
+      {
+        "title": "Bad request",
+        "detail": "unpermitted parameter",
+        "source": {
+          "pointer": "/data/attributes/fingerprint"
+        }
+      }
+      """
+    And sidekiq should have 0 "webhook" jobs
+    And sidekiq should have 0 "metric" jobs
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: Admin updates a component's name
+    Given the current account is "test1"
+    And the current account has 2 "webhook-endpoints"
+    And the current account has 1 "component"
+    And I am an admin of account "test1"
+    And I use an authentication token
+    When I send a PATCH request to "/accounts/test1/components/$0" with the following:
+      """
+      {
+        "data": {
+          "type": "components",
+          "id": "$components[0].id",
+          "attributes": {
+            "name": "MAC address"
+          }
+        }
+      }
+      """
+    Then the response status should be "200"
+    And the response should contain a valid signature header for "test1"
+    And the response body should be a "component" with the following attributes:
+      """
+      { "name": "MAC address" }
+      """
+    And sidekiq should have 2 "webhook" jobs
+    And sidekiq should have 1 "metric" job
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: Admin updates a component's metadata
+    Given the current account is "test1"
+    And the current account has 2 "webhook-endpoints"
+    And the current account has 1 "component"
+    And I am an admin of account "test1"
+    And I use an authentication token
+    When I send a PATCH request to "/accounts/test1/components/$0" with the following:
+      """
+      {
+        "data": {
+          "type": "components",
+          "id": "$components[0].id",
+          "attributes": {
+            "metadata": {
+              "addit": { "mfg": "Ryzen" }
+            }
+          }
+        }
+      }
+      """
+    Then the response status should be "200"
+    And the response should contain a valid signature header for "test1"
+    And the response body should be a "component" with the following attributes:
+      """
+      {
+        "metadata": {
+          "addit": { "mfg": "Ryzen" }
+        }
+      }
+      """
+    And sidekiq should have 2 "webhook" jobs
+    And sidekiq should have 1 "metric" job
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: Developer updates a component
+    Given the current account is "test1"
+    And the current account has 2 "webhook-endpoints"
+    And the current account has 1 "component"
+    And the current account has 1 "developer"
+    And I am a developer of account "test1"
+    And I use an authentication token
+    When I send a PATCH request to "/accounts/test1/components/$0" with the following:
+      """
+      {
+        "data": {
+          "type": "components",
+          "id": "$components[0].id",
+          "attributes": {
+            "metadata": {
+              "addit": { "mfg": "Ryzen" }
+            }
+          }
+        }
+      }
+      """
+    Then the response status should be "200"
+    And the response should contain a valid signature header for "test1"
+    And sidekiq should have 2 "webhook" jobs
+    And sidekiq should have 1 "metric" job
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: Sales updates a component
+    Given the current account is "test1"
+    And the current account has 2 "webhook-endpoints"
+    And the current account has 1 "component"
+    And the current account has 1 "sales-agent"
+    And I am a sales agent of account "test1"
+    And I use an authentication token
+    When I send a PATCH request to "/accounts/test1/components/$0" with the following:
+      """
+      {
+        "data": {
+          "type": "components",
+          "id": "$components[0].id",
+          "attributes": {
+            "metadata": {
+              "addit": { "mfg": "Ryzen" }
+            }
+          }
+        }
+      }
+      """
+    Then the response status should be "200"
+    And the response should contain a valid signature header for "test1"
+    And sidekiq should have 2 "webhook" jobs
+    And sidekiq should have 1 "metric" job
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: Support updates a component
+    Given the current account is "test1"
+    And the current account has 2 "webhook-endpoints"
+    And the current account has 1 "component"
+    And the current account has 1 "support-agent"
+    And I am a support agent of account "test1"
+    And I use an authentication token
+    When I send a PATCH request to "/accounts/test1/components/$0" with the following:
+      """
+      {
+        "data": {
+          "type": "components",
+          "id": "$components[0].id",
+          "attributes": {
+            "metadata": {
+              "addit": { "mfg": "Ryzen" }
+            }
+          }
+        }
+      }
+      """
+    Then the response status should be "200"
+    And the response should contain a valid signature header for "test1"
+    And sidekiq should have 2 "webhook" jobs
+    And sidekiq should have 1 "metric" job
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: Read only updates a component
+    Given the current account is "test1"
+    And the current account has 2 "webhook-endpoints"
+    And the current account has 1 "component"
+    And the current account has 1 "read-only"
+    And I am a read only of account "test1"
+    And I use an authentication token
+    When I send a PATCH request to "/accounts/test1/components/$0" with the following:
+      """
+      {
+        "data": {
+          "type": "components",
+          "id": "$components[0].id",
+          "attributes": {
+            "metadata": {
+              "addit": { "mfg": "Ryzen" }
+            }
+          }
+        }
+      }
+      """
+    Then the response status should be "403"
+    And the response should contain a valid signature header for "test1"
+    And sidekiq should have 0 "webhook" jobs
+    And sidekiq should have 0 "metric" jobs
+    And sidekiq should have 1 "request-log" job
+
+  @ee
+  Scenario: Environment updates an isolated component
+    Given the current account is "test1"
+    And the current account has 1 isolated "webhook-endpoint"
+    And the current account has 1 isolated "environment"
+    And the current account has 1 isolated "component"
+    And I am an environment of account "test1"
+    And I use an authentication token
+    And I send the following headers:
+      """
+      { "keygen-environment": "isolated" }
+      """
+    When I send a PATCH request to "/accounts/test1/components/$0" with the following:
+      """
+      {
+        "data": {
+          "type": "components",
+          "attributes": {
+            "metadata": { "name": "Isolated Process" }
+          }
+        }
+      }
+      """
+    Then the response status should be "200"
+    And the response body should be a "component" with the following attributes:
+      """
+      { "metadata": { "name": "Isolated Process" } }
+      """
+    And the response should contain a valid signature header for "test1"
+    And the response should contain the following headers:
+      """
+      { "Keygen-Environment": "isolated" }
+      """
+    And sidekiq should have 1 "webhook" job
+    And sidekiq should have 1 "metric" job
+    And sidekiq should have 1 "request-log" job
+
+  @ee
+  Scenario: Environment updates a shared component
+    Given the current account is "test1"
+    And the current account has 1 shared "webhook-endpoint"
+    And the current account has 1 shared "environment"
+    And the current account has 1 shared "component"
+    And I am an environment of account "test1"
+    And I use an authentication token
+    And I send the following headers:
+      """
+      { "keygen-environment": "shared" }
+      """
+    When I send a PATCH request to "/accounts/test1/components/$0" with the following:
+      """
+      {
+        "data": {
+          "type": "components",
+          "attributes": {
+            "metadata": { "name": "Shared Process" }
+          }
+        }
+      }
+      """
+    Then the response status should be "200"
+    And the response body should be a "component" with the following attributes:
+      """
+      { "metadata": { "name": "Shared Process" } }
+      """
+    And the response should contain a valid signature header for "test1"
+    And the response should contain the following headers:
+      """
+      { "Keygen-Environment": "shared" }
+      """
+    And sidekiq should have 1 "webhook" job
+    And sidekiq should have 1 "metric" job
+    And sidekiq should have 1 "request-log" job
+
+  @ee
+  Scenario: Environment updates a global component
+    Given the current account is "test1"
+    And the current account has 1 shared "webhook-endpoint"
+    And the current account has 1 shared "environment"
+    And the current account has 1 global "component"
+    And I am an environment of account "test1"
+    And I use an authentication token
+    And I send the following headers:
+      """
+      { "keygen-environment": "shared" }
+      """
+    When I send a PATCH request to "/accounts/test1/components/$0" with the following:
+      """
+      {
+        "data": {
+          "type": "components",
+          "attributes": {
+            "metadata": { "name": "Global Process" }
+          }
+        }
+      }
+      """
+    Then the response status should be "403"
+    And the response should contain a valid signature header for "test1"
+    And the response should contain the following headers:
+      """
+      { "Keygen-Environment": "shared" }
+      """
+    And sidekiq should have 0 "webhook" jobs
+    And sidekiq should have 0 "metric" jobs
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: Product updates a component
+    Given the current account is "test1"
+    And the current account has 1 "webhook-endpoint"
+    And the current account has 1 "product"
+    And the current account has 1 "policy" for the last "product"
+    And the current account has 1 "license" for the last "policy"
+    And the current account has 1 "machine" for the last "license"
+    And the current account has 1 "component" for the last "machine"
+    And I am a product of account "test1"
+    And I use an authentication token
+    When I send a PATCH request to "/accounts/test1/components/$0" with the following:
+      """
+      {
+        "data": {
+          "type": "components",
+          "id": "$components[0].id",
+          "attributes": {
+            "metadata": {
+              "addit": { "mfg": "Ryzen" }
+            }
+          }
+        }
+      }
+      """
+    Then the response status should be "200"
+    And the response should contain a valid signature header for "test1"
+    And sidekiq should have 1 "webhook" job
+    And sidekiq should have 1 "metric" job
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: Product updates a component for a different product
+    Given the current account is "test1"
+    And the current account has 1 "webhook-endpoint"
+    And the current account has 1 "product"
+    And the current account has 1 "component"
+    And I am a product of account "test1"
+    And I use an authentication token
+    When I send a PATCH request to "/accounts/test1/components/$0" with the following:
+      """
+      {
+        "data": {
+          "type": "components",
+          "id": "$components[0].id",
+          "attributes": {
+            "metadata": {
+              "addit": { "mfg": "Ryzen" }
+            }
+          }
+        }
+      }
+      """
+    Then the response status should be "404"
+    And the response should contain a valid signature header for "test1"
+    And sidekiq should have 0 "webhook" jobs
+    And sidekiq should have 0 "metric" jobs
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: License updates a component's metadata
+    Given the current account is "test1"
+    And the current account has 1 "webhook-endpoint"
+    And the current account has 1 "license"
+    And the current account has 1 "machine" for the last "license"
+    And the current account has 1 "component" for the last "machine"
+    And I am a license of account "test1"
+    And I use an authentication token
+    When I send a PATCH request to "/accounts/test1/components/$0" with the following:
+      """
+      {
+        "data": {
+          "type": "components",
+          "id": "$components[0].id",
+          "attributes": {
+            "metadata": {
+              "addit": { "mfg": "Ryzen" }
+            }
+          }
+        }
+      }
+      """
+    Then the response status should be "400"
+    And the response should contain a valid signature header for "test1"
+    And sidekiq should have 0 "webhook" jobs
+    And sidekiq should have 0 "metric" jobs
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: License updates a component for a different license
+    Given the current account is "test1"
+    And the current account has 1 "webhook-endpoint"
+    And the current account has 1 "license"
+    And the current account has 1 "component"
+    And I am a license of account "test1"
+    And I use an authentication token
+    When I send a PATCH request to "/accounts/test1/components/$0" with the following:
+      """
+      {
+        "data": {
+          "type": "components",
+          "id": "$components[0].id",
+          "attributes": {
+            "metadata": {
+              "addit": { "mfg": "Ryzen" }
+            }
+          }
+        }
+      }
+      """
+    Then the response status should be "404"
+    And the response should contain a valid signature header for "test1"
+    And sidekiq should have 0 "webhook" jobs
+    And sidekiq should have 0 "metric" jobs
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: User updates a component's metadata
+    Given the current account is "test1"
+    And the current account has 1 "webhook-endpoint"
+    And the current account has 1 "user"
+    And the current account has 1 "license" for the last "user"
+    And the current account has 1 "machine" for the last "license"
+    And the current account has 1 "component" for the last "machine"
+    And I am a user of account "test1"
+    And I use an authentication token
+    When I send a PATCH request to "/accounts/test1/components/$0" with the following:
+      """
+      {
+        "data": {
+          "type": "components",
+          "id": "$components[0].id",
+          "attributes": {
+            "metadata": {
+              "addit": { "mfg": "Ryzen" }
+            }
+          }
+        }
+      }
+      """
+    Then the response status should be "400"
+    And the response should contain a valid signature header for "test1"
+    And sidekiq should have 0 "webhook" jobs
+    And sidekiq should have 0 "metric" jobs
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: User updates a component for a different user
+    Given the current account is "test1"
+    And the current account has 1 "webhook-endpoint"
+    And the current account has 1 "user"
+    And the current account has 1 "component"
+    And I am a user of account "test1"
+    And I use an authentication token
+    When I send a PATCH request to "/accounts/test1/components/$0" with the following:
+      """
+      {
+        "data": {
+          "type": "components",
+          "id": "$components[0].id",
+          "attributes": {
+            "metadata": {
+              "addit": { "mfg": "Ryzen" }
+            }
+          }
+        }
+      }
+      """
+    Then the response status should be "404"
+    And the response should contain a valid signature header for "test1"
+    And sidekiq should have 0 "webhook" jobs
+    And sidekiq should have 0 "metric" jobs
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: Anonymous updates a component
+    Given the current account is "test1"
+    And the current account has 1 "webhook-endpoint"
+    And the current account has 1 "component"
+    When I send a PATCH request to "/accounts/test1/components/$0" with the following:
+      """
+      {
+        "data": {
+          "type": "components",
+          "id": "$components[0].id",
+          "attributes": {
+            "metadata": {
+              "addit": { "mfg": "Ryzen" }
+            }
+          }
+        }
+      }
+      """
+    Then the response status should be "401"
+    And the response should contain a valid signature header for "test1"
+    And sidekiq should have 0 "webhook" jobs
+    And sidekiq should have 0 "metric" jobs
+    And sidekiq should have 1 "request-log" job

--- a/features/api/v1/licenses/actions/validations.feature
+++ b/features/api/v1/licenses/actions/validations.feature
@@ -10515,3 +10515,730 @@ Feature: License validation actions
     And sidekiq should have 0 "webhook" jobs
     And sidekiq should have 0 "metric" jobs
     And sidekiq should have 1 "request-log" job
+
+  Scenario: Anonymous validates a valid license key scoped to an array of valid components (matching strategy: MATCH_ANY)
+    Given the current account is "test1"
+    And the current account has 1 "webhook-endpoint"
+    And the current account has 2 "products"
+    And the current account has 1 "policy" for the last "product" with the following:
+      """
+      { "fingerprintMatchingStrategy": "MATCH_ANY" }
+      """
+    And the current account has 1 "license" for the last "policy" with the following:
+      """
+      { "key": "component-key" }
+      """
+    And the current account has 3 "machines" for the last "license"
+    And the current account has 3 "components" for each "machine"
+    When I send a POST request to "/accounts/test1/licenses/actions/validate-key" with the following:
+      """
+      {
+        "meta": {
+          "key": "component-key",
+          "scope": {
+            "fingerprint": "$machines[0].fingerprint",
+            "components": [
+              "$components[0].fingerprint",
+              "$components[1].fingerprint",
+              "$components[2].fingerprint"
+            ]
+          }
+        }
+      }
+      """
+    Then the response status should be "200"
+    And the response should contain a valid signature header for "test1"
+    And the response body should contain a "license"
+    And the response body should contain meta which includes the following:
+      """
+      { "valid": true, "detail": "is valid", "code": "VALID" }
+      """
+    And sidekiq should have 1 "webhook" job
+    And sidekiq should have 1 "metric" job
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: Anonymous validates a valid license key scoped to an array of majority valid components (matching strategy: MATCH_ANY)
+    Given the current account is "test1"
+    And the current account has 1 "webhook-endpoint"
+    And the current account has 2 "products"
+    And the current account has 1 "policy" for the last "product" with the following:
+      """
+      { "fingerprintMatchingStrategy": "MATCH_ANY" }
+      """
+    And the current account has 1 "license" for the last "policy" with the following:
+      """
+      { "key": "component-key" }
+      """
+    And the current account has 3 "machines" for the last "license"
+    And the current account has 3 "components" for each "machine"
+    When I send a POST request to "/accounts/test1/licenses/actions/validate-key" with the following:
+      """
+      {
+        "meta": {
+          "key": "component-key",
+          "scope": {
+            "fingerprint": "$machines[0].fingerprint",
+            "components": [
+              "$components[0].fingerprint",
+              "$components[1].fingerprint",
+              "bar"
+            ]
+          }
+        }
+      }
+      """
+    Then the response status should be "200"
+    And the response should contain a valid signature header for "test1"
+    And the response body should contain a "license"
+    And the response body should contain meta which includes the following:
+      """
+      { "valid": true, "detail": "is valid", "code": "VALID" }
+      """
+    And sidekiq should have 1 "webhook" job
+    And sidekiq should have 1 "metric" job
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: Anonymous validates a valid license key scoped to an array of invalid components (matching strategy: MATCH_ANY)
+    Given the current account is "test1"
+    And the current account has 1 "webhook-endpoint"
+    And the current account has 2 "products"
+    And the current account has 1 "policy" for the last "product" with the following:
+      """
+      { "fingerprintMatchingStrategy": "MATCH_ANY" }
+      """
+    And the current account has 1 "license" for the last "policy" with the following:
+      """
+      { "key": "component-key" }
+      """
+    And the current account has 3 "machines" for the last "license"
+    And the current account has 3 "components" for each "machine"
+    When I send a POST request to "/accounts/test1/licenses/actions/validate-key" with the following:
+      """
+      {
+        "meta": {
+          "key": "component-key",
+          "scope": {
+            "fingerprint": "$machines[0].fingerprint",
+            "components": [
+              "foo",
+              "bar",
+              "baz"
+            ]
+          }
+        }
+      }
+      """
+    Then the response status should be "200"
+    And the response should contain a valid signature header for "test1"
+    And the response body should contain a "license"
+    And the response body should contain meta which includes the following:
+      """
+      { "valid": false, "detail": "one or more component is not activated (does not match any associated components)", "code": "COMPONENTS_SCOPE_MISMATCH" }
+      """
+    And sidekiq should have 1 "webhook" job
+    And sidekiq should have 1 "metric" job
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: Anonymous validates a valid license key scoped to an array of majority invalid components (matching strategy: MATCH_ANY)
+    Given the current account is "test1"
+    And the current account has 1 "webhook-endpoint"
+    And the current account has 2 "products"
+    And the current account has 1 "policy" for the last "product" with the following:
+      """
+      { "fingerprintMatchingStrategy": "MATCH_ANY" }
+      """
+    And the current account has 1 "license" for the last "policy" with the following:
+      """
+      { "key": "component-key" }
+      """
+    And the current account has 3 "machines" for the last "license"
+    And the current account has 3 "components" for each "machine"
+    When I send a POST request to "/accounts/test1/licenses/actions/validate-key" with the following:
+      """
+      {
+        "meta": {
+          "key": "component-key",
+          "scope": {
+            "fingerprint": "$machines[0].fingerprint",
+            "components": [
+              "$components[0].fingerprint",
+              "foo",
+              "bar"
+            ]
+          }
+        }
+      }
+      """
+    Then the response status should be "200"
+    And the response should contain a valid signature header for "test1"
+    And the response body should contain a "license"
+    And the response body should contain meta which includes the following:
+      """
+      { "valid": true, "detail": "is valid", "code": "VALID" }
+      """
+    And sidekiq should have 1 "webhook" job
+    And sidekiq should have 1 "metric" job
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: Anonymous validates a valid license key scoped to an array of misassociated components (matching strategy: MATCH_ANY)
+    Given the current account is "test1"
+    And the current account has 1 "webhook-endpoint"
+    And the current account has 2 "products"
+    And the current account has 1 "policy" for the last "product" with the following:
+      """
+      { "fingerprintMatchingStrategy": "MATCH_ANY" }
+      """
+    And the current account has 1 "license" for the last "policy" with the following:
+      """
+      { "key": "component-key" }
+      """
+    And the current account has 3 "machines" for the last "license"
+    And the current account has 3 "components" for each "machine"
+    When I send a POST request to "/accounts/test1/licenses/actions/validate-key" with the following:
+      """
+      {
+        "meta": {
+          "key": "component-key",
+          "scope": {
+            "fingerprint": "$machines[0].fingerprint",
+            "components": [
+              "$components[3].fingerprint",
+              "$components[4].fingerprint",
+              "$components[5].fingerprint"
+            ]
+          }
+        }
+      }
+      """
+    Then the response status should be "200"
+    And the response should contain a valid signature header for "test1"
+    And the response body should contain a "license"
+    And the response body should contain meta which includes the following:
+      """
+      { "valid": false, "detail": "one or more component is not activated (does not match any associated components)", "code": "COMPONENTS_SCOPE_MISMATCH" }
+      """
+    And sidekiq should have 1 "webhook" job
+    And sidekiq should have 1 "metric" job
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: Anonymous validates a valid license key scoped to an array of valid components (matching strategy: MATCH_MOST)
+    Given the current account is "test1"
+    And the current account has 1 "webhook-endpoint"
+    And the current account has 2 "products"
+    And the current account has 1 "policy" for the last "product" with the following:
+      """
+      { "fingerprintMatchingStrategy": "MATCH_MOST" }
+      """
+    And the current account has 1 "license" for the last "policy" with the following:
+      """
+      { "key": "component-key" }
+      """
+    And the current account has 3 "machines" for the last "license"
+    And the current account has 3 "components" for each "machine"
+    When I send a POST request to "/accounts/test1/licenses/actions/validate-key" with the following:
+      """
+      {
+        "meta": {
+          "key": "component-key",
+          "scope": {
+            "fingerprint": "$machines[0].fingerprint",
+            "components": [
+              "$components[0].fingerprint",
+              "$components[1].fingerprint",
+              "$components[2].fingerprint"
+            ]
+          }
+        }
+      }
+      """
+    Then the response status should be "200"
+    And the response should contain a valid signature header for "test1"
+    And the response body should contain a "license"
+    And the response body should contain meta which includes the following:
+      """
+      { "valid": true, "detail": "is valid", "code": "VALID" }
+      """
+    And sidekiq should have 1 "webhook" job
+    And sidekiq should have 1 "metric" job
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: Anonymous validates a valid license key scoped to an array of majority valid components (matching strategy: MATCH_MOST)
+    Given the current account is "test1"
+    And the current account has 1 "webhook-endpoint"
+    And the current account has 2 "products"
+    And the current account has 1 "policy" for the last "product" with the following:
+      """
+      { "fingerprintMatchingStrategy": "MATCH_MOST" }
+      """
+    And the current account has 1 "license" for the last "policy" with the following:
+      """
+      { "key": "component-key" }
+      """
+    And the current account has 3 "machines" for the last "license"
+    And the current account has 3 "components" for each "machine"
+    When I send a POST request to "/accounts/test1/licenses/actions/validate-key" with the following:
+      """
+      {
+        "meta": {
+          "key": "component-key",
+          "scope": {
+            "fingerprint": "$machines[0].fingerprint",
+            "components": [
+              "$components[0].fingerprint",
+              "$components[1].fingerprint",
+              "bar"
+            ]
+          }
+        }
+      }
+      """
+    Then the response status should be "200"
+    And the response should contain a valid signature header for "test1"
+    And the response body should contain a "license"
+    And the response body should contain meta which includes the following:
+      """
+      { "valid": true, "detail": "is valid", "code": "VALID" }
+      """
+    And sidekiq should have 1 "webhook" job
+    And sidekiq should have 1 "metric" job
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: Anonymous validates a valid license key scoped to an array of invalid components (matching strategy: MATCH_MOST)
+    Given the current account is "test1"
+    And the current account has 1 "webhook-endpoint"
+    And the current account has 2 "products"
+    And the current account has 1 "policy" for the last "product" with the following:
+      """
+      { "fingerprintMatchingStrategy": "MATCH_MOST" }
+      """
+    And the current account has 1 "license" for the last "policy" with the following:
+      """
+      { "key": "component-key" }
+      """
+    And the current account has 3 "machines" for the last "license"
+    And the current account has 3 "components" for each "machine"
+    When I send a POST request to "/accounts/test1/licenses/actions/validate-key" with the following:
+      """
+      {
+        "meta": {
+          "key": "component-key",
+          "scope": {
+            "fingerprint": "$machines[0].fingerprint",
+            "components": [
+              "foo",
+              "bar",
+              "baz"
+            ]
+          }
+        }
+      }
+      """
+    Then the response status should be "200"
+    And the response should contain a valid signature header for "test1"
+    And the response body should contain a "license"
+    And the response body should contain meta which includes the following:
+      """
+      { "valid": false, "detail": "one or more component is not activated (does not match enough associated components)", "code": "COMPONENTS_SCOPE_MISMATCH" }
+      """
+    And sidekiq should have 1 "webhook" job
+    And sidekiq should have 1 "metric" job
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: Anonymous validates a valid license key scoped to an array of majority invalid components (matching strategy: MATCH_MOST)
+    Given the current account is "test1"
+    And the current account has 1 "webhook-endpoint"
+    And the current account has 2 "products"
+    And the current account has 1 "policy" for the last "product" with the following:
+      """
+      { "fingerprintMatchingStrategy": "MATCH_MOST" }
+      """
+    And the current account has 1 "license" for the last "policy" with the following:
+      """
+      { "key": "component-key" }
+      """
+    And the current account has 3 "machines" for the last "license"
+    And the current account has 3 "components" for each "machine"
+    When I send a POST request to "/accounts/test1/licenses/actions/validate-key" with the following:
+      """
+      {
+        "meta": {
+          "key": "component-key",
+          "scope": {
+            "fingerprint": "$machines[0].fingerprint",
+            "components": [
+              "$components[0].fingerprint",
+              "foo",
+              "bar"
+            ]
+          }
+        }
+      }
+      """
+    Then the response status should be "200"
+    And the response should contain a valid signature header for "test1"
+    And the response body should contain a "license"
+    And the response body should contain meta which includes the following:
+      """
+      { "valid": false, "detail": "one or more component is not activated (does not match enough associated components)", "code": "COMPONENTS_SCOPE_MISMATCH" }
+      """
+    And sidekiq should have 1 "webhook" job
+    And sidekiq should have 1 "metric" job
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: Anonymous validates a valid license key scoped to an array of misassociated components (matching strategy: MATCH_MOST)
+    Given the current account is "test1"
+    And the current account has 1 "webhook-endpoint"
+    And the current account has 2 "products"
+    And the current account has 1 "policy" for the last "product" with the following:
+      """
+      { "fingerprintMatchingStrategy": "MATCH_MOST" }
+      """
+    And the current account has 1 "license" for the last "policy" with the following:
+      """
+      { "key": "component-key" }
+      """
+    And the current account has 3 "machines" for the last "license"
+    And the current account has 3 "components" for each "machine"
+    When I send a POST request to "/accounts/test1/licenses/actions/validate-key" with the following:
+      """
+      {
+        "meta": {
+          "key": "component-key",
+          "scope": {
+            "fingerprint": "$machines[0].fingerprint",
+            "components": [
+              "$components[3].fingerprint",
+              "$components[4].fingerprint",
+              "$components[5].fingerprint"
+            ]
+          }
+        }
+      }
+      """
+    Then the response status should be "200"
+    And the response should contain a valid signature header for "test1"
+    And the response body should contain a "license"
+    And the response body should contain meta which includes the following:
+      """
+      { "valid": false, "detail": "one or more component is not activated (does not match enough associated components)", "code": "COMPONENTS_SCOPE_MISMATCH" }
+      """
+    And sidekiq should have 1 "webhook" job
+    And sidekiq should have 1 "metric" job
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: Anonymous validates a valid license key scoped to an array of valid components (matching strategy: MATCH_ALL)
+    Given the current account is "test1"
+    And the current account has 1 "webhook-endpoint"
+    And the current account has 2 "products"
+    And the current account has 1 "policy" for the last "product" with the following:
+      """
+      { "fingerprintMatchingStrategy": "MATCH_ALL" }
+      """
+    And the current account has 1 "license" for the last "policy" with the following:
+      """
+      { "key": "component-key" }
+      """
+    And the current account has 3 "machines" for the last "license"
+    And the current account has 3 "components" for each "machine"
+    When I send a POST request to "/accounts/test1/licenses/actions/validate-key" with the following:
+      """
+      {
+        "meta": {
+          "key": "component-key",
+          "scope": {
+            "fingerprint": "$machines[0].fingerprint",
+            "components": [
+              "$components[0].fingerprint",
+              "$components[1].fingerprint",
+              "$components[2].fingerprint"
+            ]
+          }
+        }
+      }
+      """
+    Then the response status should be "200"
+    And the response should contain a valid signature header for "test1"
+    And the response body should contain a "license"
+    And the response body should contain meta which includes the following:
+      """
+      { "valid": true, "detail": "is valid", "code": "VALID" }
+      """
+    And sidekiq should have 1 "webhook" job
+    And sidekiq should have 1 "metric" job
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: Anonymous validates a valid license key scoped to an array of majority valid components (matching strategy: MATCH_ALL)
+    Given the current account is "test1"
+    And the current account has 1 "webhook-endpoint"
+    And the current account has 2 "products"
+    And the current account has 1 "policy" for the last "product" with the following:
+      """
+      { "fingerprintMatchingStrategy": "MATCH_ALL" }
+      """
+    And the current account has 1 "license" for the last "policy" with the following:
+      """
+      { "key": "component-key" }
+      """
+    And the current account has 3 "machines" for the last "license"
+    And the current account has 3 "components" for each "machine"
+    When I send a POST request to "/accounts/test1/licenses/actions/validate-key" with the following:
+      """
+      {
+        "meta": {
+          "key": "component-key",
+          "scope": {
+            "fingerprint": "$machines[0].fingerprint",
+            "components": [
+              "$components[0].fingerprint",
+              "$components[1].fingerprint",
+              "bar"
+            ]
+          }
+        }
+      }
+      """
+    Then the response status should be "200"
+    And the response should contain a valid signature header for "test1"
+    And the response body should contain a "license"
+    And the response body should contain meta which includes the following:
+      """
+      { "valid": false, "detail": "one or more component is not activated (does not match all associated components)", "code": "COMPONENTS_SCOPE_MISMATCH" }
+      """
+    And sidekiq should have 1 "webhook" job
+    And sidekiq should have 1 "metric" job
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: Anonymous validates a valid license key scoped to an array of invalid components (matching strategy: MATCH_ALL)
+    Given the current account is "test1"
+    And the current account has 1 "webhook-endpoint"
+    And the current account has 2 "products"
+    And the current account has 1 "policy" for the last "product" with the following:
+      """
+      { "fingerprintMatchingStrategy": "MATCH_ALL" }
+      """
+    And the current account has 1 "license" for the last "policy" with the following:
+      """
+      { "key": "component-key" }
+      """
+    And the current account has 3 "machines" for the last "license"
+    And the current account has 3 "components" for each "machine"
+    When I send a POST request to "/accounts/test1/licenses/actions/validate-key" with the following:
+      """
+      {
+        "meta": {
+          "key": "component-key",
+          "scope": {
+            "fingerprint": "$machines[0].fingerprint",
+            "components": [
+              "foo",
+              "bar",
+              "baz"
+            ]
+          }
+        }
+      }
+      """
+    Then the response status should be "200"
+    And the response should contain a valid signature header for "test1"
+    And the response body should contain a "license"
+    And the response body should contain meta which includes the following:
+      """
+      { "valid": false, "detail": "one or more component is not activated (does not match all associated components)", "code": "COMPONENTS_SCOPE_MISMATCH" }
+      """
+    And sidekiq should have 1 "webhook" job
+    And sidekiq should have 1 "metric" job
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: Anonymous validates a valid license key scoped to an array of majority invalid components (matching strategy: MATCH_ALL)
+    Given the current account is "test1"
+    And the current account has 1 "webhook-endpoint"
+    And the current account has 2 "products"
+    And the current account has 1 "policy" for the last "product" with the following:
+      """
+      { "fingerprintMatchingStrategy": "MATCH_ALL" }
+      """
+    And the current account has 1 "license" for the last "policy" with the following:
+      """
+      { "key": "component-key" }
+      """
+    And the current account has 3 "machines" for the last "license"
+    And the current account has 3 "components" for each "machine"
+    When I send a POST request to "/accounts/test1/licenses/actions/validate-key" with the following:
+      """
+      {
+        "meta": {
+          "key": "component-key",
+          "scope": {
+            "fingerprint": "$machines[0].fingerprint",
+            "components": [
+              "$components[0].fingerprint",
+              "foo",
+              "bar"
+            ]
+          }
+        }
+      }
+      """
+    Then the response status should be "200"
+    And the response should contain a valid signature header for "test1"
+    And the response body should contain a "license"
+    And the response body should contain meta which includes the following:
+      """
+      { "valid": false, "detail": "one or more component is not activated (does not match all associated components)", "code": "COMPONENTS_SCOPE_MISMATCH" }
+      """
+    And sidekiq should have 1 "webhook" job
+    And sidekiq should have 1 "metric" job
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: Anonymous validates a valid license key scoped to an array of misassociated components (matching strategy: MATCH_ALL)
+    Given the current account is "test1"
+    And the current account has 1 "webhook-endpoint"
+    And the current account has 2 "products"
+    And the current account has 1 "policy" for the last "product" with the following:
+      """
+      { "fingerprintMatchingStrategy": "MATCH_ALL" }
+      """
+    And the current account has 1 "license" for the last "policy" with the following:
+      """
+      { "key": "component-key" }
+      """
+    And the current account has 3 "machines" for the last "license"
+    And the current account has 3 "components" for each "machine"
+    When I send a POST request to "/accounts/test1/licenses/actions/validate-key" with the following:
+      """
+      {
+        "meta": {
+          "key": "component-key",
+          "scope": {
+            "fingerprint": "$machines[0].fingerprint",
+            "components": [
+              "$components[3].fingerprint",
+              "$components[4].fingerprint",
+              "$components[5].fingerprint"
+            ]
+          }
+        }
+      }
+      """
+    Then the response status should be "200"
+    And the response should contain a valid signature header for "test1"
+    And the response body should contain a "license"
+    And the response body should contain meta which includes the following:
+      """
+      { "valid": false, "detail": "one or more component is not activated (does not match all associated components)", "code": "COMPONENTS_SCOPE_MISMATCH" }
+      """
+    And sidekiq should have 1 "webhook" job
+    And sidekiq should have 1 "metric" job
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: Anonymous validates a valid license key scoped to an array of components without a fingerprint scope
+    Given the current account is "test1"
+    And the current account has 1 "webhook-endpoint"
+    And the current account has 2 "products"
+    And the current account has 1 "policy" for the last "product"
+    And the current account has 1 "license" for the last "policy" with the following:
+      """
+      { "key": "component-key" }
+      """
+    And the current account has 3 "machines" for the last "license"
+    And the current account has 3 "components" for each "machine"
+    When I send a POST request to "/accounts/test1/licenses/actions/validate-key" with the following:
+      """
+      {
+        "meta": {
+          "key": "component-key",
+          "scope": {
+            "components": [
+              "$components[0].fingerprint",
+              "$components[1].fingerprint",
+              "$components[2].fingerprint"
+            ]
+          }
+        }
+      }
+      """
+    Then the response status should be "200"
+    And the response should contain a valid signature header for "test1"
+    And the response body should contain a "license"
+    And the response body should contain meta which includes the following:
+      """
+      { "valid": false, "detail": "fingerprint scope is required when using the components scope", "code": "FINGERPRINT_SCOPE_REQUIRED" }
+      """
+    And sidekiq should have 1 "webhook" job
+    And sidekiq should have 1 "metric" job
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: Anonymous validates a valid license key scoped to an array of components with a fingerprints scope
+    Given the current account is "test1"
+    And the current account has 1 "webhook-endpoint"
+    And the current account has 2 "products"
+    And the current account has 1 "policy" for the last "product"
+    And the current account has 1 "license" for the last "policy" with the following:
+      """
+      { "key": "component-key" }
+      """
+    And the current account has 3 "machines" for the last "license"
+    And the current account has 3 "components" for each "machine"
+    When I send a POST request to "/accounts/test1/licenses/actions/validate-key" with the following:
+      """
+      {
+        "meta": {
+          "key": "component-key",
+          "scope": {
+            "fingerprints": ["$machines[0].fingerprint"],
+            "components": [
+              "$components[0].fingerprint",
+              "$components[1].fingerprint",
+              "$components[2].fingerprint"
+            ]
+          }
+        }
+      }
+      """
+    Then the response status should be "200"
+    And the response should contain a valid signature header for "test1"
+    And the response body should contain a "license"
+    And the response body should contain meta which includes the following:
+      """
+      { "valid": false, "detail": "fingerprint scope is required when using the components scope", "code": "FINGERPRINT_SCOPE_REQUIRED" }
+      """
+    And sidekiq should have 1 "webhook" job
+    And sidekiq should have 1 "metric" job
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: Anonymous validates a valid license key scoped to an array of components with an invalid fingerprint
+    Given the current account is "test1"
+    And the current account has 1 "webhook-endpoint"
+    And the current account has 2 "products"
+    And the current account has 1 "policy" for the last "product"
+    And the current account has 1 "license" for the last "policy" with the following:
+      """
+      { "key": "component-key" }
+      """
+    And the current account has 1 "machine" for the last "license"
+    When I send a POST request to "/accounts/test1/licenses/actions/validate-key" with the following:
+      """
+      {
+        "meta": {
+          "key": "component-key",
+          "scope": {
+            "fingerprint": "foo",
+            "components": [
+              "bar",
+              "baz",
+              "qux"
+            ]
+          }
+        }
+      }
+      """
+    Then the response status should be "200"
+    And the response should contain a valid signature header for "test1"
+    And the response body should contain a "license"
+    And the response body should contain meta which includes the following:
+      """
+      { "valid": false, "detail": "fingerprint is not activated (does not match any associated machines)", "code": "FINGERPRINT_SCOPE_MISMATCH" }
+      """
+    And sidekiq should have 1 "webhook" job
+    And sidekiq should have 1 "metric" job
+    And sidekiq should have 1 "request-log" job

--- a/features/api/v1/licenses/actions/validations.feature
+++ b/features/api/v1/licenses/actions/validations.feature
@@ -7298,7 +7298,7 @@ Feature: License validation actions
     And the response body should contain a "license"
     And the response body should contain meta which includes the following:
       """
-      { "valid": false, "detail": "fingerprint is not activated (does not match enough associated machines)", "code": "FINGERPRINT_SCOPE_MISMATCH" }
+      { "valid": false, "detail": "one or more fingerprint is not activated (does not match enough associated machines)", "code": "FINGERPRINT_SCOPE_MISMATCH" }
       """
     And sidekiq should have 1 "webhook" job
     And sidekiq should have 1 "metric" job
@@ -7350,7 +7350,7 @@ Feature: License validation actions
     And the response body should contain a "license"
     And the response body should contain meta which includes the following:
       """
-      { "valid": false, "detail": "fingerprint is not activated (does not match enough associated machines)", "code": "FINGERPRINT_SCOPE_MISMATCH" }
+      { "valid": false, "detail": "fingerprint is not activated (does not match any associated machines)", "code": "FINGERPRINT_SCOPE_MISMATCH" }
       """
     And sidekiq should have 1 "webhook" job
     And sidekiq should have 1 "metric" job
@@ -7457,7 +7457,7 @@ Feature: License validation actions
     And the response body should contain a "license"
     And the response body should contain meta which includes the following:
       """
-      { "valid": false, "detail": "fingerprint is not activated (does not match all associated machines)", "code": "FINGERPRINT_SCOPE_MISMATCH" }
+      { "valid": false, "detail": "one or more fingerprint is not activated (does not match all associated machines)", "code": "FINGERPRINT_SCOPE_MISMATCH" }
       """
     And sidekiq should have 1 "webhook" job
     And sidekiq should have 1 "metric" job
@@ -7725,7 +7725,7 @@ Feature: License validation actions
     And the response body should contain a "license"
     And the response body should contain meta which includes the following:
       """
-      { "valid": false, "detail": "fingerprint is not activated (does not match any associated machines)", "code": "FINGERPRINT_SCOPE_MISMATCH" }
+      { "valid": false, "detail": "one or more fingerprint is not activated (does not match any associated machines)", "code": "FINGERPRINT_SCOPE_MISMATCH" }
       """
     And sidekiq should have 1 "webhook" jobs
     And sidekiq should have 1 "metric" job

--- a/features/api/v1/machines/actions/checkouts.feature
+++ b/features/api/v1/machines/actions/checkouts.feature
@@ -766,6 +766,55 @@ Feature: Machine checkout actions
     And sidekiq should have 1 "metric" job
     And sidekiq should have 1 "request-log" job
 
+  Scenario: Admin performs a machine checkout with component includes (POST)
+    Given the current account is "test1"
+    And the current account has 1 "webhook-endpoint"
+    And the current account has 1 "machine"
+    And the current account has 3 "components" for the last "machine"
+    And I am an admin of account "test1"
+    And I use an authentication token
+    When I send a POST request to "/accounts/test1/machines/$0/actions/check-out" with the following:
+      """
+      { "meta": { "include": ["components"] } }
+      """
+    Then the response status should be "200"
+    And the response body should be a "machine-file" with the following encoded certificate data:
+      """
+      {
+        "included": [
+          { "type": "components", "id": "$components[0]" },
+          { "type": "components", "id": "$components[1]" },
+          { "type": "components", "id": "$components[2]" }
+        ]
+      }
+      """
+    And sidekiq should have 1 "webhook" job
+    And sidekiq should have 1 "metric" job
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: Admin performs a machine checkout with component includes (GET)
+    Given the current account is "test1"
+    And the current account has 1 "webhook-endpoint"
+    And the current account has 1 "machine"
+    And the current account has 3 "components" for the last "machine"
+    And I am an admin of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/machines/$0/actions/check-out?include=components"
+    Then the response status should be "200"
+    And the response should be a "MACHINE" certificate with the following encoded data:
+      """
+      {
+        "included": [
+          { "type": "components", "id": "$components[0]" },
+          { "type": "components", "id": "$components[1]" },
+          { "type": "components", "id": "$components[2]" }
+        ]
+      }
+      """
+    And sidekiq should have 1 "webhook" job
+    And sidekiq should have 1 "metric" job
+    And sidekiq should have 1 "request-log" job
+
   Scenario: Admin performs a machine checkout with a group include (POST)
     Given the current account is "test1"
     And the current account has 1 "webhook-endpoint"

--- a/features/api/v1/machines/relationships/components.feature
+++ b/features/api/v1/machines/relationships/components.feature
@@ -1,0 +1,345 @@
+@api/v1
+Feature: Machine components relationship
+  Background:
+    Given the following "accounts" exist:
+      | Name    | Slug  |
+      | Test 1  | test1 |
+      | Test 2  | test2 |
+    And I send and accept JSON
+
+  Scenario: Endpoint should be inaccessible when account is disabled
+    Given the account "test1" is canceled
+    Given I am an admin of account "test1"
+    And the current account is "test1"
+    And the current account has 1 "machine"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/machines/$0/components"
+    Then the response status should be "403"
+
+  # Index
+  Scenario: Admin retrieves a paginated list of components for a machine with no other pages
+    Given I am an admin of account "test1"
+    And the current account is "test1"
+    And the current account has 1 "machine"
+    And the current account has 2 "components" for the last "machine"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/machines/$0/components?page[number]=1&page[size]=5"
+    Then the response status should be "200"
+    And the response body should be an array with 2 "components"
+    And the response body should contain the following links:
+      """
+      {
+        "self": "/v1/accounts/test1/machines/$machines[0]/components?page[number]=1&page[size]=5",
+        "prev": null,
+        "next": null,
+        "first": "/v1/accounts/test1/machines/$machines[0]/components?page[number]=1&page[size]=5",
+        "last": "/v1/accounts/test1/machines/$machines[0]/components?page[number]=1&page[size]=5",
+        "meta": {
+          "pages": 1,
+          "count": 2
+        }
+      }
+      """
+    And the response should contain a valid signature header for "test1"
+
+  Scenario: Admin retrieves a paginated list of components for a machine with other pages
+    Given I am an admin of account "test1"
+    And the current account is "test1"
+    And the current account has 1 "machine"
+    And the current account has 20 "components" for the last "machine"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/machines/$0/components?page[number]=1&page[size]=5"
+    Then the response status should be "200"
+    And the response body should be an array with 5 "components"
+    And the response body should contain the following links:
+      """
+      {
+        "self": "/v1/accounts/test1/machines/$machines[0]/components?page[number]=1&page[size]=5",
+        "prev": null,
+        "next": "/v1/accounts/test1/machines/$machines[0]/components?page[number]=2&page[size]=5",
+        "first": "/v1/accounts/test1/machines/$machines[0]/components?page[number]=1&page[size]=5",
+        "last": "/v1/accounts/test1/machines/$machines[0]/components?page[number]=4&page[size]=5",
+        "meta": {
+          "pages": 4,
+          "count": 20
+        }
+      }
+      """
+
+  Scenario: Admin retrieves the components for a machine by fingerprint
+    Given I am an admin of account "test1"
+    And the current account is "test1"
+    And the current account has 1 "machine"
+    And the last "machine" has the following attributes:
+      """
+      { "fingerprint": "foo" }
+      """
+    And the current account has 3 "components" for the last "machine"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/machines/foo/components"
+    Then the response status should be "200"
+    And the response body should be an array with 3 "components"
+
+  @ee
+  Scenario: Isolated environment retrieves the components for an isolated machine
+    Given the current account is "test1"
+    And the current account has 1 isolated "environment"
+    And the current account has 1 isolated "machine"
+    And the current account has 3 isolated "components" for each "machine"
+    And I am an environment of account "test1"
+    And I use an authentication token
+    And I send the following headers:
+      """
+      { "Keygen-Environment": "isolated" }
+      """
+    When I send a GET request to "/accounts/test1/machines/$0/components"
+    Then the response status should be "200"
+    And the response body should be an array with 3 "components"
+
+  @ee
+  Scenario: Shared environment retrieves the components for a shared machine
+    Given the current account is "test1"
+    And the current account has 1 shared "environment"
+    And the current account has 1 shared "machine"
+    And the current account has 3 shared "components" for each "machine"
+    And I am an environment of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/machines/$0/components?environment=shared"
+    Then the response status should be "200"
+    And the response body should be an array with 3 "components"
+
+  @ee
+  Scenario: Shared environment retrieves the components for a global machine
+    Given the current account is "test1"
+    And the current account has 1 shared "environment"
+    And the current account has 1 global "machine"
+    And the current account has 3 global "components" for each "machine"
+    And I am an environment of account "test1"
+    And I use an authentication token
+    And I send the following headers:
+      """
+      { "Keygen-Environment": "shared" }
+      """
+    When I send a GET request to "/accounts/test1/machines/$0/components"
+    Then the response status should be "200"
+    And the response body should be an array with 3 "components"
+
+  Scenario: Product retrieves the components for a machine
+    Given the current account is "test1"
+    And the current account has 2 "products"
+    And the current account has 1 "policy" for the first "product"
+    And the current account has 1 "license" for the last "policy"
+    And the current account has 1 "machine" for the last "license"
+    And the current account has 3 "components" for the last "machine"
+    And I am a product of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/machines/$0/components"
+    Then the response status should be "200"
+    And the response body should be an array with 3 "components"
+
+  Scenario: Product retrieves the components for a different product's machine
+    Given the current account is "test1"
+    And the current account has 2 "products"
+    And the current account has 1 "policy" for the second "product"
+    And the current account has 1 "license" for the last "policy"
+    And the current account has 1 "machine" for the last "license"
+    And the current account has 3 "components" for the last "machine"
+    And I am a product of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/machines/$0/components"
+    Then the response status should be "404"
+
+  Scenario: License retrieves the components for a machine
+    Given the current account is "test1"
+    And the current account has 1 "license"
+    And the current account has 1 "machine" for the last "license"
+    And the current account has 3 "components" for the last "machine"
+    And I am a license of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/machines/$0/components"
+    Then the response status should be "200"
+    And the response body should be an array with 3 "components"
+
+  Scenario: License retrieves the components for different license's machine
+    Given the current account is "test1"
+    And the current account has 1 "license"
+    And the current account has 1 "machine"
+    And the current account has 3 "components" for the last "machine"
+    And I am a license of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/machines/$0/components"
+    Then the response status should be "404"
+
+  Scenario: User retrieves the components for a machine
+    Given the current account is "test1"
+    And the current account has 1 "user"
+    And the current account has 1 "license" for the last "user"
+    And the current account has 1 "machine" for the last "license"
+    And the current account has 3 "components" for the last "machine"
+    And I am a user of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/machines/$0/components"
+    Then the response status should be "200"
+    And the response body should be an array with 3 "components"
+
+  Scenario: User retrieves the components for different user's machine
+    Given the current account is "test1"
+    And the current account has 1 "user"
+    And the current account has 1 "machine"
+    And the current account has 3 "components" for the last "machine"
+    And I am a user of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/machines/$0/components"
+    Then the response status should be "404"
+
+  # Show
+  Scenario: Admin retrieves a component for a machine
+    Given I am an admin of account "test1"
+    And the current account is "test1"
+    And the current account has 1 "machine"
+    And the current account has 3 "components"
+    And all "components" have the following attributes:
+      """
+      { "machineId": "$machines[0]" }
+      """
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/machines/$0/components/$0"
+    Then the response status should be "200"
+    And the response body should be a "component"
+
+  @ee
+  Scenario: Isolated environment retrieves the license for an isolated machine
+    Given the current account is "test1"
+    And the current account has 1 isolated "environment"
+    And the current account has 1 isolated "machine"
+    And the current account has 1 isolated "component" for each "machine"
+    And I am an environment of account "test1"
+    And I use an authentication token
+    And I send the following headers:
+      """
+      { "Keygen-Environment": "isolated" }
+      """
+    When I send a GET request to "/accounts/test1/machines/$0/components/$0"
+    Then the response status should be "200"
+    And the response body should be a "component"
+
+  @ee
+  Scenario: Shared environment retrieves the license for a shared machine
+    Given the current account is "test1"
+    And the current account has 1 shared "environment"
+    And the current account has 1 shared "machine"
+    And the current account has 1 shared "component" for each "machine"
+    And I am an environment of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/machines/$0/components/$0?environment=shared"
+    Then the response status should be "200"
+    And the response body should be a "component"
+
+  @ee
+  Scenario: Shared environment retrieves the license for a global machine
+    Given the current account is "test1"
+    And the current account has 1 shared "environment"
+    And the current account has 1 global "machine"
+    And the current account has 1 global "component" for each "machine"
+    And I am an environment of account "test1"
+    And I use an authentication token
+    And I send the following headers:
+      """
+      { "Keygen-Environment": "shared" }
+      """
+    When I send a GET request to "/accounts/test1/machines/$0/components/$0"
+    Then the response status should be "200"
+    And the response body should be a "component"
+
+  Scenario: Product retrieves a component for a machine
+    Given the current account is "test1"
+    And the current account has 2 "products"
+    And the current account has 1 "policy" for the first "product"
+    And the current account has 1 "license" for the last "policy"
+    And the current account has 1 "machine" for the last "license"
+    And the current account has 3 "components" for the last "machine"
+    And I am a product of account "test1"
+    And the current product has 1 "machine"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/machines/$0/components/$0"
+    Then the response status should be "200"
+    And the response body should be a "component"
+
+  Scenario: Product retrieves the components for a different product's machine
+    Given the current account is "test1"
+    And the current account has 2 "products"
+    And the current account has 1 "policy" for the second "product"
+    And the current account has 1 "license" for the last "policy"
+    And the current account has 1 "machine" for the last "license"
+    And the current account has 3 "components" for the last "machine"
+    And I am a product of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/machines/$0/components"
+    Then the response status should be "404"
+
+  Scenario: User retrieves a machine's component
+    Given the current account is "test1"
+    And the current account has 2 "users"
+    And the current account has 1 "license" for the second "user"
+    And the current account has 1 "machine" for the last "license"
+    And the current account has 1 "component" for the last "machine"
+    And I am a user of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/machines/$0/components/$0"
+    Then the response status should be "200"
+
+  Scenario: User retireves a machine's component for a different user
+    Given the current account is "test1"
+    And the current account has 2 "users"
+    And the current account has 1 "license" for the third "user"
+    And the current account has 1 "machine" for the last "license"
+    And the current account has 1 "component" for the last "machine"
+    And I am a user of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/machines/$0/components/$0"
+    Then the response status should be "404"
+
+  Scenario: License retrieves a machine's component
+    Given the current account is "test1"
+    And the current account has 1 "license"
+    And the current account has 1 "machine" for the last "license"
+    And the current account has 3 "components" for the last "machine"
+    And I am a license of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/machines/$0/components/$0"
+    Then the response status should be "200"
+
+  Scenario: License retireves a machine's component for a different license
+    Given the current account is "test1"
+    And the current account has 1 "license"
+    And the current account has 1 "machine"
+    And the current account has 3 "components" for the last "machine"
+    And I am a license of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/machines/$0/components/$0"
+    Then the response status should be "404"
+
+  Scenario: License retrieves a wrongly scoped machine's component
+    Given the current account is "test1"
+    And the current account has 2 "licenses"
+    And the current account has 1 "machine" for the first "license"
+    And the current account has 1 "machine" for the second "license"
+    And the current account has 1 "component" for the first "machine"
+    And the current account has 1 "component" for the second "machine"
+    And I am a license of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/machines/$0/components/$1"
+    Then the response status should be "404"
+
+  Scenario: Admin attempts to retrieve the components for a machine of another account
+    Given I am an admin of account "test2"
+    And the current account is "test1"
+    And the current account has 1 "machine"
+    And the current account has 3 "components"
+    And all "components" have the following attributes:
+      """
+      { "machineId": "$machines[0]" }
+      """
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/machines/$0/components"
+    Then the response status should be "401"

--- a/features/api/v1/policies/create.feature
+++ b/features/api/v1/policies/create.feature
@@ -2686,6 +2686,7 @@ Feature: Create policy
           "attributes": {
             "name": "Premium Add-On",
             "requireFingerprintScope": true,
+            "requireComponentsScope": true,
             "requireProductScope": true,
             "requirePolicyScope": true,
             "requireMachineScope": true,
@@ -2711,6 +2712,7 @@ Feature: Create policy
       {
         "name": "Premium Add-On",
         "requireFingerprintScope": true,
+        "requireComponentsScope": true,
         "requireProductScope": true,
         "requirePolicyScope": true,
         "requireMachineScope": true,

--- a/features/api/v1/policies/update.feature
+++ b/features/api/v1/policies/update.feature
@@ -40,6 +40,7 @@ Feature: Update policy
           "id": "$policies[0].id",
           "attributes": {
             "requireFingerprintScope": true,
+            "requireComponentsScope": true,
             "name": "Trial",
             "maxCores": 32,
             "maxUses": 3
@@ -50,6 +51,7 @@ Feature: Update policy
     Then the response status should be "200"
     And the response body should be a "policy" with a duration that is not nil
     And the response body should be a "policy" with a requireFingerprintScope
+    And the response body should be a "policy" with a requireComponentsScope
     And the response body should be a "policy" with the name "Trial"
     And the response body should be a "policy" with the maxCores "32"
     And the response body should be a "policy" with the maxUses "3"

--- a/features/step_definitions/placeholder_steps.rb
+++ b/features/step_definitions/placeholder_steps.rb
@@ -10,6 +10,8 @@ PLACEHOLDERS = %w[
   key
   license
   machine
+  machine_component
+  component
   machine_process
   process
   metric
@@ -132,6 +134,8 @@ def parse_placeholders(str, account:, bearer:, crypt:)
             case resource.singularize
             when 'constraint'
               account.release_entitlement_constraints.all.send(*(index.nil? ? [:sample] : [:[], index.to_i]))
+            when 'component'
+              account.machine_components.all.send(*(index.nil? ? [:sample] : [:[], index.to_i]))
             when 'process'
               account.machine_processes.all.send(*(index.nil? ? [:sample] : [:[], index.to_i]))
             when 'artifact'
@@ -217,6 +221,8 @@ def parse_path_placeholders(str, account:, bearer:, crypt:)
             account.release_engines.send(:[], index.to_i).id
           when "request-logs"
             account.request_logs.send(:[], index.to_i).id
+          when "components"
+            account.machine_components.send(:[], index.to_i).id
           when "processes"
             account.machine_processes.send(:[], index.to_i).id
           when "owners"

--- a/spec/factories/machine_component.rb
+++ b/spec/factories/machine_component.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :machine_component, aliases: %i[component] do
+    initialize_with { new(**attributes.reject { NIL_ENVIRONMENT == _2 }) }
+
+    sequence :name, %w[HWID HDDID SSD CPU MOBO IP MAC].cycle
+    fingerprint { SecureRandom.hex(16) }
+
+    account     { nil }
+    environment { NIL_ENVIRONMENT }
+    machine     { build(:machine, account:, environment:) }
+
+    trait :in_isolated_environment do
+      environment { build(:environment, :isolated, account:) }
+    end
+
+    trait :isolated do
+      in_isolated_environment
+    end
+
+    trait :in_shared_environment do
+      environment { build(:environment, :shared, account:) }
+    end
+
+    trait :shared do
+      in_shared_environment
+    end
+
+    trait :in_nil_environment do
+      environment { nil }
+    end
+
+    trait :global do
+      in_nil_environment
+    end
+  end
+end

--- a/spec/models/machine_component.rb
+++ b/spec/models/machine_component.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'spec_helper'
+
+describe MachineComponent, type: :model do
+  let(:account) { create(:account) }
+
+  it_behaves_like :environmental
+
+  describe '#environment=' do
+    context 'on create' do
+      it 'should apply default environment matching machine' do
+        environment = create(:environment, account:)
+        machine     = create(:machine, account:, environment:)
+        component   = create(:component, account:, machine:)
+
+        expect(component.environment).to eq machine.environment
+      end
+
+      it 'should not raise when environment matches machine' do
+        environment = create(:environment, account:)
+        machine     = create(:machine, account:, environment:)
+
+        expect { create(:component, account:, environment:, machine:) }.to_not raise_error
+      end
+
+      it 'should raise when environment does not match machine' do
+        environment = create(:environment, account:)
+        machine     = create(:machine, account:, environment: nil)
+
+        expect { create(:component, account:, environment:, machine:) }.to raise_error ActiveRecord::RecordInvalid
+      end
+    end
+
+    context 'on update' do
+      it 'should not raise when environment matches machine' do
+        environment = create(:environment, account:)
+        component   = create(:component, account:, environment:)
+
+        expect { component.update!(machine: create(:machine, account:, environment:)) }.to_not raise_error
+      end
+
+      it 'should raise when environment does not match machine' do
+        environment = create(:environment, account:)
+        component   = create(:component, account:, environment:)
+
+        expect { component.update!(machine: create(:machine, account:, environment: nil)) }.to raise_error ActiveRecord::RecordInvalid
+      end
+    end
+  end
+end

--- a/spec/policies/machine_component_policy_spec.rb
+++ b/spec/policies/machine_component_policy_spec.rb
@@ -1,0 +1,762 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'spec_helper'
+
+describe MachineComponentPolicy, type: :policy do
+  subject { described_class.new(record, account:, environment:, bearer:, token:) }
+
+  with_role_authorization :admin do
+    with_scenarios %i[accessing_machine_components] do
+      with_token_authentication do
+        with_permissions %w[component.read] do
+          without_token_permissions { denies :index }
+
+          allows :index
+        end
+
+        with_wildcard_permissions { allows :index }
+        with_default_permissions  { allows :index }
+        without_permissions       { denies :index }
+
+        within_environment :isolated do
+          with_bearer_and_token_trait :in_shared_environment do
+            denies :index
+          end
+
+          with_bearer_and_token_trait :in_nil_environment do
+            denies :index
+          end
+
+          allows :index
+        end
+
+        within_environment :shared do
+          with_bearer_and_token_trait :in_isolated_environment do
+            denies :index
+          end
+
+          with_bearer_and_token_trait :in_nil_environment do
+            allows :index
+          end
+
+          allows :index
+        end
+
+        within_environment nil do
+          with_bearer_and_token_trait :in_isolated_environment do
+            denies :index
+          end
+
+          with_bearer_and_token_trait :in_shared_environment do
+            denies :index
+          end
+
+          allows :index
+        end
+      end
+    end
+
+    with_scenarios %i[accessing_a_machine_component] do
+      with_token_authentication do
+        with_permissions %w[component.read] do
+          without_token_permissions { denies :show }
+
+          allows :show
+        end
+
+        with_permissions %w[component.create] do
+          without_token_permissions { denies :create }
+
+          allows :create
+        end
+
+        with_permissions %w[component.update] do
+          without_token_permissions { denies :update }
+
+          allows :update
+        end
+
+        with_permissions %w[component.delete] do
+          without_token_permissions { denies :destroy }
+
+          allows :destroy
+        end
+
+        with_wildcard_permissions do
+          without_token_permissions do
+            denies :show, :create, :update, :destroy
+          end
+
+          allows :show, :create, :update, :destroy
+        end
+
+        with_default_permissions do
+          without_token_permissions do
+            denies :show, :create, :update, :destroy
+          end
+
+          allows :show, :create, :update, :destroy
+        end
+
+        without_permissions do
+          denies :show, :create, :update, :destroy
+        end
+
+        within_environment :isolated do
+          with_bearer_and_token_trait :in_shared_environment do
+            denies :show, :create, :update, :destroy
+          end
+
+          with_bearer_and_token_trait :in_nil_environment do
+            denies :show, :create, :update, :destroy
+          end
+
+          allows :show, :create, :update, :destroy
+        end
+
+        within_environment :shared do
+          with_bearer_and_token_trait :in_isolated_environment do
+            denies :show, :create, :update, :destroy
+          end
+
+          with_bearer_and_token_trait :in_nil_environment do
+            allows :show, :create, :update, :destroy
+          end
+
+          allows :show, :create, :update, :destroy
+        end
+
+        within_environment nil do
+          with_bearer_and_token_trait :in_isolated_environment do
+            denies :show, :create, :update, :destroy
+          end
+
+          with_bearer_and_token_trait :in_shared_environment do
+            denies :show, :create, :update, :destroy
+          end
+
+          allows :show, :create, :update, :destroy
+        end
+      end
+    end
+
+    with_scenarios %i[accessing_another_account accessing_machine_components] do
+      with_token_authentication do
+        with_permissions %w[component.read] do
+          denies :index
+        end
+
+        with_wildcard_permissions { denies :index }
+        with_default_permissions  { denies :index }
+        without_permissions       { denies :index }
+      end
+    end
+
+    with_scenarios %i[accessing_another_account accessing_a_machine_component] do
+      with_token_authentication do
+        with_permissions %w[component.read] do
+          denies :show
+        end
+
+        with_permissions %w[component.create] do
+          denies :create
+        end
+
+        with_permissions %w[component.update] do
+          denies :update
+        end
+
+        with_permissions %w[component.delete] do
+          denies :destroy
+        end
+
+        with_wildcard_permissions do
+          denies :show, :create, :update, :destroy
+        end
+
+        with_default_permissions do
+          denies :show, :create, :update, :destroy
+        end
+
+        without_permissions do
+          denies :show, :create, :update, :destroy
+        end
+      end
+    end
+  end
+
+  with_role_authorization :environment do
+    within_environment :self do
+      with_scenarios %i[accessing_machine_components] do
+        with_token_authentication do
+          with_permissions %w[component.read] do
+            without_token_permissions { denies :index }
+
+            allows :index
+          end
+
+          with_wildcard_permissions { allows :index }
+          with_default_permissions  { allows :index }
+          without_permissions       { denies :index }
+
+          within_environment :isolated do
+            with_bearer_and_token_trait :isolated do
+              allows :index
+            end
+
+            with_bearer_and_token_trait :shared do
+              denies :index
+            end
+          end
+
+          within_environment :shared do
+            with_bearer_and_token_trait :isolated do
+              denies :index
+            end
+
+            with_bearer_and_token_trait :shared do
+              allows :index
+            end
+          end
+
+          within_environment nil do
+            with_bearer_and_token_trait :isolated do
+              denies :index
+            end
+
+            with_bearer_and_token_trait :shared do
+              denies :index
+            end
+          end
+        end
+      end
+
+      with_scenarios %i[accessing_a_machine_component] do
+        with_token_authentication do
+          with_permissions %w[component.read] do
+            without_token_permissions { denies :show }
+
+            allows :show
+          end
+
+          with_permissions %w[component.create] do
+            without_token_permissions { denies :create }
+
+            allows :create
+          end
+
+          with_permissions %w[component.update] do
+            without_token_permissions { denies :update }
+
+            allows :update
+          end
+
+          with_permissions %w[component.delete] do
+            without_token_permissions { denies :destroy }
+
+            allows :destroy
+          end
+
+          with_wildcard_permissions do
+            without_token_permissions do
+              denies :show, :create, :update, :destroy
+            end
+
+            allows :show, :create, :update, :destroy
+          end
+
+          with_default_permissions do
+            without_token_permissions do
+              denies :show, :create, :update, :destroy
+            end
+
+            allows :show, :create, :update, :destroy
+          end
+
+          without_permissions do
+            denies :show, :create, :update, :destroy
+          end
+
+          within_environment :isolated do
+            with_bearer_and_token_trait :isolated do
+              allows :show, :create, :update, :destroy
+            end
+
+            with_bearer_and_token_trait :shared do
+              denies :show, :create, :update, :destroy
+            end
+          end
+
+          within_environment :shared do
+            with_bearer_and_token_trait :isolated do
+              denies :show, :create, :update, :destroy
+            end
+
+            with_bearer_and_token_trait :shared do
+              allows :show, :create, :update, :destroy
+            end
+          end
+
+          within_environment nil do
+            with_bearer_and_token_trait :isolated do
+              denies :show, :create, :update, :destroy
+            end
+
+            with_bearer_and_token_trait :shared do
+              denies :show, :create, :update, :destroy
+            end
+          end
+        end
+      end
+    end
+  end
+
+  with_role_authorization :product do
+    with_scenarios %i[accessing_its_machine_components] do
+      with_token_authentication do
+        with_permissions %w[component.read] do
+          without_token_permissions { denies :index }
+
+          allows :index
+        end
+
+        with_wildcard_permissions { allows :index }
+        with_default_permissions  { allows :index }
+        without_permissions       { denies :index }
+      end
+    end
+
+    with_scenarios %i[accessing_its_machine_component] do
+      with_token_authentication do
+        with_permissions %w[component.read] do
+          without_token_permissions { denies :show }
+
+          allows :show
+        end
+
+        with_permissions %w[component.create] do
+          without_token_permissions { denies :create }
+
+          allows :create
+        end
+
+        with_permissions %w[component.update] do
+          without_token_permissions { denies :update }
+
+          allows :update
+        end
+
+        with_permissions %w[component.delete] do
+          without_token_permissions { denies :destroy }
+
+          allows :destroy
+        end
+
+        with_wildcard_permissions do
+          without_token_permissions do
+            denies :show, :create, :update, :destroy
+          end
+
+          allows :show, :create, :update, :destroy
+        end
+
+        with_default_permissions do
+          without_token_permissions do
+            denies :show, :create, :update, :destroy
+          end
+
+          allows :show, :create, :update, :destroy
+        end
+
+        without_permissions do
+          denies :show, :create, :update, :destroy
+        end
+      end
+    end
+
+    with_scenarios %i[accessing_machine_components] do
+      with_token_authentication do
+        with_permissions %w[component.read] do
+          denies :index
+        end
+
+        with_wildcard_permissions { denies :index }
+        with_default_permissions  { denies :index }
+        without_permissions       { denies :index }
+      end
+    end
+
+    with_scenarios %i[accessing_a_machine_component] do
+      with_token_authentication do
+        with_permissions %w[component.read] do
+          denies :show
+        end
+
+        with_permissions %w[component.create] do
+          denies :create
+        end
+
+        with_permissions %w[component.update] do
+          denies :update
+        end
+
+        with_permissions %w[component.delete] do
+          denies :destroy
+        end
+
+        with_wildcard_permissions do
+          denies :show, :create, :update, :destroy
+        end
+
+        with_default_permissions do
+          denies :show, :create, :update, :destroy
+        end
+
+        without_permissions do
+          denies :show, :create, :update, :destroy
+        end
+      end
+    end
+  end
+
+  with_role_authorization :license do
+    with_scenarios %i[accessing_its_machine_components] do
+      with_license_authentication do
+        with_permissions %w[component.read] do
+          allows :index
+        end
+
+        with_wildcard_permissions { allows :index }
+        with_default_permissions  { allows :index }
+        without_permissions       { denies :index }
+      end
+
+      with_token_authentication do
+        with_permissions %w[component.read] do
+          allows :index
+        end
+
+        with_wildcard_permissions { allows :index }
+        with_default_permissions  { allows :index }
+        without_permissions       { denies :index }
+      end
+    end
+
+    with_scenarios %i[accessing_its_machine_component] do
+      with_license_authentication do
+        with_permissions %w[component.read] do
+          allows :show
+        end
+
+        with_permissions %w[component.create] do
+          allows :create
+        end
+
+        with_permissions %w[component.update] do
+          allows :update
+        end
+
+        with_permissions %w[component.delete] do
+          allows :destroy
+        end
+
+        with_wildcard_permissions do
+          allows :show, :create, :update, :destroy
+        end
+
+        with_default_permissions do
+          allows :show, :create, :update, :destroy
+        end
+
+        without_permissions do
+          denies :show, :create, :update, :destroy
+        end
+      end
+
+      with_token_authentication do
+        with_permissions %w[component.read] do
+          without_token_permissions { denies :show }
+
+          allows :show
+        end
+
+        with_permissions %w[component.create] do
+          without_token_permissions { denies :create }
+
+          allows :create
+        end
+
+        with_permissions %w[component.update] do
+          without_token_permissions { denies :update }
+
+          allows :update
+        end
+
+        with_permissions %w[component.delete] do
+          without_token_permissions { denies :destroy }
+
+          allows :destroy
+        end
+
+        with_wildcard_permissions do
+          without_token_permissions do
+            denies :show, :create, :update, :destroy
+          end
+
+          allows :show, :create, :update, :destroy
+        end
+
+        with_default_permissions do
+          without_token_permissions do
+            denies :show, :create, :update, :destroy
+          end
+
+          allows :show, :create, :update, :destroy
+        end
+
+        without_permissions do
+          denies :show, :create, :update, :destroy
+        end
+      end
+    end
+
+    with_scenarios %i[accessing_machine_components] do
+      with_license_authentication do
+        with_permissions %w[component.read] do
+          denies :index
+        end
+
+        with_wildcard_permissions { denies :index }
+        with_default_permissions  { denies :index }
+        without_permissions       { denies :index }
+      end
+
+      with_token_authentication do
+        with_permissions %w[component.read] do
+          denies :index
+        end
+
+        with_wildcard_permissions { denies :index }
+        with_default_permissions  { denies :index }
+        without_permissions       { denies :index }
+      end
+    end
+
+    with_scenarios %i[accessing_a_machine_component] do
+      with_license_authentication do
+        with_permissions %w[component.read] do
+          denies :show
+        end
+
+        with_permissions %w[component.create] do
+          denies :create
+        end
+
+        with_permissions %w[component.update] do
+          denies :update
+        end
+
+        with_permissions %w[component.delete] do
+          denies :destroy
+        end
+
+        with_wildcard_permissions do
+          denies :show, :create, :update, :destroy
+        end
+
+        with_default_permissions do
+          denies :show, :create, :update, :destroy
+        end
+
+        without_permissions do
+          denies :show, :create, :update, :destroy
+        end
+      end
+
+      with_token_authentication do
+        with_permissions %w[component.read] do
+          denies :show
+        end
+
+        with_permissions %w[component.create] do
+          denies :create
+        end
+
+        with_permissions %w[component.update] do
+          denies :update
+        end
+
+        with_permissions %w[component.delete] do
+          denies :destroy
+        end
+
+        with_wildcard_permissions do
+          denies :show, :create, :update, :destroy
+        end
+
+        with_default_permissions do
+          denies :show, :create, :update, :destroy
+        end
+
+        without_permissions do
+          denies :show, :create, :update, :destroy
+        end
+      end
+    end
+  end
+
+  with_role_authorization :user do
+    with_bearer_trait :with_licenses do
+      with_scenarios %i[accessing_its_machine_components] do
+        with_token_authentication do
+          with_permissions %w[component.read] do
+            allows :index
+          end
+
+          with_wildcard_permissions { allows :index }
+          with_default_permissions  { allows :index }
+          without_permissions       { denies :index }
+        end
+      end
+
+      with_scenarios %i[accessing_its_machine_component] do
+        with_token_authentication do
+          with_permissions %w[component.read] do
+            without_token_permissions { denies :show }
+
+            allows :show
+          end
+
+          with_permissions %w[component.create] do
+            without_token_permissions { denies :create }
+
+            allows :create
+          end
+
+          with_permissions %w[component.update] do
+            without_token_permissions { denies :update }
+
+            allows :update
+          end
+
+          with_permissions %w[component.delete] do
+            without_token_permissions { denies :destroy }
+
+            allows :destroy
+          end
+
+          with_wildcard_permissions do
+            without_token_permissions do
+              denies :show, :create, :update, :destroy
+            end
+
+            allows :show, :create, :update, :destroy
+          end
+
+          with_default_permissions do
+            without_token_permissions do
+              denies :show, :create, :update, :destroy
+            end
+
+            allows :show, :create, :update, :destroy
+          end
+
+          without_permissions do
+            denies :show, :create, :update, :destroy
+          end
+        end
+      end
+
+      with_scenarios %i[accessing_machine_components] do
+        with_token_authentication do
+          with_permissions %w[component.read] do
+            denies :index
+          end
+
+          with_wildcard_permissions { denies :index }
+          with_default_permissions  { denies :index }
+          without_permissions       { denies :index }
+        end
+      end
+
+      with_scenarios %i[accessing_a_machine_component] do
+        with_token_authentication do
+          with_permissions %w[component.read] do
+            denies :show
+          end
+
+          with_wildcard_permissions do
+            denies :show, :create, :update, :destroy
+          end
+
+          with_default_permissions do
+            denies :show, :create, :update, :destroy
+          end
+
+          without_permissions do
+            denies :show, :create, :update, :destroy
+          end
+        end
+      end
+    end
+
+    with_scenarios %i[accessing_machine_components] do
+      with_token_authentication do
+        with_permissions %w[component.read] do
+          denies :index
+        end
+
+        with_wildcard_permissions { denies :index }
+        with_default_permissions  { denies :index }
+        without_permissions       { denies :index }
+      end
+    end
+
+    with_scenarios %i[accessing_a_machine_component] do
+      with_token_authentication do
+        with_permissions %w[component.read] do
+          denies :show
+        end
+
+        with_permissions %w[component.create] do
+          denies :create
+        end
+
+        with_permissions %w[component.update] do
+          denies :update
+        end
+
+        with_permissions %w[component.delete] do
+          denies :destroy
+        end
+
+        with_wildcard_permissions do
+          denies :show, :create, :update, :destroy
+        end
+
+        with_default_permissions do
+          denies :show, :create, :update, :destroy
+        end
+
+        without_permissions do
+          denies :show, :create, :update, :destroy
+        end
+      end
+    end
+  end
+
+  without_authorization do
+    with_scenarios %i[accessing_machine_components] do
+      without_authentication do
+        denies :index
+      end
+    end
+
+    with_scenarios %i[accessing_a_machine_component] do
+      without_authentication do
+        denies :show, :create, :update, :destroy
+      end
+    end
+  end
+end

--- a/spec/policies/machine_components/license_policy_spec.rb
+++ b/spec/policies/machine_components/license_policy_spec.rb
@@ -1,0 +1,332 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'spec_helper'
+
+describe MachineComponents::LicensePolicy, type: :policy do
+  subject { described_class.new(record, account:, environment:, bearer:, token:, machine_component:) }
+
+  with_role_authorization :admin do
+    with_scenarios %i[accessing_a_machine_component accessing_its_license] do
+      with_token_authentication do
+        with_permissions %w[license.read] do
+          without_token_permissions { denies :show }
+
+          allows :show
+        end
+
+        with_wildcard_permissions do
+          without_token_permissions { denies :show }
+
+          allows :show
+        end
+
+        with_default_permissions do
+          without_token_permissions { denies :show }
+
+          allows :show
+        end
+
+        without_permissions do
+          denies :show
+        end
+
+        within_environment :isolated do
+          with_bearer_and_token_trait :in_shared_environment do
+            denies :show
+          end
+
+          with_bearer_and_token_trait :in_nil_environment do
+            denies :show
+          end
+
+          allows :show
+        end
+
+        within_environment :shared do
+          with_bearer_and_token_trait :in_isolated_environment do
+            denies :show
+          end
+
+          with_bearer_and_token_trait :in_nil_environment do
+            allows :show
+          end
+
+          allows :show
+        end
+
+        within_environment nil do
+          with_bearer_and_token_trait :in_isolated_environment do
+            denies :show
+          end
+
+          with_bearer_and_token_trait :in_shared_environment do
+            denies :show
+          end
+
+          allows :show
+        end
+      end
+    end
+
+    with_scenarios %i[accessing_another_account accessing_a_machine_component accessing_its_license] do
+      with_token_authentication do
+        with_permissions %w[license.read] do
+          denies :show
+        end
+
+        with_wildcard_permissions do
+          denies :show
+        end
+
+        with_default_permissions do
+          denies :show
+        end
+
+        without_permissions do
+          denies :show
+        end
+      end
+    end
+  end
+
+  with_role_authorization :environment do
+    within_environment :self do
+      with_scenarios %i[accessing_a_machine_component accessing_its_license] do
+        with_token_authentication do
+          with_permissions %w[license.read] do
+            without_token_permissions { denies :show }
+
+            allows :show
+          end
+
+          with_wildcard_permissions do
+            without_token_permissions { denies :show }
+
+            allows :show
+          end
+
+          with_default_permissions do
+            without_token_permissions { denies :show }
+
+            allows :show
+          end
+
+          without_permissions do
+            denies :show
+          end
+        end
+      end
+    end
+
+    with_scenarios %i[accessing_a_machine_component accessing_its_license] do
+      with_token_authentication do
+        with_permissions %w[license.read] do
+          denies :show
+        end
+
+        with_wildcard_permissions do
+          denies :show
+        end
+
+        with_default_permissions do
+          denies :show
+        end
+
+        without_permissions do
+          denies :show
+        end
+      end
+    end
+  end
+
+  with_role_authorization :product do
+    with_scenarios %i[accessing_its_machine_component accessing_its_license] do
+      with_token_authentication do
+        with_permissions %w[license.read] do
+          without_token_permissions { denies :show }
+
+          allows :show
+        end
+
+        with_wildcard_permissions do
+          without_token_permissions { denies :show }
+
+          allows :show
+        end
+
+        with_default_permissions do
+          without_token_permissions { denies :show }
+
+          allows :show
+        end
+
+        without_permissions do
+          denies :show
+        end
+      end
+    end
+
+    with_scenarios %i[accessing_a_machine_component accessing_its_license] do
+      with_token_authentication do
+        with_permissions %w[license.read] do
+          denies :show
+        end
+
+        with_wildcard_permissions do
+          denies :show
+        end
+
+        with_default_permissions do
+          denies :show
+        end
+
+        without_permissions do
+          denies :show
+        end
+      end
+    end
+  end
+
+  with_role_authorization :license do
+    with_scenarios %i[accessing_its_machine_component accessing_its_license] do
+      with_license_authentication do
+        with_permissions %w[license.read] do
+          allows :show
+        end
+
+        with_wildcard_permissions do
+          allows :show
+        end
+
+        with_default_permissions do
+          allows :show
+        end
+
+        without_permissions do
+          denies :show
+        end
+      end
+
+      with_token_authentication do
+        with_permissions %w[license.read] do
+          without_token_permissions { denies :show }
+
+          allows :show
+        end
+
+        with_wildcard_permissions do
+          without_token_permissions { denies :show }
+
+          allows :show
+        end
+
+        with_default_permissions do
+          without_token_permissions { denies :show }
+
+          allows :show
+        end
+
+        without_permissions do
+          denies :show
+        end
+      end
+    end
+
+    with_scenarios %i[accessing_a_machine_component accessing_its_license] do
+      with_license_authentication do
+        with_permissions %w[license.read] do
+          denies :show
+        end
+
+        with_wildcard_permissions do
+          denies :show
+        end
+
+        with_default_permissions do
+          denies :show
+        end
+
+        without_permissions do
+          denies :show
+        end
+      end
+
+      with_token_authentication do
+        with_permissions %w[license.read] do
+          denies :show
+        end
+
+        with_wildcard_permissions do
+          denies :show
+        end
+
+        with_default_permissions do
+          denies :show
+        end
+
+        without_permissions do
+          denies :show
+        end
+      end
+    end
+  end
+
+  with_role_authorization :user do
+    with_bearer_trait :with_licenses do
+      with_scenarios %i[accessing_its_machine_component accessing_its_license] do
+        with_token_authentication do
+          with_permissions %w[license.read] do
+            without_token_permissions { denies :show }
+
+            allows :show
+          end
+
+          with_wildcard_permissions do
+            without_token_permissions { denies :show }
+
+            allows :show
+          end
+
+          with_default_permissions do
+            without_token_permissions { denies :show }
+
+            allows :show
+          end
+
+          without_permissions do
+            denies :show
+          end
+        end
+      end
+    end
+
+    with_scenarios %i[accessing_a_machine_component accessing_its_license] do
+      with_token_authentication do
+        with_permissions %w[license.read] do
+          denies :show
+        end
+
+        with_wildcard_permissions do
+          denies :show
+        end
+
+        with_default_permissions do
+          denies :show
+        end
+
+        without_permissions do
+          denies :show
+        end
+      end
+    end
+  end
+
+  without_authorization do
+    with_scenarios %i[accessing_a_machine_component accessing_its_license] do
+      without_authentication do
+        denies :show
+      end
+    end
+  end
+end

--- a/spec/policies/machine_components/machine_policy_spec.rb
+++ b/spec/policies/machine_components/machine_policy_spec.rb
@@ -1,0 +1,332 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'spec_helper'
+
+describe MachineComponents::MachinePolicy, type: :policy do
+  subject { described_class.new(record, account:, environment:, bearer:, token:, machine_component:) }
+
+  with_role_authorization :admin do
+    with_scenarios %i[accessing_a_machine_component accessing_its_machine] do
+      with_token_authentication do
+        with_permissions %w[machine.read] do
+          without_token_permissions { denies :show }
+
+          allows :show
+        end
+
+        with_wildcard_permissions do
+          without_token_permissions { denies :show }
+
+          allows :show
+        end
+
+        with_default_permissions do
+          without_token_permissions { denies :show }
+
+          allows :show
+        end
+
+        without_permissions do
+          denies :show
+        end
+
+        within_environment :isolated do
+          with_bearer_and_token_trait :in_shared_environment do
+            denies :show
+          end
+
+          with_bearer_and_token_trait :in_nil_environment do
+            denies :show
+          end
+
+          allows :show
+        end
+
+        within_environment :shared do
+          with_bearer_and_token_trait :in_isolated_environment do
+            denies :show
+          end
+
+          with_bearer_and_token_trait :in_nil_environment do
+            allows :show
+          end
+
+          allows :show
+        end
+
+        within_environment nil do
+          with_bearer_and_token_trait :in_isolated_environment do
+            denies :show
+          end
+
+          with_bearer_and_token_trait :in_shared_environment do
+            denies :show
+          end
+
+          allows :show
+        end
+      end
+    end
+
+    with_scenarios %i[accessing_another_account accessing_a_machine_component accessing_its_machine] do
+      with_token_authentication do
+        with_permissions %w[machine.read] do
+          denies :show
+        end
+
+        with_wildcard_permissions do
+          denies :show
+        end
+
+        with_default_permissions do
+          denies :show
+        end
+
+        without_permissions do
+          denies :show
+        end
+      end
+    end
+  end
+
+  with_role_authorization :environment do
+    within_environment :self do
+      with_scenarios %i[accessing_a_machine_component accessing_its_machine] do
+        with_token_authentication do
+          with_permissions %w[machine.read] do
+            without_token_permissions { denies :show }
+
+            allows :show
+          end
+
+          with_wildcard_permissions do
+            without_token_permissions { denies :show }
+
+            allows :show
+          end
+
+          with_default_permissions do
+            without_token_permissions { denies :show }
+
+            allows :show
+          end
+
+          without_permissions do
+            denies :show
+          end
+        end
+      end
+    end
+
+    with_scenarios %i[accessing_a_machine_component accessing_its_machine] do
+      with_token_authentication do
+        with_permissions %w[machine.read] do
+          denies :show
+        end
+
+        with_wildcard_permissions do
+          denies :show
+        end
+
+        with_default_permissions do
+          denies :show
+        end
+
+        without_permissions do
+          denies :show
+        end
+      end
+    end
+  end
+
+  with_role_authorization :product do
+    with_scenarios %i[accessing_its_machine_component accessing_its_machine] do
+      with_token_authentication do
+        with_permissions %w[machine.read] do
+          without_token_permissions { denies :show }
+
+          allows :show
+        end
+
+        with_wildcard_permissions do
+          without_token_permissions { denies :show }
+
+          allows :show
+        end
+
+        with_default_permissions do
+          without_token_permissions { denies :show }
+
+          allows :show
+        end
+
+        without_permissions do
+          denies :show
+        end
+      end
+    end
+
+    with_scenarios %i[accessing_a_machine_component accessing_its_machine] do
+      with_token_authentication do
+        with_permissions %w[machine.read] do
+          denies :show
+        end
+
+        with_wildcard_permissions do
+          denies :show
+        end
+
+        with_default_permissions do
+          denies :show
+        end
+
+        without_permissions do
+          denies :show
+        end
+      end
+    end
+  end
+
+  with_role_authorization :license do
+    with_scenarios %i[accessing_its_machine_component accessing_its_machine] do
+      with_license_authentication do
+        with_permissions %w[machine.read] do
+          allows :show
+        end
+
+        with_wildcard_permissions do
+          allows :show
+        end
+
+        with_default_permissions do
+          allows :show
+        end
+
+        without_permissions do
+          denies :show
+        end
+      end
+
+      with_token_authentication do
+        with_permissions %w[machine.read] do
+          without_token_permissions { denies :show }
+
+          allows :show
+        end
+
+        with_wildcard_permissions do
+          without_token_permissions { denies :show }
+
+          allows :show
+        end
+
+        with_default_permissions do
+          without_token_permissions { denies :show }
+
+          allows :show
+        end
+
+        without_permissions do
+          denies :show
+        end
+      end
+    end
+
+    with_scenarios %i[accessing_a_machine_component accessing_its_machine] do
+      with_license_authentication do
+        with_permissions %w[machine.read] do
+          denies :show
+        end
+
+        with_wildcard_permissions do
+          denies :show
+        end
+
+        with_default_permissions do
+          denies :show
+        end
+
+        without_permissions do
+          denies :show
+        end
+      end
+
+      with_token_authentication do
+        with_permissions %w[machine.read] do
+          denies :show
+        end
+
+        with_wildcard_permissions do
+          denies :show
+        end
+
+        with_default_permissions do
+          denies :show
+        end
+
+        without_permissions do
+          denies :show
+        end
+      end
+    end
+  end
+
+  with_role_authorization :user do
+    with_bearer_trait :with_licenses do
+      with_scenarios %i[accessing_its_machine_component accessing_its_machine] do
+        with_token_authentication do
+          with_permissions %w[machine.read] do
+            without_token_permissions { denies :show }
+
+            allows :show
+          end
+
+          with_wildcard_permissions do
+            without_token_permissions { denies :show }
+
+            allows :show
+          end
+
+          with_default_permissions do
+            without_token_permissions { denies :show }
+
+            allows :show
+          end
+
+          without_permissions do
+            denies :show
+          end
+        end
+      end
+    end
+
+    with_scenarios %i[accessing_a_machine_component accessing_its_machine] do
+      with_token_authentication do
+        with_permissions %w[machine.read] do
+          denies :show
+        end
+
+        with_wildcard_permissions do
+          denies :show
+        end
+
+        with_default_permissions do
+          denies :show
+        end
+
+        without_permissions do
+          denies :show
+        end
+      end
+    end
+  end
+
+  without_authorization do
+    with_scenarios %i[accessing_a_machine_component accessing_its_machine] do
+      without_authentication do
+        denies :show
+      end
+    end
+  end
+end

--- a/spec/policies/machine_components/product_policy_spec.rb
+++ b/spec/policies/machine_components/product_policy_spec.rb
@@ -1,0 +1,332 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'spec_helper'
+
+describe MachineComponents::ProductPolicy, type: :policy do
+  subject { described_class.new(record, account:, environment:, bearer:, token:, machine_component:) }
+
+  with_role_authorization :admin do
+    with_scenarios %i[accessing_a_machine_component accessing_its_product] do
+      with_token_authentication do
+        with_permissions %w[product.read] do
+          without_token_permissions { denies :show }
+
+          allows :show
+        end
+
+        with_wildcard_permissions do
+          without_token_permissions { denies :show }
+
+          allows :show
+        end
+
+        with_default_permissions do
+          without_token_permissions { denies :show }
+
+          allows :show
+        end
+
+        without_permissions do
+          denies :show
+        end
+
+        within_environment :isolated do
+          with_bearer_and_token_trait :in_shared_environment do
+            denies :show
+          end
+
+          with_bearer_and_token_trait :in_nil_environment do
+            denies :show
+          end
+
+          allows :show
+        end
+
+        within_environment :shared do
+          with_bearer_and_token_trait :in_isolated_environment do
+            denies :show
+          end
+
+          with_bearer_and_token_trait :in_nil_environment do
+            allows :show
+          end
+
+          allows :show
+        end
+
+        within_environment nil do
+          with_bearer_and_token_trait :in_isolated_environment do
+            denies :show
+          end
+
+          with_bearer_and_token_trait :in_shared_environment do
+            denies :show
+          end
+
+          allows :show
+        end
+      end
+    end
+
+    with_scenarios %i[accessing_another_account accessing_a_machine_component accessing_its_product] do
+      with_token_authentication do
+        with_permissions %w[product.read] do
+          denies :show
+        end
+
+        with_wildcard_permissions do
+          denies :show
+        end
+
+        with_default_permissions do
+          denies :show
+        end
+
+        without_permissions do
+          denies :show
+        end
+      end
+    end
+  end
+
+  with_role_authorization :environment do
+    within_environment :self do
+      with_scenarios %i[accessing_a_machine_component accessing_its_product] do
+        with_token_authentication do
+          with_permissions %w[product.read] do
+            without_token_permissions { denies :show }
+
+            allows :show
+          end
+
+          with_wildcard_permissions do
+            without_token_permissions { denies :show }
+
+            allows :show
+          end
+
+          with_default_permissions do
+            without_token_permissions { denies :show }
+
+            allows :show
+          end
+
+          without_permissions do
+            denies :show
+          end
+        end
+      end
+    end
+
+    with_scenarios %i[accessing_a_machine_component accessing_its_product] do
+      with_token_authentication do
+        with_permissions %w[product.read] do
+          denies :show
+        end
+
+        with_wildcard_permissions do
+          denies :show
+        end
+
+        with_default_permissions do
+          denies :show
+        end
+
+        without_permissions do
+          denies :show
+        end
+      end
+    end
+  end
+
+  with_role_authorization :product do
+    with_scenarios %i[accessing_its_machine_component accessing_its_product] do
+      with_token_authentication do
+        with_permissions %w[product.read] do
+          without_token_permissions { denies :show }
+
+          allows :show
+        end
+
+        with_wildcard_permissions do
+          without_token_permissions { denies :show }
+
+          allows :show
+        end
+
+        with_default_permissions do
+          without_token_permissions { denies :show }
+
+          allows :show
+        end
+
+        without_permissions do
+          denies :show
+        end
+      end
+    end
+
+    with_scenarios %i[accessing_a_machine_component accessing_its_product] do
+      with_token_authentication do
+        with_permissions %w[product.read] do
+          denies :show
+        end
+
+        with_wildcard_permissions do
+          denies :show
+        end
+
+        with_default_permissions do
+          denies :show
+        end
+
+        without_permissions do
+          denies :show
+        end
+      end
+    end
+  end
+
+  with_role_authorization :license do
+    with_scenarios %i[accessing_its_machine_component accessing_its_product] do
+      with_license_authentication do
+        with_permissions %w[product.read] do
+          allows :show
+        end
+
+        with_wildcard_permissions do
+          allows :show
+        end
+
+        with_default_permissions do
+          denies :show
+        end
+
+        without_permissions do
+          denies :show
+        end
+      end
+
+      with_token_authentication do
+        with_permissions %w[product.read] do
+          without_token_permissions { denies :show }
+
+          allows :show
+        end
+
+        with_wildcard_permissions do
+          without_token_permissions { denies :show }
+
+          allows :show
+        end
+
+        with_default_permissions do
+          without_token_permissions { denies :show }
+
+          denies :show
+        end
+
+        without_permissions do
+          denies :show
+        end
+      end
+    end
+
+    with_scenarios %i[accessing_a_machine_component accessing_its_product] do
+      with_license_authentication do
+        with_permissions %w[product.read] do
+          denies :show
+        end
+
+        with_wildcard_permissions do
+          denies :show
+        end
+
+        with_default_permissions do
+          denies :show
+        end
+
+        without_permissions do
+          denies :show
+        end
+      end
+
+      with_token_authentication do
+        with_permissions %w[product.read] do
+          denies :show
+        end
+
+        with_wildcard_permissions do
+          denies :show
+        end
+
+        with_default_permissions do
+          denies :show
+        end
+
+        without_permissions do
+          denies :show
+        end
+      end
+    end
+  end
+
+  with_role_authorization :user do
+    with_bearer_trait :with_licenses do
+      with_scenarios %i[accessing_its_machine_component accessing_its_product] do
+        with_token_authentication do
+          with_permissions %w[product.read] do
+            without_token_permissions { denies :show }
+
+            allows :show
+          end
+
+          with_wildcard_permissions do
+            without_token_permissions { denies :show }
+
+            allows :show
+          end
+
+          with_default_permissions do
+            without_token_permissions { denies :show }
+
+            denies :show
+          end
+
+          without_permissions do
+            denies :show
+          end
+        end
+      end
+    end
+
+    with_scenarios %i[accessing_a_machine_component accessing_its_product] do
+      with_token_authentication do
+        with_permissions %w[product.read] do
+          denies :show
+        end
+
+        with_wildcard_permissions do
+          denies :show
+        end
+
+        with_default_permissions do
+          denies :show
+        end
+
+        without_permissions do
+          denies :show
+        end
+      end
+    end
+  end
+
+  without_authorization do
+    with_scenarios %i[accessing_a_machine_component accessing_its_product] do
+      without_authentication do
+        denies :show
+      end
+    end
+  end
+end

--- a/spec/policies/machines/machine_component_policy_spec.rb
+++ b/spec/policies/machines/machine_component_policy_spec.rb
@@ -1,0 +1,496 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'spec_helper'
+
+describe Machines::MachineComponentPolicy, type: :policy do
+  subject { described_class.new(record, account:, environment:, bearer:, token:, machine:) }
+
+  with_role_authorization :admin do
+    with_scenarios %i[accessing_a_machine accessing_its_machine_components] do
+      with_token_authentication do
+        with_permissions %w[component.read] do
+          without_token_permissions { denies :index }
+
+          allows :index
+        end
+
+        with_wildcard_permissions { allows :index }
+        with_default_permissions  { allows :index }
+        without_permissions       { denies :index }
+
+        within_environment :isolated do
+          with_bearer_and_token_trait :in_shared_environment do
+            denies :index
+          end
+
+          with_bearer_and_token_trait :in_nil_environment do
+            denies :index
+          end
+
+          allows :index
+        end
+
+        within_environment :shared do
+          with_bearer_and_token_trait :in_isolated_environment do
+            denies :index
+          end
+
+          with_bearer_and_token_trait :in_nil_environment do
+            allows :index
+          end
+
+          allows :index
+        end
+
+        within_environment nil do
+          with_bearer_and_token_trait :in_isolated_environment do
+            denies :index
+          end
+
+          with_bearer_and_token_trait :in_shared_environment do
+            denies :index
+          end
+
+          allows :index
+        end
+      end
+    end
+
+    with_scenarios %i[accessing_a_machine accessing_its_machine_component] do
+      with_token_authentication do
+        with_permissions %w[component.read] do
+          without_token_permissions { denies :show }
+
+          allows :show
+        end
+
+        with_wildcard_permissions do
+          without_token_permissions do
+            denies :show
+          end
+
+          allows :show
+        end
+
+        with_default_permissions do
+          without_token_permissions do
+            denies :show
+          end
+
+          allows :show
+        end
+
+        without_permissions do
+          denies :show
+        end
+
+        within_environment :isolated do
+          with_bearer_and_token_trait :in_shared_environment do
+            denies :show
+          end
+
+          with_bearer_and_token_trait :in_nil_environment do
+            denies :show
+          end
+
+          allows :show
+        end
+
+        within_environment :shared do
+          with_bearer_and_token_trait :in_isolated_environment do
+            denies :show
+          end
+
+          with_bearer_and_token_trait :in_nil_environment do
+            allows :show
+          end
+
+          allows :show
+        end
+
+        within_environment nil do
+          with_bearer_and_token_trait :in_isolated_environment do
+            denies :show
+          end
+
+          with_bearer_and_token_trait :in_shared_environment do
+            denies :show
+          end
+
+          allows :show
+        end
+      end
+    end
+
+    with_scenarios %i[accessing_another_account accessing_a_machine accessing_its_machine_component] do
+      with_token_authentication do
+        with_permissions %w[component.read] do
+          denies :show
+        end
+
+        with_wildcard_permissions do
+          denies :show
+        end
+
+        with_default_permissions do
+          denies :show
+        end
+
+        without_permissions do
+          denies :show
+        end
+      end
+    end
+  end
+
+  with_role_authorization :environment do
+    within_environment :self do
+      with_scenarios %i[accessing_a_machine accessing_its_machine_components] do
+        with_token_authentication do
+          with_permissions %w[component.read] do
+            without_token_permissions { denies :index }
+
+            allows :index
+          end
+
+          with_wildcard_permissions { allows :index }
+          with_default_permissions  { allows :index }
+          without_permissions       { denies :index }
+        end
+      end
+
+      with_scenarios %i[accessing_a_machine accessing_its_machine_component] do
+        with_token_authentication do
+          with_permissions %w[component.read] do
+            without_token_permissions { denies :show }
+
+            allows :show
+          end
+
+          with_wildcard_permissions do
+            allows :show
+          end
+
+          with_default_permissions do
+            allows :show
+          end
+
+          without_permissions do
+            denies :show
+          end
+        end
+      end
+    end
+
+    with_scenarios %i[accessing_a_machine accessing_its_machine_components] do
+      with_token_authentication do
+        with_permissions %w[component.read] do
+          without_token_permissions { denies :index }
+
+          denies :index
+        end
+
+        with_wildcard_permissions { denies :index }
+        with_default_permissions  { denies :index }
+        without_permissions       { denies :index }
+      end
+    end
+
+    with_scenarios %i[accessing_a_machine accessing_its_machine_component] do
+      with_token_authentication do
+        with_permissions %w[component.read] do
+          without_token_permissions { denies :show }
+
+          denies :show
+        end
+
+        with_wildcard_permissions do
+          denies :show
+        end
+
+        with_default_permissions do
+          denies :show
+        end
+
+        without_permissions do
+          denies :show
+        end
+      end
+    end
+  end
+
+  with_role_authorization :product do
+    with_scenarios %i[accessing_its_machine accessing_its_machine_components] do
+      with_token_authentication do
+        with_permissions %w[component.read] do
+          without_token_permissions { denies :index }
+
+          allows :index
+        end
+
+        with_wildcard_permissions { allows :index }
+        with_default_permissions  { allows :index }
+        without_permissions       { denies :index }
+      end
+    end
+
+    with_scenarios %i[accessing_its_machine accessing_its_machine_component] do
+      with_token_authentication do
+        with_permissions %w[component.read] do
+          without_token_permissions { denies :show }
+
+          allows :show
+        end
+
+        with_wildcard_permissions do
+          allows :show
+        end
+
+        with_default_permissions do
+          allows :show
+        end
+
+        without_permissions do
+          denies :show
+        end
+      end
+    end
+
+    with_scenarios %i[accessing_a_machine accessing_its_machine_components] do
+      with_token_authentication do
+        with_permissions %w[component.read] do
+          without_token_permissions { denies :index }
+
+          denies :index
+        end
+
+        with_wildcard_permissions { denies :index }
+        with_default_permissions  { denies :index }
+        without_permissions       { denies :index }
+      end
+    end
+
+    with_scenarios %i[accessing_a_machine accessing_its_machine_component] do
+      with_token_authentication do
+        with_permissions %w[component.read] do
+          without_token_permissions { denies :show }
+
+          denies :show
+        end
+
+        with_wildcard_permissions do
+          denies :show
+        end
+
+        with_default_permissions do
+          denies :show
+        end
+
+        without_permissions do
+          denies :show
+        end
+      end
+    end
+  end
+
+  with_role_authorization :license do
+    with_scenarios %i[accessing_its_machine accessing_its_machine_components] do
+      with_token_authentication do
+        with_permissions %w[component.read] do
+          without_token_permissions { denies :index }
+
+          allows :index
+        end
+
+        with_wildcard_permissions { allows :index }
+        with_default_permissions  { allows :index }
+        without_permissions       { denies :index }
+      end
+    end
+
+    with_scenarios %i[accessing_its_machine accessing_its_machine_component] do
+      with_license_authentication do
+        with_permissions %w[component.read] do
+          allows :show
+        end
+
+        with_wildcard_permissions do
+          allows :show
+        end
+
+        with_default_permissions do
+          allows :show
+        end
+
+        without_permissions do
+          denies :show
+        end
+      end
+
+      with_token_authentication do
+        with_permissions %w[component.read] do
+          without_token_permissions { denies :show }
+
+          allows :show
+        end
+
+        with_wildcard_permissions do
+          allows :show
+        end
+
+        with_default_permissions do
+          allows :show
+        end
+
+        without_permissions do
+          denies :show
+        end
+      end
+    end
+
+    with_scenarios %i[accessing_a_machine accessing_its_machine_components] do
+      with_token_authentication do
+        with_permissions %w[component.read] do
+          without_token_permissions { denies :index }
+
+          denies :index
+        end
+
+        with_wildcard_permissions { denies :index }
+        with_default_permissions  { denies :index }
+        without_permissions       { denies :index }
+      end
+    end
+
+    with_scenarios %i[accessing_a_machine accessing_its_machine_component] do
+      with_license_authentication do
+        with_permissions %w[component.read] do
+          denies :show
+        end
+
+        with_wildcard_permissions do
+          denies :show
+        end
+
+        with_default_permissions do
+          denies :show
+        end
+
+        without_permissions do
+          denies :show
+        end
+      end
+
+      with_token_authentication do
+        with_permissions %w[component.read] do
+          without_token_permissions { denies :show }
+
+          denies :show
+        end
+
+        with_wildcard_permissions do
+          denies :show
+        end
+
+        with_default_permissions do
+          denies :show
+        end
+
+        without_permissions do
+          denies :show
+        end
+      end
+    end
+  end
+
+  with_role_authorization :user do
+    with_bearer_trait :with_licenses do
+      with_scenarios %i[accessing_its_machine accessing_its_machine_components] do
+        with_token_authentication do
+          with_permissions %w[component.read] do
+            without_token_permissions { denies :index }
+
+            allows :index
+          end
+
+          with_wildcard_permissions { allows :index }
+          with_default_permissions  { allows :index }
+          without_permissions       { denies :index }
+        end
+      end
+
+      with_scenarios %i[accessing_its_machine accessing_its_machine_component] do
+        with_token_authentication do
+          with_permissions %w[component.read] do
+            without_token_permissions { denies :show }
+
+            allows :show
+          end
+
+          with_wildcard_permissions do
+            allows :show
+          end
+
+          with_default_permissions do
+            allows :show
+          end
+
+          without_permissions do
+            denies :show
+          end
+        end
+      end
+    end
+
+    with_scenarios %i[accessing_a_machine accessing_its_machine_components] do
+      with_token_authentication do
+        with_permissions %w[component.read] do
+          without_token_permissions { denies :index }
+
+          denies :index
+        end
+
+        with_wildcard_permissions { denies :index }
+        with_default_permissions  { denies :index }
+        without_permissions       { denies :index }
+      end
+    end
+
+    with_scenarios %i[accessing_a_machine accessing_its_machine_component] do
+      with_token_authentication do
+        with_permissions %w[component.read] do
+          without_token_permissions { denies :show }
+
+          denies :show
+        end
+
+        with_wildcard_permissions do
+          denies :show
+        end
+
+        with_default_permissions do
+          denies :show
+        end
+
+        without_permissions do
+          denies :show
+        end
+      end
+    end
+  end
+
+  without_authorization do
+    with_scenarios %i[accessing_a_machine accessing_its_machine_components] do
+      without_authentication do
+        denies :index
+      end
+    end
+
+    with_scenarios %i[accessing_a_machine accessing_its_machine_component] do
+      without_authentication do
+        denies :show
+      end
+    end
+  end
+end

--- a/spec/support/helpers/authorization_helper.rb
+++ b/spec/support/helpers/authorization_helper.rb
@@ -283,6 +283,8 @@ module AuthorizationHelper
       case scenarios
       in [*, :accessing_its_release | :accessing_a_release, *]
         let(:product) { release.product }
+      in [*, :accessing_its_machine_component | :accessing_a_machine_component, *]
+        let(:product) { machine_component.product }
       in [*, :accessing_its_machine_process | :accessing_a_machine_process, *]
         let(:product) { machine_process.product }
       in [*, :accessing_its_pooled_key | :accessing_a_pooled_key, *]
@@ -565,6 +567,8 @@ module AuthorizationHelper
 
           license.user
         }
+      in [*, :accessing_its_machine_component | :accessing_a_machine_component, *]
+        let(:user) { machine_component.user }
       in [*, :accessing_its_machine_process | :accessing_a_machine_process, *]
         let(:user) { machine_process.user }
       in [*, :accessing_its_machine | :accessing_a_machine, *]
@@ -789,6 +793,8 @@ module AuthorizationHelper
 
           create(:machine, account: license.account, license:)
         }
+      in [*, :accessing_its_machine_component | :accessing_a_machine_component, *]
+        let(:machine) { machine_component.machine }
       in [*, :accessing_its_machine_process | :accessing_a_machine_process, *]
         let(:machine) { machine_process.machine }
       in [*, :accessing_its_license | :accessing_a_license, *]
@@ -1292,6 +1298,8 @@ module AuthorizationHelper
 
           create(:license, *license_traits, account: policy.account, policy:)
         }
+      in [*, :accessing_its_machine_component | :accessing_a_machine_component, *]
+        let(:license) { machine_component.license }
       in [*, :accessing_its_machine_process | :accessing_a_machine_process, *]
         let(:license) { machine_process.license }
       in [*, :accessing_its_policy | :accessing_a_policy, *]

--- a/spec/support/helpers/authorization_helper.rb
+++ b/spec/support/helpers/authorization_helper.rb
@@ -824,6 +824,68 @@ module AuthorizationHelper
       let(:record) { machine }
     end
 
+    def accessing_machine_components(scenarios)
+      case scenarios
+      in [*, :accessing_another_account, *]
+        let(:machine_components) { create_list(:component, 3, account: other_account) }
+      else
+        let(:machine_components) { create_list(:component, 3, account:) }
+      end
+
+      let(:record) { machine_components }
+    end
+
+    def accessing_a_machine_component(scenarios)
+      case scenarios
+      in [*, :accessing_another_account, *]
+        let(:machine_component) { create(:component, account: other_account) }
+      else
+        let(:machine_component) { create(:component, account:) }
+      end
+
+      let(:record) { machine_component }
+    end
+
+    def accessing_its_machine_components(scenarios)
+      case scenarios
+      in [*, :accessing_its_machine | :accessing_a_machine, *]
+        let(:machine_components) { create_list(:component, 3, account: machine.account, machine:) }
+      in [:as_product, *]
+        let(:_policy)            { create(:policy, *policy_traits, account:, product: bearer) }
+        let(:_license)           { create(:license, *license_traits, account:, policy: _policy) }
+        let(:_machine)           { create(:machine, account:, license: _license) }
+        let(:machine_components) { create_list(:component, 3, account:, machine: _machine) }
+      in [:as_license, *]
+        let(:_machine)           { create(:machine, account:, license: bearer) }
+        let(:machine_components) { create_list(:component, 3, account:, machine: _machine) }
+      in [:as_user, *]
+        let(:_machine)           { create(:machine, account:, license: bearer.licenses.first) }
+        let(:machine_components) { create_list(:component, 3, account:, machine: _machine) }
+      end
+
+      let(:record) { machine_components }
+    end
+
+    def accessing_its_machine_component(scenarios)
+      case scenarios
+      in [*, :accessing_its_machine | :accessing_a_machine, *]
+        let(:machine_component) { create(:component, account: machine.account, machine:) }
+      in [:as_product, *]
+        let(:_policy)           { create(:policy, *policy_traits, account:, product: bearer) }
+        let(:_license)          { create(:license, *license_traits, account:, policy: _policy) }
+        let(:_machine)          { create(:machine, account:, license: _license) }
+        let(:machine_component) { create(:component, account:, machine: _machine) }
+      in [:as_license, *]
+        let(:_machine)          { create(:machine, account:, license: bearer) }
+        let(:machine_component) { create(:component, account:, machine: _machine) }
+      in [:as_user, *]
+        let(:_machine)          { create(:machine, account:, license: bearer.licenses.first) }
+        let(:machine_component) { create(:component, account:, machine: _machine) }
+      end
+
+      let(:record) { machine_component }
+    end
+
     def accessing_machine_processes(scenarios)
       case scenarios
       in [*, :accessing_another_account, *]
@@ -851,12 +913,12 @@ module AuthorizationHelper
       in [*, :accessing_its_machine | :accessing_a_machine, *]
         let(:machine_processes) { create_list(:process, 3, account: machine.account, machine:) }
       in [:as_product, *]
-        let(:_policy)            { create(:policy, *policy_traits, account:, product: bearer) }
-        let(:_license)           { create(:license, *license_traits, account:, policy: _policy) }
-        let(:_machine)           { create(:machine, account:, license: _license) }
+        let(:_policy)           { create(:policy, *policy_traits, account:, product: bearer) }
+        let(:_license)          { create(:license, *license_traits, account:, policy: _policy) }
+        let(:_machine)          { create(:machine, account:, license: _license) }
         let(:machine_processes) { create_list(:process, 3, account:, machine: _machine) }
       in [:as_license, *]
-        let(:_machine)           { create(:machine, account:, license: bearer) }
+        let(:_machine)          { create(:machine, account:, license: bearer) }
         let(:machine_processes) { create_list(:process, 3, account:, machine: _machine) }
       in [:as_user, *]
         let(:_machine)          { create(:machine, account:, license: bearer.licenses.first) }
@@ -871,15 +933,15 @@ module AuthorizationHelper
       in [*, :accessing_its_machine | :accessing_a_machine, *]
         let(:machine_process) { create(:process, account: machine.account, machine:) }
       in [:as_product, *]
-        let(:_policy)          { create(:policy, *policy_traits, account:, product: bearer) }
-        let(:_license)         { create(:license, *license_traits, account:, policy: _policy) }
-        let(:_machine)         { create(:machine, account:, license: _license) }
+        let(:_policy)         { create(:policy, *policy_traits, account:, product: bearer) }
+        let(:_license)        { create(:license, *license_traits, account:, policy: _policy) }
+        let(:_machine)        { create(:machine, account:, license: _license) }
         let(:machine_process) { create(:process, account:, machine: _machine) }
       in [:as_license, *]
-        let(:_machine)         { create(:machine, account:, license: bearer) }
+        let(:_machine)        { create(:machine, account:, license: bearer) }
         let(:machine_process) { create(:process, account:, machine: _machine) }
       in [:as_user, *]
-        let(:_machine)         { create(:machine, account:, license: bearer.licenses.first) }
+        let(:_machine)        { create(:machine, account:, license: bearer.licenses.first) }
         let(:machine_process) { create(:process, account:, machine: _machine) }
       end
 


### PR DESCRIPTION
Closes #390. Adds a machine component resource for tracking a machine's hardware components, instead of relying on multiple machines. Can be asserted during validation via the new `components` validation scope.

## Post-deploy

```bash
# Add new permissions and event types
rake db:seed

# Migrate existing role permissions
rake keygen:permissions:admins:add[component.create,component.delete,component.read,component.update]
rake keygen:permissions:environments:add[component.create,component.delete,component.read,component.update]
rake keygen:permissions:products:add[component.create,component.delete,component.read,component.update]
rake keygen:permissions:licenses:add[component.create,component.delete,component.read,component.update]
rake keygen:permissions:users:add[component.create,component.delete,component.read,component.update]
```

(Would be nice to support `component.{create,delete,read,update}` for the above Rake task.)