### PR TITLE
Add API migrations to license file certificates

### DIFF
--- a/app/controllers/api/v1/event_logs_controller.rb
+++ b/app/controllers/api/v1/event_logs_controller.rb
@@ -20,7 +20,7 @@ module Api::V1
 
       json = Rails.cache.fetch(cache_key, expires_in: 1.minute, race_condition_ttl: 30.seconds) do
         event_logs = apply_pagination(authorized_scope(apply_scopes(current_account.event_logs)).preload(:event_type, :account, :whodunnit, :resource))
-        data = Keygen::JSONAPI::Renderer.new.render(event_logs)
+        data = Keygen::JSONAPI.render(event_logs)
 
         data.tap do |d|
           d[:links] = pagination_links(event_logs)

--- a/app/controllers/api/v1/licenses/actions/checkouts_controller.rb
+++ b/app/controllers/api/v1/licenses/actions/checkouts_controller.rb
@@ -55,7 +55,7 @@ module Api::V1::Licenses::Actions
                                :include,
                                :encrypt,
                                :ttl,
-                              )
+                             )
 
       license_file = checkout_license_file(**kwargs)
 
@@ -85,6 +85,7 @@ module Api::V1::Licenses::Actions
         to: :check_out?
 
       license_file = LicenseCheckoutService.call(
+        api_version: current_api_version,
         environment: current_environment,
         account: current_account,
         license:,

--- a/app/controllers/api/v1/machines/actions/checkouts_controller.rb
+++ b/app/controllers/api/v1/machines/actions/checkouts_controller.rb
@@ -55,7 +55,7 @@ module Api::V1::Machines::Actions
                                :include,
                                :encrypt,
                                :ttl,
-                              )
+                             )
 
       machine_file = checkout_machine_file(**kwargs)
 
@@ -87,6 +87,7 @@ module Api::V1::Machines::Actions
         to: :check_out?
 
       machine_file = MachineCheckoutService.call(
+        api_version: current_api_version,
         environment: current_environment,
         account: current_account,
         machine:,

--- a/app/controllers/api/v1/metrics_controller.rb
+++ b/app/controllers/api/v1/metrics_controller.rb
@@ -16,7 +16,7 @@ module Api::V1
 
       json = Rails.cache.fetch(cache_key, expires_in: 1.minute, race_condition_ttl: 30.seconds) do
         metrics = apply_pagination(authorized_scope(apply_scopes(current_account.metrics)).preload(:event_type))
-        data    = Keygen::JSONAPI::Renderer.new.render(metrics)
+        data    = Keygen::JSONAPI.render(metrics)
 
         data.tap { _1[:links] = pagination_links(metrics) }
       end

--- a/app/controllers/api/v1/plans_controller.rb
+++ b/app/controllers/api/v1/plans_controller.rb
@@ -9,7 +9,7 @@ module Api::V1
 
       json = Rails.cache.fetch(cache_key, expires_in: 1.hour, race_condition_ttl: 1.minute) do
         plans = apply_pagination(apply_scopes(Plan.visible).reorder('price ASC NULLS FIRST'))
-        data = Keygen::JSONAPI::Renderer.new.render(plans)
+        data = Keygen::JSONAPI.render(plans)
 
         data
       end

--- a/app/controllers/api/v1/request_logs_controller.rb
+++ b/app/controllers/api/v1/request_logs_controller.rb
@@ -23,7 +23,7 @@ module Api::V1
 
       json = Rails.cache.fetch(cache_key, expires_in: 1.minute, race_condition_ttl: 30.seconds) do
         request_logs = apply_pagination(authorized_scope(apply_scopes(current_account.request_logs)).without_blobs.preload(:account, :requestor, :resource))
-        data = Keygen::JSONAPI::Renderer.new.render(request_logs)
+        data = Keygen::JSONAPI.render(request_logs)
 
         data.tap do |d|
           d[:links] = pagination_links(request_logs)

--- a/app/services/license_checkout_service.rb
+++ b/app/services/license_checkout_service.rb
@@ -1,9 +1,8 @@
 # frozen_string_literal: true
 
 class LicenseCheckoutService < AbstractCheckoutService
-  class InvalidAccountError < StandardError; end
-  class InvalidLicenseError < StandardError; end
   class InvalidIncludeError < StandardError; end
+  class InvalidLicenseError < StandardError; end
 
   ALLOWED_INCLUDES = %w[
     entitlements
@@ -14,22 +13,17 @@ class LicenseCheckoutService < AbstractCheckoutService
     user
   ].freeze
 
-  def initialize(account:, license:, environment: nil, encrypt: false, ttl: 1.month, include: [], api_version: nil)
-    raise InvalidAccountError, 'account must be present' unless
-      account.present?
-
+  def initialize(license:, environment: nil, include: [], **kwargs)
     raise InvalidLicenseError, 'license must be present' unless
       license.present?
 
     raise InvalidIncludeError, 'invalid includes' if
       (include - ALLOWED_INCLUDES).any?
 
-    @account     = account
     @license     = license
     @environment = environment
-    @api_version = api_version
 
-    super(account:, encrypt:, ttl:, include:)
+    super(scheme: license.scheme, include:, **kwargs)
   end
 
   def call
@@ -43,28 +37,12 @@ class LicenseCheckoutService < AbstractCheckoutService
     meta = { issued: issued_at, expiry: expires_at, ttl: ttl }
     incl = includes & ALLOWED_INCLUDES
     data = renderer.render(license, meta: meta, include: incl)
-
-    # Migrate dataset to target version
-    migrator = RequestMigrations::Migrator.new(
-      from: CURRENT_API_VERSION,
-      to: api_version || account.api_version,
-    )
-
-    # Migrate the license
-    migrator.migrate!(data:)
-
-    # FIXME(ezekg) Migration expects a data top-level key, so we're adding
-    #              that here. It still mutates the includes.
-    #
-    # Migrate includes
-    migrator.migrate!(data: {
-      data: data[:included],
-    })
+                   .to_json
 
     enc = if encrypted?
-            encrypt(data.to_json, secret: license.key)
+            encrypt(data, secret: license.key)
           else
-            encode(data.to_json, strict: true)
+            encode(data, strict: true)
           end
     sig = sign(enc, key: private_key, algorithm: algorithm, prefix: 'license')
     alg = if encrypted?
@@ -96,36 +74,5 @@ class LicenseCheckoutService < AbstractCheckoutService
   private
 
   attr_reader :environment,
-              :account,
-              :license,
-              :api_version
-
-  def private_key
-    case license.scheme
-    when 'RSA_2048_PKCS1_PSS_SIGN_V2',
-         'RSA_2048_PKCS1_SIGN_V2',
-         'RSA_2048_PKCS1_PSS_SIGN',
-         'RSA_2048_PKCS1_SIGN',
-         'RSA_2048_PKCS1_ENCRYPT',
-         'RSA_2048_JWT_RS256'
-      account.private_key
-    else
-      account.ed25519_private_key
-    end
-  end
-
-  def algorithm
-    case license.scheme
-    when 'RSA_2048_PKCS1_PSS_SIGN_V2',
-         'RSA_2048_PKCS1_PSS_SIGN'
-      'rsa-pss-sha256'
-    when 'RSA_2048_PKCS1_SIGN_V2',
-         'RSA_2048_PKCS1_SIGN',
-         'RSA_2048_PKCS1_ENCRYPT',
-         'RSA_2048_JWT_RS256'
-      'rsa-sha256'
-    else
-      'ed25519'
-    end
-  end
+              :license
 end

--- a/features/api/v1/licenses/actions/checkouts.feature
+++ b/features/api/v1/licenses/actions/checkouts.feature
@@ -583,6 +583,64 @@ Feature: License checkout actions
     And sidekiq should have 1 "metric" job
     And sidekiq should have 1 "request-log" job
 
+  Scenario: Admin performs a license checkout with a policy include (POST, v1.4)
+    Given the current account is "test1"
+    And the current account has 1 "webhook-endpoint"
+    And the current account has 1 "policy"
+    And the current account has 1 "license" for the last "policy"
+    And I am an admin of account "test1"
+    And I use an authentication token
+    And I use API version "1.4"
+    When I send a POST request to "/accounts/test1/licenses/$0/actions/check-out?include=policy"
+    Then the response status should be "200"
+    And the response body should be a "license-file" with the following encoded certificate data:
+      """
+      {
+        "included": [
+          {
+            "type": "policies",
+            "id": "$policies[0]",
+            "attributes": {
+              "machineUniquenessStrategy": "UNIQUE_PER_LICENSE",
+              "machineMatchingStrategy": "MATCH_ANY"
+            }
+          }
+        ]
+      }
+      """
+    And sidekiq should have 1 "webhook" job
+    And sidekiq should have 1 "metric" job
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: Admin performs a license checkout with a policy include (POST, v1.3)
+    Given the current account is "test1"
+    And the current account has 1 "webhook-endpoint"
+    And the current account has 1 "policy"
+    And the current account has 1 "license" for the last "policy"
+    And I am an admin of account "test1"
+    And I use an authentication token
+    And I use API version "1.3"
+    When I send a POST request to "/accounts/test1/licenses/$0/actions/check-out?include=policy"
+    Then the response status should be "200"
+    And the response body should be a "license-file" with the following encoded certificate data:
+      """
+      {
+        "included": [
+          {
+            "type": "policies",
+            "id": "$policies[0]",
+            "attributes": {
+              "fingerprintUniquenessStrategy": "UNIQUE_PER_LICENSE",
+              "fingerprintMatchingStrategy": "MATCH_ANY"
+            }
+          }
+        ]
+      }
+      """
+    And sidekiq should have 1 "webhook" job
+    And sidekiq should have 1 "metric" job
+    And sidekiq should have 1 "request-log" job
+
   Scenario: Admin performs a license checkout with a policy include (GET)
     Given the current account is "test1"
     And the current account has 1 "webhook-endpoint"

--- a/features/api/v1/licenses/actions/checkouts.feature
+++ b/features/api/v1/licenses/actions/checkouts.feature
@@ -593,6 +593,7 @@ Feature: License checkout actions
     And I use API version "1.4"
     When I send a POST request to "/accounts/test1/licenses/$0/actions/check-out?include=policy"
     Then the response status should be "200"
+    And the response should contain a valid signature header for "test1"
     And the response body should be a "license-file" with the following encoded certificate data:
       """
       {
@@ -622,6 +623,7 @@ Feature: License checkout actions
     And I use API version "1.3"
     When I send a POST request to "/accounts/test1/licenses/$0/actions/check-out?include=policy"
     Then the response status should be "200"
+    And the response should contain a valid signature header for "test1"
     And the response body should be a "license-file" with the following encoded certificate data:
       """
       {

--- a/features/api/v1/machines/actions/checkouts.feature
+++ b/features/api/v1/machines/actions/checkouts.feature
@@ -646,6 +646,7 @@ Feature: Machine checkout actions
     And I use API version "1.4"
     When I send a POST request to "/accounts/test1/machines/$0/actions/check-out?include=license.policy"
     Then the response status should be "200"
+    And the response should contain a valid signature header for "test1"
     And the response body should be a "machine-file" with the following encoded certificate data:
       """
       {
@@ -677,6 +678,7 @@ Feature: Machine checkout actions
     And I use API version "1.3"
     When I send a POST request to "/accounts/test1/machines/$0/actions/check-out?include=license.policy"
     Then the response status should be "200"
+    And the response should contain a valid signature header for "test1"
     And the response body should be a "machine-file" with the following encoded certificate data:
       """
       {

--- a/features/api/v1/machines/actions/checkouts.feature
+++ b/features/api/v1/machines/actions/checkouts.feature
@@ -635,6 +635,68 @@ Feature: Machine checkout actions
     And sidekiq should have 1 "metric" job
     And sidekiq should have 1 "request-log" job
 
+  Scenario: Admin performs a machine checkout with a policy include (POST, v1.4)
+    Given the current account is "test1"
+    And the current account has 1 "webhook-endpoint"
+    And the current account has 1 "policy"
+    And the current account has 1 "license" for the last "policy"
+    And the current account has 1 "machine" for the last "license"
+    And I am an admin of account "test1"
+    And I use an authentication token
+    And I use API version "1.4"
+    When I send a POST request to "/accounts/test1/machines/$0/actions/check-out?include=license.policy"
+    Then the response status should be "200"
+    And the response body should be a "machine-file" with the following encoded certificate data:
+      """
+      {
+        "included": [
+          { "type": "licenses", "id": "$licenses[0]" },
+          {
+            "type": "policies",
+            "id": "$policies[0]",
+            "attributes": {
+              "machineUniquenessStrategy": "UNIQUE_PER_LICENSE",
+              "machineMatchingStrategy": "MATCH_ANY"
+            }
+          }
+        ]
+      }
+      """
+    And sidekiq should have 1 "webhook" job
+    And sidekiq should have 1 "metric" job
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: Admin performs a machine checkout with a policy include (POST, v1.3)
+    Given the current account is "test1"
+    And the current account has 1 "webhook-endpoint"
+    And the current account has 1 "policy"
+    And the current account has 1 "license" for the last "policy"
+    And the current account has 1 "machine" for the last "license"
+    And I am an admin of account "test1"
+    And I use an authentication token
+    And I use API version "1.3"
+    When I send a POST request to "/accounts/test1/machines/$0/actions/check-out?include=license.policy"
+    Then the response status should be "200"
+    And the response body should be a "machine-file" with the following encoded certificate data:
+      """
+      {
+        "included": [
+          { "type": "licenses", "id": "$licenses[0]" },
+          {
+            "type": "policies",
+            "id": "$policies[0]",
+            "attributes": {
+              "fingerprintUniquenessStrategy": "UNIQUE_PER_LICENSE",
+              "fingerprintMatchingStrategy": "MATCH_ANY"
+            }
+          }
+        ]
+      }
+      """
+    And sidekiq should have 1 "webhook" job
+    And sidekiq should have 1 "metric" job
+    And sidekiq should have 1 "request-log" job
+
   Scenario: Admin performs a machine checkout with a policy include (GET)
     Given the current account is "test1"
     And the current account has 1 "webhook-endpoint"

--- a/lib/keygen/jsonapi/renderer.rb
+++ b/lib/keygen/jsonapi/renderer.rb
@@ -4,8 +4,10 @@ require 'jsonapi/serializable/renderer'
 
 module Keygen::JSONAPI
   class Renderer < ::JSONAPI::Serializable::Renderer
-    def initialize(account: nil, bearer: nil, token: nil, context: nil)
-      @renderer = ::JSONAPI::Renderer.new
+    def initialize(account: nil, bearer: nil, token: nil, context: nil, api_version: nil)
+      @renderer        = ::JSONAPI::Renderer.new
+      @api_version     = api_version
+      @account         = account
       @default_options = {
         class: -> klass { "#{klass}Serializer".safe_constantize },
         expose: {
@@ -19,11 +21,40 @@ module Keygen::JSONAPI
     end
 
     def render(resources, options = {})
-      super(resources, default_options.merge(options || {}))
+      data = super(resources, { **default_options, **options })
+
+      # Migrate dataset to target API version
+      migrate!(data:)
+
+      data
     end
 
     private
 
-    attr_reader :default_options
+    attr_reader :default_options,
+                :api_version,
+                :account
+
+    def migrate!(data:)
+      current_version = CURRENT_API_VERSION
+      target_version  = api_version || account&.api_version
+      return if
+        current_version.nil? || target_version.nil?
+
+      migrator = RequestMigrations::Migrator.new(
+        from: current_version,
+        to: target_version,
+      )
+
+      # FIXME(ezekg) Migrations expect a top-level data key, so we're adding
+      #              that here. It still mutates the includes.
+      if data.key?(:included)
+        migrator.migrate!(data: {
+          data: data[:included],
+        })
+      end
+
+      migrator.migrate!(data:)
+    end
   end
 end


### PR DESCRIPTION
Resources included inside license files, e.g. policies, did not have API migrations applied to them. This resolves that.