### PR TITLE
Update event logs pruning to only prune duplicates

### DIFF
--- a/app/models/event_log.rb
+++ b/app/models/event_log.rb
@@ -21,6 +21,10 @@ class EventLog < ApplicationRecord
 
   has_environment
 
+  # NOTE(ezekg) Would love to add a default instead of this, but alas,
+  #             the table is too big and it would break everything.
+  before_create -> { self.created_date ||= (created_at || Date.current) }
+
   scope :for_event_type, -> event {
     where(event_type_id: EventType.where(event:))
   }

--- a/db/migrate/20231013164654_add_created_date_to_event_logs.rb
+++ b/db/migrate/20231013164654_add_created_date_to_event_logs.rb
@@ -1,0 +1,11 @@
+class AddCreatedDateToEventLogs < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def change
+    add_column :event_logs, :created_date, :date, null: true
+
+    add_index :event_logs, %i[account_id created_date],
+      order: { created_date: :desc },
+      algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_14_184536) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_13_164654) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_stat_statements"
@@ -109,7 +109,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_14_184536) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.uuid "environment_id"
+    t.date "created_date"
     t.index ["account_id", "created_at"], name: "index_event_logs_on_account_id_and_created_at", order: { created_at: :desc }
+    t.index ["account_id", "created_date"], name: "index_event_logs_on_account_id_and_created_date", order: { created_date: :desc }
     t.index ["environment_id"], name: "index_event_logs_on_environment_id"
     t.index ["event_type_id"], name: "index_event_logs_on_event_type_id"
     t.index ["idempotency_key"], name: "index_event_logs_on_idempotency_key", unique: true

--- a/spec/factories/event_log.rb
+++ b/spec/factories/event_log.rb
@@ -10,6 +10,34 @@ FactoryBot.define do
     whodunnit   { build(:user, account:, environment:) }
     event_type
 
+    trait :license_validation_succeeded do
+      event_type { build(:event_type, event: 'license.validation.succeeded') }
+    end
+
+    trait :license_validation_failed do
+      event_type { build(:event_type, event: 'license.validation.failed') }
+    end
+
+    trait :machine_heartbeat_ping do
+      event_type { build(:event_type, event: 'machine.heartbeat.ping') }
+    end
+
+    trait :process_heartbeat_ping do
+      event_type { build(:event_type, event: 'process.heartbeat.ping') }
+    end
+
+    trait :license_created do
+      event_type { build(:event_type, event: 'license.created') }
+    end
+
+    trait :machine_created do
+      event_type { build(:event_type, event: 'machine.created') }
+    end
+
+    trait :machine_deleted do
+      event_type { build(:event_type, event: 'machine.deleted') }
+    end
+
     trait :in_isolated_environment do
       environment { build(:environment, :isolated, account:) }
     end

--- a/spec/factories/event_type.rb
+++ b/spec/factories/event_type.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :event_type do
-    initialize_with { new(**attributes) }
+    initialize_with { EventType.find_by(event:) || new(**attributes) }
 
     event { "test.event.#{SecureRandom.hex}" }
   end


### PR DESCRIPTION
Closes #762. Keeps latest event log per-resource, per-day and per-event, removing all duplicates for space savings.