### PR TITLE
Upgrade Rails Autoscale to Judoscale

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -96,8 +96,10 @@ group :production do
   # Monitoring/APM
   gem 'barnes'
 
-  unless ENV.key?('NO_RAILS_AUTOSCALE')
-    gem 'rails_autoscale_agent'
+  # Autoscaling
+  unless ENV.key?('NO_JUDOSCALE') || ENV.key?('NO_RAILS_AUTOSCALE')
+    gem 'judoscale-rails'
+    gem 'judoscale-sidekiq'
   end
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -98,8 +98,8 @@ group :production do
 
   # Autoscaling
   unless ENV.key?('NO_JUDOSCALE') || ENV.key?('NO_RAILS_AUTOSCALE')
-    gem 'judoscale-rails'
-    gem 'judoscale-sidekiq'
+    gem 'judoscale-rails', '~> 1.5.4'
+    gem 'judoscale-sidekiq', '~> 1.5.4'
   end
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -257,12 +257,12 @@ GEM
     jsonapi-renderer (0.2.2)
     jsonapi-serializable (0.3.1)
       jsonapi-renderer (~> 0.2.0)
-    judoscale-rails (1.5.3)
-      judoscale-ruby (= 1.5.3)
+    judoscale-rails (1.5.4)
+      judoscale-ruby (= 1.5.4)
       railties
-    judoscale-ruby (1.5.3)
-    judoscale-sidekiq (1.5.3)
-      judoscale-ruby (= 1.5.3)
+    judoscale-ruby (1.5.4)
+    judoscale-sidekiq (1.5.4)
+      judoscale-ruby (= 1.5.4)
       sidekiq (>= 5.0)
     jwt (2.3.0)
     kaminari (1.2.2)
@@ -530,8 +530,8 @@ DEPENDENCIES
   httparty (~> 0.21.0)
   json (~> 2.3.0)
   jsonapi-rails (= 0.4.0)
-  judoscale-rails
-  judoscale-sidekiq
+  judoscale-rails (~> 1.5.4)
+  judoscale-sidekiq (~> 1.5.4)
   jwt
   kaminari (~> 1.2.0)
   listen (>= 3.8.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -257,6 +257,13 @@ GEM
     jsonapi-renderer (0.2.2)
     jsonapi-serializable (0.3.1)
       jsonapi-renderer (~> 0.2.0)
+    judoscale-rails (1.5.3)
+      judoscale-ruby (= 1.5.3)
+      railties
+    judoscale-ruby (1.5.3)
+    judoscale-sidekiq (1.5.3)
+      judoscale-ruby (= 1.5.3)
+      sidekiq (>= 5.0)
     jwt (2.3.0)
     kaminari (1.2.2)
       activesupport (>= 4.1.0)
@@ -369,7 +376,6 @@ GEM
     rails-pattern_matching (0.2.0)
       activemodel
       activerecord
-    rails_autoscale_agent (0.11.0)
     railties (7.1.3)
       actionpack (= 7.1.3)
       activesupport (= 7.1.3)
@@ -524,6 +530,8 @@ DEPENDENCIES
   httparty (~> 0.21.0)
   json (~> 2.3.0)
   jsonapi-rails (= 0.4.0)
+  judoscale-rails
+  judoscale-sidekiq
   jwt
   kaminari (~> 1.2.0)
   listen (>= 3.8.0)
@@ -542,7 +550,6 @@ DEPENDENCIES
   rack-timeout
   rails (~> 7.1.3)
   rails-pattern_matching
-  rails_autoscale_agent
   redis (~> 4.7.1)
   request_migrations (~> 1.1)
   rotp (~> 6.2)


### PR DESCRIPTION
Rails Autoscale was [renamed to Judoscale](https://github.com/judoscale/judoscale-ruby?tab=readme-ov-file#migrating-from-rails_autoscale_agent) awhile back. This updates the gem, and adds Sidekiq autoscaling.

~~Blocked by https://github.com/judoscale/judoscale-ruby/issues/195.~~