### PR TITLE
Fix N+1 on users index when users are not new (Prosopite)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -105,7 +105,6 @@ group :development, :test do
   gem 'byebug', platform: :mri
   gem 'dotenv-rails'
   gem 'timecop', '~> 0.9.5'
-  gem 'bullet', '~> 7.1.1'
   gem 'parallel_tests', '~> 4.2.1'
   gem 'cuke_modeler', '~> 3.19' # for running `parallel_test --group-by scenarios`
   gem 'faker', '~> 2.20.0'
@@ -121,8 +120,11 @@ group :test do
   gem 'cucumber-rails', '~> 2.5', require: false
   gem 'rspec-rails', '~> 6.0.3'
   gem 'rspec-expectations', '~> 3.12.1'
+  gem 'db-query-matchers'
   gem 'factory_bot_rails', '~> 6.2'
   gem 'database_cleaner', '~> 2.0'
   gem 'webmock', '~> 3.14.0'
   gem 'elif', '~> 0.1.0'
+  gem 'prosopite'
+  gem 'pg_query'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,9 +120,6 @@ GEM
     bcrypt (3.1.17)
     bigdecimal (3.1.4)
     builder (3.2.4)
-    bullet (7.1.1)
-      activesupport (>= 3.0.0)
-      uniform_notifier (~> 1.11)
     byebug (11.1.3)
     capybara (3.36.0)
       addressable
@@ -190,6 +187,9 @@ GEM
       database_cleaner-core (~> 2.0.0)
     database_cleaner-core (2.0.1)
     date (3.3.3)
+    db-query-matchers (0.12.0)
+      activesupport (>= 4.0, < 7.2)
+      rspec (>= 3.0)
     diff-lcs (1.5.0)
     dotenv (2.7.6)
     dotenv-rails (2.7.6)
@@ -216,6 +216,7 @@ GEM
       raabro (~> 1.4)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    google-protobuf (3.25.2)
     haml (5.2.2)
       temple (>= 0.8.0)
       tilt
@@ -318,6 +319,8 @@ GEM
     parallel_tests (4.2.1)
       parallel
     pg (1.3.4)
+    pg_query (5.1.0)
+      google-protobuf (>= 3.22.3)
     premailer (1.15.0)
       addressable
       css_parser (>= 1.6.0)
@@ -325,6 +328,7 @@ GEM
     premailer-rails (1.11.1)
       actionmailer (>= 3)
       premailer (~> 1.7, >= 1.7.9)
+    prosopite (1.4.2)
     psych (5.1.0)
       stringio
     public_suffix (4.0.6)
@@ -397,6 +401,10 @@ GEM
       rack (>= 1.4)
     rexml (3.2.5)
     rotp (6.2.0)
+    rspec (3.12.0)
+      rspec-core (~> 3.12.0)
+      rspec-expectations (~> 3.12.0)
+      rspec-mocks (~> 3.12.0)
     rspec-core (3.12.2)
       rspec-support (~> 3.12.0)
     rspec-expectations (3.12.1)
@@ -483,7 +491,6 @@ GEM
       rails (>= 6.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    uniform_notifier (1.16.0)
     uri (0.12.2)
     webmock (3.14.0)
       addressable (>= 2.8.0)
@@ -509,11 +516,11 @@ DEPENDENCIES
   aws-sdk-s3 (~> 1)
   barnes
   bcrypt (~> 3.1.7)
-  bullet (~> 7.1.1)
   byebug
   cucumber-rails (~> 2.5)
   cuke_modeler (~> 3.19)
   database_cleaner (~> 2.0)
+  db-query-matchers
   dotenv-rails
   ed25519
   elif (~> 0.1.0)
@@ -534,7 +541,9 @@ DEPENDENCIES
   openssl (~> 3.1.0)
   parallel_tests (~> 4.2.1)
   pg (~> 1.3.4)
+  pg_query
   premailer-rails
+  prosopite
   puma (~> 6.4.2)
   rack (~> 2.2.6.2)
   rack-attack (~> 6.6)

--- a/app/controllers/api/v1/products/relationships/release_artifacts_controller.rb
+++ b/app/controllers/api/v1/products/relationships/release_artifacts_controller.rb
@@ -19,7 +19,7 @@ module Api::V1::Products::Relationships
     authorize :product
 
     def index
-      artifacts = apply_pagination(authorized_scope(apply_scopes(product.release_artifacts)).preload(:platform, :arch, :filetype))
+      artifacts = apply_pagination(authorized_scope(apply_scopes(product.release_artifacts)).preload(:platform, :arch, :filetype, release: %i[product entitlements constraints]))
       authorize! artifacts,
         with: Products::ReleaseArtifactPolicy
 

--- a/app/controllers/api/v1/release_packages_controller.rb
+++ b/app/controllers/api/v1/release_packages_controller.rb
@@ -12,7 +12,7 @@ module Api::V1
     before_action :set_package, only: %i[show update destroy]
 
     def index
-      packages = apply_pagination(authorized_scope(apply_scopes(current_account.release_packages)).preload(:engine))
+      packages = apply_pagination(authorized_scope(apply_scopes(current_account.release_packages)).preload(:product, :engine))
       authorize! packages
 
       render jsonapi: packages

--- a/app/controllers/api/v1/releases/relationships/release_artifacts_controller.rb
+++ b/app/controllers/api/v1/releases/relationships/release_artifacts_controller.rb
@@ -17,7 +17,7 @@ module Api::V1::Releases::Relationships
     authorize :release
 
     def index
-      artifacts = apply_pagination(authorized_scope(apply_scopes(release.artifacts)).preload(:platform, :arch, :filetype))
+      artifacts = apply_pagination(authorized_scope(apply_scopes(release.artifacts)).preload(:platform, :arch, :filetype, release: %i[product entitlements constraints]))
       authorize! artifacts,
         with: Releases::ReleaseArtifactPolicy
 

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -22,7 +22,7 @@ module Api::V1
       # We're applying scopes and preloading after the policy scope because
       # our policy scope may include a UNION, and scopes/preloading need to
       # be applied after the UNION query has been performed.
-      users = apply_pagination(authorized_scope(apply_scopes(current_account.users)).preload(:role))
+      users = apply_pagination(authorized_scope(apply_scopes(current_account.users)).preload(:role, :any_active_license))
       authorize! users
 
       render jsonapi: users

--- a/app/models/license.rb
+++ b/app/models/license.rb
@@ -552,16 +552,17 @@ class License < ApplicationRecord
         )
   end
 
-  def entitled?(*identifiers)
-    identifiers = identifiers.flatten
-                             .compact
-
+  def entitled?(*entls)
+    entls = entls.flatten.compact
     return true if
-      identifiers.empty?
+      entls.empty?
 
-    entls = Entitlement.where(id: identifiers).or(
-      Entitlement.where(code: identifiers),
-    )
+    unless entls.all?(Entitlement)
+      entls = Entitlement.where(id: entls)
+                         .or(
+                           Entitlement.where(code: entls),
+                         )
+    end
 
     (entls & entitlements).size == entls.size
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -350,16 +350,16 @@ class User < ApplicationRecord
   end
 
   def entitled?(*identifiers)
-    identifiers = identifiers.flatten
-                             .compact
-
+    entls = entls.flatten.compact
     return true if
-      identifiers.empty?
+      entls.empty?
 
-    entls = Entitlement.where(id: identifiers)
-                       .or(
-                         Entitlement.where(code: identifiers),
-                       )
+    unless entls.all?(Entitlement)
+      entls = Entitlement.where(id: entls)
+                         .or(
+                           Entitlement.where(code: entls),
+                         )
+    end
 
     (entls & entitlements).size == entls.size
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -85,6 +85,9 @@ module Keygen
     # We don't need this: https://guides.rubyonrails.org/security.html#unsafe-query-generation
     config.action_dispatch.perform_deep_munge = false
 
+    # FIXME(ezekg) Fix deprecation warning (not sure where it's coming from)
+    config.action_dispatch.show_exceptions = :none
+
     # Add support for trusted proxies
     config.action_dispatch.trusted_proxies =
       ActionDispatch::RemoteIp::TRUSTED_PROXIES + ENV.fetch('TRUSTED_PROXIES') { '' }

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'bullet'
-
 Rails.application.configure do
   # Configure 'rails notes' to inspect Cucumber files
   config.annotations.register_directories('features')
@@ -88,13 +86,6 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
-
-  # Configure Bullet for performance tests
-  config.after_initialize do
-    Bullet.enable = true
-    Bullet.bullet_logger = true
-    Bullet.rails_logger = true
-  end
 
   # Clear cache on reload when using caching (see https://github.com/rails/rails/issues/43767)
   unless config.cache_classes

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'bullet'
-
 Rails.application.configure do
   # Configure 'rails notes' to inspect Cucumber files
   config.annotations.register_directories('features')
@@ -95,17 +93,12 @@ Rails.application.configure do
   # Disable colored logs in test env
   config.colorize_logging = false
 
-  # Configure Bullet for performance tests
+  # Configure Prosopite for performance tests (e.g. N+1s)
   config.after_initialize do
-    Bullet.enable = true
-    Bullet.bullet_logger = true
-
-    # Raise an error if e.g. an n+1 query is detected
-    Bullet.raise = true
-
-    # FIXME(ezekg) For some reason, we're seeing failures even though
-    #              we're not eager loading anything.
-    Bullet.unused_eager_loading_enable = false
+    Prosopite.enabled          = true
+    Prosopite.prosopite_logger = true
+    Prosopite.rails_logger     = true
+    Prosopite.raise            = true
   end
 end
 

--- a/config/initializers/backtrace_silencers.rb
+++ b/config/initializers/backtrace_silencers.rb
@@ -6,4 +6,4 @@
 # Rails.backtrace_cleaner.add_silencer { |line| line =~ /my_noisy_library/ }
 
 # You can also remove all the silencers if you're trying to debug a problem that might stem from framework code.
-Rails.backtrace_cleaner.remove_silencers!
+# Rails.backtrace_cleaner.remove_silencers!

--- a/features/api/v1/releases/relationships/constraints.feature
+++ b/features/api/v1/releases/relationships/constraints.feature
@@ -418,12 +418,11 @@ Feature: Release constraints relationship
     And the first error should have the following properties:
       """
       {
-        "title": "Unprocessable resource",
-        "detail": "must exist",
+        "title": "Unprocessable entity",
+        "detail": "entitlement 'f5bcf743-52a3-4318-b35c-044fb201d70e' relationship not found",
         "source": {
-          "pointer": "/data/relationships/entitlement"
-        },
-        "code": "ENTITLEMENT_NOT_FOUND"
+          "pointer": "/data/2"
+        }
       }
       """
     And sidekiq should have 0 "webhook" jobs

--- a/features/api/v1/searches/search.feature
+++ b/features/api/v1/searches/search.feature
@@ -1,4 +1,4 @@
-@skip/bullet
+@skip/prosopite
 @api/v1
 Feature: Search
 

--- a/features/api/v1/users/index.feature
+++ b/features/api/v1/users/index.feature
@@ -396,204 +396,122 @@ Feature: List users
   Scenario: Admin retrieves users filtered by status (active)
     Given I am an admin of account "test1"
     And the current account is "test1"
-    And the current account has 7 "users"
-    And the second "user" has the following attributes:
-      """
-      { "bannedAt": "$time.now" }
-      """
-    And the current account has 6 userless "licenses"
-    And the first "license" has the following attributes:
-      """
-      { "userId": "$users[7]" }
-      """
-    And the second "license" has the following attributes:
-      """
-      { "userId": "$users[4]" }
-      """
-    And the third "license" has the following attributes:
-      """
-      {
-        "lastValidatedAt": "$time.2.days.ago",
-        "createdAt": "$time.91.days.ago",
-        "userId": "$users[5]"
-      }
-      """
-    And the fourth "license" has the following attributes:
-      """
-      {
-        "lastValidatedAt": "$time.91.days.ago",
-        "createdAt": "$time.101.days.ago",
-        "userId": "$users[3]"
-      }
-      """
-    # NOTE(ezekg) Updating user created timestamps in reverse order,
-    #             after license assignment.
-    And the fifth "user" has the following attributes:
-      """
-      { "createdAt": "$time.1.year.ago" }
-      """
-    And the fourth "user" has the following attributes:
-      """
-      { "createdAt": "$time.1.year.ago" }
-      """
-    And the third "user" has the following attributes:
-      """
-      { "createdAt": "$time.1.year.ago" }
-      """
+    And time is frozen at "2024-02-07T00:00:00.000Z"
+    And the current account has the following "user" rows:
+      | id                                   | email                                     | created_at               | banned_at                |
+      | d00998f9-d224-4ee7-ac4e-f1e5fe318ff7 | new.user.active@keygen.example            | 2024-02-07T00:00:00.000Z |                          |
+      | 31e30cc1-d454-40dc-b4ae-93ad683ddf33 | old.user.inactive@keygen.example          | 2023-02-07T00:00:00.000Z |                          |
+      | 31e7d077-88ed-4808-bd4b-00b23fc35a57 | old.user.new.license@keygen.example       | 2023-02-07T00:00:00.000Z |                          |
+      | 08c7f078-85d3-46cf-b34c-8dbcef0d30cd | old.user.old.license@keygen.example       | 2023-02-07T00:00:00.000Z |                          |
+      | 2b8dcb3b-4518-4ffb-8512-b49d36dd7dd5 | old.user.validated.license@keygen.example | 2023-02-07T00:00:00.000Z |                          |
+      | 44dce69e-bb15-4915-9adc-074f8b57a61c | old.user.checkout.license@keygen.example  | 2023-02-07T00:00:00.000Z |                          |
+      | a04ac105-ec12-4dc9-89d0-06dd99124349 | old.user.checkin.license@keygen.example   | 2023-02-07T00:00:00.000Z |                          |
+      | 6a0e6577-05eb-47d4-8498-a32d81f5c2b8 | old.user.mixed.licenses@keygen.example    | 2023-02-07T00:00:00.000Z |                          |
+      | 5e360440-acd7-4c63-973e-5133b2ebfdbb | banned.user@keygen.example                | 2024-02-07T00:00:00.000Z | 2024-01-07T00:00:00.000Z |
+    And the current account has the following "license" rows:
+      | id                                   | user_id                              | created_at               | last_validated_at        | last_check_out_at        | last_check_in_at         |
+      | df0beed9-1ab2-4097-9558-cd0adddf321a | 31e7d077-88ed-4808-bd4b-00b23fc35a57 | 2024-02-07T00:00:00.000Z |                          |                          |                          |
+      | c29fc20f-ec09-4cf4-8145-f910109e5705 | 08c7f078-85d3-46cf-b34c-8dbcef0d30cd | 2023-02-07T00:00:00.000Z |                          |                          |                          |
+      | af5c7d44-26bd-4bfd-9dcc-8aed721308ab | 2b8dcb3b-4518-4ffb-8512-b49d36dd7dd5 | 2023-02-07T00:00:00.000Z | 2024-02-07T00:00:00.000Z |                          |                          |
+      | ee26deca-5688-451f-86bd-801291dd2d24 | 44dce69e-bb15-4915-9adc-074f8b57a61c | 2023-02-07T00:00:00.000Z |                          | 2024-02-07T00:00:00.000Z |                          |
+      | e4304d3f-4d6c-4faf-86ee-0ddbb3324aa5 | a04ac105-ec12-4dc9-89d0-06dd99124349 | 2023-02-07T00:00:00.000Z |                          |                          | 2024-02-07T00:00:00.000Z |
+      | 2022a17f-87e4-4b4c-a07b-e28b45f43d6a | 6a0e6577-05eb-47d4-8498-a32d81f5c2b8 | 2023-02-07T00:00:00.000Z |                          |                          |                          |
+      | ce5fc968-cff0-4b41-9f5d-cb42c330d01c | 6a0e6577-05eb-47d4-8498-a32d81f5c2b8 | 2023-02-07T00:00:00.000Z | 2024-02-07T00:00:00.000Z |                          |                          |
     And I use an authentication token
     When I send a GET request to "/accounts/test1/users?status=ACTIVE"
     Then the response status should be "200"
-    And the response body should be an array with 5 "users"
+    And the response body should be an array with 6 "users"
+    And time is unfrozen
 
   Scenario: Admin retrieves users filtered by status (inactive)
     Given I am an admin of account "test1"
     And the current account is "test1"
-    And the current account has 7 "users"
-    And the first "user" has the following attributes:
-      """
-      { "createdAt": "$time.1.year.ago" }
-      """
-    And the second "user" has the following attributes:
-      """
-      { "bannedAt": "$time.now" }
-      """
-    And the third "user" has the following attributes:
-      """
-      { "createdAt": "$time.1.year.ago" }
-      """
-    And the fourth "user" has the following attributes:
-      """
-      { "createdAt": "$time.1.year.ago" }
-      """
-    And the current account has 6 userless "licenses"
-    And the first "license" has the following attributes:
-      """
-      { "userId": "$users[7]" }
-      """
-    And the second "license" has the following attributes:
-      """
-      { "userId": "$users[4]" }
-      """
-    And the third "license" has the following attributes:
-      """
-      {
-        "lastValidatedAt": "$time.2.days.ago",
-        "createdAt": "$time.91.days.ago",
-        "userId": "$users[6]"
-      }
-      """
-    And the fourth "license" has the following attributes:
-      """
-      {
-        "lastValidatedAt": "$time.91.days.ago",
-        "createdAt": "$time.101.days.ago",
-        "userId": "$users[3]"
-      }
-      """
+    And time is frozen at "2024-02-07T00:00:00.000Z"
+    And the current account has the following "user" rows:
+      | id                                   | email                                     | created_at               | banned_at                |
+      | d00998f9-d224-4ee7-ac4e-f1e5fe318ff7 | new.user.active@keygen.example            | 2024-02-07T00:00:00.000Z |                          |
+      | 31e30cc1-d454-40dc-b4ae-93ad683ddf33 | old.user.inactive@keygen.example          | 2023-02-07T00:00:00.000Z |                          |
+      | 31e7d077-88ed-4808-bd4b-00b23fc35a57 | old.user.new.license@keygen.example       | 2023-02-07T00:00:00.000Z |                          |
+      | 08c7f078-85d3-46cf-b34c-8dbcef0d30cd | old.user.old.license@keygen.example       | 2023-02-07T00:00:00.000Z |                          |
+      | 2b8dcb3b-4518-4ffb-8512-b49d36dd7dd5 | old.user.validated.license@keygen.example | 2023-02-07T00:00:00.000Z |                          |
+      | 44dce69e-bb15-4915-9adc-074f8b57a61c | old.user.checkout.license@keygen.example  | 2023-02-07T00:00:00.000Z |                          |
+      | a04ac105-ec12-4dc9-89d0-06dd99124349 | old.user.checkin.license@keygen.example   | 2023-02-07T00:00:00.000Z |                          |
+      | 6a0e6577-05eb-47d4-8498-a32d81f5c2b8 | old.user.mixed.licenses@keygen.example    | 2023-02-07T00:00:00.000Z |                          |
+      | 5e360440-acd7-4c63-973e-5133b2ebfdbb | banned.user@keygen.example                | 2024-02-07T00:00:00.000Z | 2024-01-07T00:00:00.000Z |
+    And the current account has the following "license" rows:
+      | id                                   | user_id                              | created_at               | last_validated_at        | last_check_out_at        | last_check_in_at         |
+      | df0beed9-1ab2-4097-9558-cd0adddf321a | 31e7d077-88ed-4808-bd4b-00b23fc35a57 | 2024-02-07T00:00:00.000Z |                          |                          |                          |
+      | c29fc20f-ec09-4cf4-8145-f910109e5705 | 08c7f078-85d3-46cf-b34c-8dbcef0d30cd | 2023-02-07T00:00:00.000Z |                          |                          |                          |
+      | af5c7d44-26bd-4bfd-9dcc-8aed721308ab | 2b8dcb3b-4518-4ffb-8512-b49d36dd7dd5 | 2023-02-07T00:00:00.000Z | 2024-02-07T00:00:00.000Z |                          |                          |
+      | ee26deca-5688-451f-86bd-801291dd2d24 | 44dce69e-bb15-4915-9adc-074f8b57a61c | 2023-02-07T00:00:00.000Z |                          | 2024-02-07T00:00:00.000Z |                          |
+      | e4304d3f-4d6c-4faf-86ee-0ddbb3324aa5 | a04ac105-ec12-4dc9-89d0-06dd99124349 | 2023-02-07T00:00:00.000Z |                          |                          | 2024-02-07T00:00:00.000Z |
+      | 2022a17f-87e4-4b4c-a07b-e28b45f43d6a | 6a0e6577-05eb-47d4-8498-a32d81f5c2b8 | 2023-02-07T00:00:00.000Z |                          |                          |                          |
+      | ce5fc968-cff0-4b41-9f5d-cb42c330d01c | 6a0e6577-05eb-47d4-8498-a32d81f5c2b8 | 2023-02-07T00:00:00.000Z | 2024-02-07T00:00:00.000Z |                          |                          |
     And I use an authentication token
     When I send a GET request to "/accounts/test1/users?status=INACTIVE"
     Then the response status should be "200"
     And the response body should be an array with 2 "users"
+    And time is unfrozen
 
   Scenario: Admin retrieves users filtered by status (banned)
     Given I am an admin of account "test1"
     And the current account is "test1"
-    And the current account has 7 "users"
-    And the first "user" has the following attributes:
-      """
-      { "createdAt": "$time.1.year.ago" }
-      """
-    And the second "user" has the following attributes:
-      """
-      { "bannedAt": "$time.now" }
-      """
-    And the third "user" has the following attributes:
-      """
-      { "createdAt": "$time.1.year.ago" }
-      """
-    And the fourth "user" has the following attributes:
-      """
-      { "createdAt": "$time.1.year.ago" }
-      """
-    And the current account has 6 userless "licenses"
-    And the first "license" has the following attributes:
-      """
-      { "userId": "$users[7]" }
-      """
-    And the second "license" has the following attributes:
-      """
-      { "userId": "$users[4]" }
-      """
-    And the third "license" has the following attributes:
-      """
-      {
-        "lastValidatedAt": "$time.2.days.ago",
-        "createdAt": "$time.91.days.ago",
-        "userId": "$users[6]"
-      }
-      """
-    And the fourth "license" has the following attributes:
-      """
-      {
-        "lastValidatedAt": "$time.91.days.ago",
-        "createdAt": "$time.101.days.ago",
-        "userId": "$users[3]"
-      }
-      """
+    And time is frozen at "2024-02-07T00:00:00.000Z"
+    And the current account has the following "user" rows:
+      | id                                   | email                                     | created_at               | banned_at                |
+      | d00998f9-d224-4ee7-ac4e-f1e5fe318ff7 | new.user.active@keygen.example            | 2024-02-07T00:00:00.000Z |                          |
+      | 31e30cc1-d454-40dc-b4ae-93ad683ddf33 | old.user.inactive@keygen.example          | 2023-02-07T00:00:00.000Z |                          |
+      | 31e7d077-88ed-4808-bd4b-00b23fc35a57 | old.user.new.license@keygen.example       | 2023-02-07T00:00:00.000Z |                          |
+      | 08c7f078-85d3-46cf-b34c-8dbcef0d30cd | old.user.old.license@keygen.example       | 2023-02-07T00:00:00.000Z |                          |
+      | 2b8dcb3b-4518-4ffb-8512-b49d36dd7dd5 | old.user.validated.license@keygen.example | 2023-02-07T00:00:00.000Z |                          |
+      | 44dce69e-bb15-4915-9adc-074f8b57a61c | old.user.checkout.license@keygen.example  | 2023-02-07T00:00:00.000Z |                          |
+      | a04ac105-ec12-4dc9-89d0-06dd99124349 | old.user.checkin.license@keygen.example   | 2023-02-07T00:00:00.000Z |                          |
+      | 6a0e6577-05eb-47d4-8498-a32d81f5c2b8 | old.user.mixed.licenses@keygen.example    | 2023-02-07T00:00:00.000Z |                          |
+      | 5e360440-acd7-4c63-973e-5133b2ebfdbb | banned.user@keygen.example                | 2024-02-07T00:00:00.000Z | 2024-01-07T00:00:00.000Z |
+    And the current account has the following "license" rows:
+      | id                                   | user_id                              | created_at               | last_validated_at        | last_check_out_at        | last_check_in_at         |
+      | df0beed9-1ab2-4097-9558-cd0adddf321a | 31e7d077-88ed-4808-bd4b-00b23fc35a57 | 2024-02-07T00:00:00.000Z |                          |                          |                          |
+      | c29fc20f-ec09-4cf4-8145-f910109e5705 | 08c7f078-85d3-46cf-b34c-8dbcef0d30cd | 2023-02-07T00:00:00.000Z |                          |                          |                          |
+      | af5c7d44-26bd-4bfd-9dcc-8aed721308ab | 2b8dcb3b-4518-4ffb-8512-b49d36dd7dd5 | 2023-02-07T00:00:00.000Z | 2024-02-07T00:00:00.000Z |                          |                          |
+      | ee26deca-5688-451f-86bd-801291dd2d24 | 44dce69e-bb15-4915-9adc-074f8b57a61c | 2023-02-07T00:00:00.000Z |                          | 2024-02-07T00:00:00.000Z |                          |
+      | e4304d3f-4d6c-4faf-86ee-0ddbb3324aa5 | a04ac105-ec12-4dc9-89d0-06dd99124349 | 2023-02-07T00:00:00.000Z |                          |                          | 2024-02-07T00:00:00.000Z |
+      | 2022a17f-87e4-4b4c-a07b-e28b45f43d6a | 6a0e6577-05eb-47d4-8498-a32d81f5c2b8 | 2023-02-07T00:00:00.000Z |                          |                          |                          |
+      | ce5fc968-cff0-4b41-9f5d-cb42c330d01c | 6a0e6577-05eb-47d4-8498-a32d81f5c2b8 | 2023-02-07T00:00:00.000Z | 2024-02-07T00:00:00.000Z |                          |                          |
     And I use an authentication token
     When I send a GET request to "/accounts/test1/users?status=BANNED"
     Then the response status should be "200"
     And the response body should be an array with 1 "user"
+    And time is unfrozen
 
   Scenario: Admin retrieves users filtered by status (invalid)
     Given I am an admin of account "test1"
     And the current account is "test1"
-    And the current account has 7 "users"
-    And the first "user" has the following attributes:
-      """
-      { "createdAt": "$time.1.year.ago" }
-      """
-    And the second "user" has the following attributes:
-      """
-      { "bannedAt": "$time.now" }
-      """
-    And the third "user" has the following attributes:
-      """
-      { "createdAt": "$time.1.year.ago" }
-      """
-    And the fourth "user" has the following attributes:
-      """
-      { "createdAt": "$time.1.year.ago" }
-      """
-    And the current account has 6 userless "licenses"
-    And the first "license" has the following attributes:
-      """
-      { "userId": "$users[7]" }
-      """
-    And the second "license" has the following attributes:
-      """
-      { "userId": "$users[4]" }
-      """
-    And the third "license" has the following attributes:
-      """
-      {
-        "lastValidatedAt": "$time.2.days.ago",
-        "createdAt": "$time.91.days.ago",
-        "userId": "$users[6]"
-      }
-      """
-    And the fourth "license" has the following attributes:
-      """
-      {
-        "lastValidatedAt": "$time.91.days.ago",
-        "createdAt": "$time.101.days.ago",
-        "userId": "$users[3]"
-      }
-      """
+    And time is frozen at "2024-02-07T00:00:00.000Z"
+    And the current account has the following "user" rows:
+      | id                                   | email                                     | created_at               | banned_at                |
+      | d00998f9-d224-4ee7-ac4e-f1e5fe318ff7 | new.user.active@keygen.example            | 2024-02-07T00:00:00.000Z |                          |
+      | 31e30cc1-d454-40dc-b4ae-93ad683ddf33 | old.user.inactive@keygen.example          | 2023-02-07T00:00:00.000Z |                          |
+      | 31e7d077-88ed-4808-bd4b-00b23fc35a57 | old.user.new.license@keygen.example       | 2023-02-07T00:00:00.000Z |                          |
+      | 08c7f078-85d3-46cf-b34c-8dbcef0d30cd | old.user.old.license@keygen.example       | 2023-02-07T00:00:00.000Z |                          |
+      | 2b8dcb3b-4518-4ffb-8512-b49d36dd7dd5 | old.user.validated.license@keygen.example | 2023-02-07T00:00:00.000Z |                          |
+      | 44dce69e-bb15-4915-9adc-074f8b57a61c | old.user.checkout.license@keygen.example  | 2023-02-07T00:00:00.000Z |                          |
+      | a04ac105-ec12-4dc9-89d0-06dd99124349 | old.user.checkin.license@keygen.example   | 2023-02-07T00:00:00.000Z |                          |
+      | 6a0e6577-05eb-47d4-8498-a32d81f5c2b8 | old.user.mixed.licenses@keygen.example    | 2023-02-07T00:00:00.000Z |                          |
+      | 5e360440-acd7-4c63-973e-5133b2ebfdbb | banned.user@keygen.example                | 2024-02-07T00:00:00.000Z | 2024-01-07T00:00:00.000Z |
+    And the current account has the following "license" rows:
+      | id                                   | user_id                              | created_at               | last_validated_at        | last_check_out_at        | last_check_in_at         |
+      | df0beed9-1ab2-4097-9558-cd0adddf321a | 31e7d077-88ed-4808-bd4b-00b23fc35a57 | 2024-02-07T00:00:00.000Z |                          |                          |                          |
+      | c29fc20f-ec09-4cf4-8145-f910109e5705 | 08c7f078-85d3-46cf-b34c-8dbcef0d30cd | 2023-02-07T00:00:00.000Z |                          |                          |                          |
+      | af5c7d44-26bd-4bfd-9dcc-8aed721308ab | 2b8dcb3b-4518-4ffb-8512-b49d36dd7dd5 | 2023-02-07T00:00:00.000Z | 2024-02-07T00:00:00.000Z |                          |                          |
+      | ee26deca-5688-451f-86bd-801291dd2d24 | 44dce69e-bb15-4915-9adc-074f8b57a61c | 2023-02-07T00:00:00.000Z |                          | 2024-02-07T00:00:00.000Z |                          |
+      | e4304d3f-4d6c-4faf-86ee-0ddbb3324aa5 | a04ac105-ec12-4dc9-89d0-06dd99124349 | 2023-02-07T00:00:00.000Z |                          |                          | 2024-02-07T00:00:00.000Z |
+      | 2022a17f-87e4-4b4c-a07b-e28b45f43d6a | 6a0e6577-05eb-47d4-8498-a32d81f5c2b8 | 2023-02-07T00:00:00.000Z |                          |                          |                          |
+      | ce5fc968-cff0-4b41-9f5d-cb42c330d01c | 6a0e6577-05eb-47d4-8498-a32d81f5c2b8 | 2023-02-07T00:00:00.000Z | 2024-02-07T00:00:00.000Z |                          |                          |
     And I use an authentication token
     When I send a GET request to "/accounts/test1/users?status=INVALID"
     Then the response status should be "200"
     And the response body should be an array with 0 "users"
+    And time is unfrozen
 
   Scenario: Product retrieves all users for their product (multiple licenses per-user)
     Given the current account is "test1"

--- a/features/step_definitions/before_after_steps.rb
+++ b/features/step_definitions/before_after_steps.rb
@@ -14,10 +14,8 @@ RequestMigrations.supported_versions.each do |version|
   end
 end
 
-# FIXME(ezekg) This is super hacky but there's no easy way to disable
-#              bullet outside of adding controller filters
-Before("@skip/bullet") { Bullet.instance_variable_set :@enable, false }
-After("@skip/bullet") { Bullet.instance_variable_set :@enable, true }
+Before("@skip/prosopite") { Prosopite.enabled = false }
+After("@skip/prosopite")  { Prosopite.enabled = true }
 
 Before do |scenario|
   # Skip CE tests if we're running in an EE env, and vice-versa
@@ -36,8 +34,6 @@ Before do |scenario|
   return skip_this_scenario if
     scenario.tags.any? { _1.name == '@skip' }
 
-  Bullet.start_request if Bullet.enable?
-
   ActionMailer::Base.deliveries.clear
   Sidekiq::Worker.clear_all
   StripeHelper.start
@@ -51,9 +47,6 @@ Before do |scenario|
 end
 
 After do |scenario|
-  Bullet.perform_out_of_channel_notifications if Bullet.enable? && Bullet.notification?
-  Bullet.end_request if Bullet.enable?
-
   Faker::UniqueGenerator.clear
   StripeHelper.stop
 

--- a/features/step_definitions/request_steps.rb
+++ b/features/step_definitions/request_steps.rb
@@ -61,10 +61,12 @@ When /^I send a GET request to "([^\"]*)"$/ do |path|
   else
   end
 
-  unless path.starts_with?('//')
-    get "//api.keygen.sh/#{@api_version}/#{path.sub(/^\//, '')}"
-  else
-    get path
+  Prosopite.scan do
+    unless path.starts_with?('//')
+      get "//api.keygen.sh/#{@api_version}/#{path.sub(/^\//, '')}"
+    else
+      get path
+    end
   end
 end
 
@@ -79,7 +81,9 @@ When /^I send a POST request to "([^\"]*)"$/ do |path|
   else
   end
 
-  post "//api.keygen.sh/#{@api_version}/#{path.sub(/^\//, '')}"
+  Prosopite.scan do
+    post "//api.keygen.sh/#{@api_version}/#{path.sub(/^\//, '')}"
+  end
 end
 
 When /^I send a PUT request to "([^\"]*)"$/ do |path|
@@ -93,7 +97,9 @@ When /^I send a PUT request to "([^\"]*)"$/ do |path|
   else
   end
 
-  put "//api.keygen.sh/#{@api_version}/#{path.sub(/^\//, '')}"
+  Prosopite.scan do
+    put "//api.keygen.sh/#{@api_version}/#{path.sub(/^\//, '')}"
+  end
 end
 
 When /^I send a PATCH request to "([^\"]*)"$/ do |path|
@@ -107,7 +113,9 @@ When /^I send a PATCH request to "([^\"]*)"$/ do |path|
   else
   end
 
-  patch "//api.keygen.sh/#{@api_version}/#{path.sub(/^\//, '')}"
+  Prosopite.scan do
+    patch "//api.keygen.sh/#{@api_version}/#{path.sub(/^\//, '')}"
+  end
 end
 
 When /^I send a POST request to "([^\"]*)" with the following:$/ do |path, body|
@@ -122,7 +130,9 @@ When /^I send a POST request to "([^\"]*)" with the following:$/ do |path, body|
   else
   end
 
-  post "//api.keygen.sh/#{@api_version}/#{path.sub(/^\//, '')}", body
+  Prosopite.scan do
+    post "//api.keygen.sh/#{@api_version}/#{path.sub(/^\//, '')}", body
+  end
 end
 
 When /^I send a POST request to "([^\"]*)" with the following badly encoded data:$/ do |path, body|
@@ -137,7 +147,9 @@ When /^I send a POST request to "([^\"]*)" with the following badly encoded data
   else
   end
 
-  post "//api.keygen.sh/#{@api_version}/#{path.sub(/^\//, '')}", body.encode!('CP1252')
+  Prosopite.scan do
+    post "//api.keygen.sh/#{@api_version}/#{path.sub(/^\//, '')}", body.encode!('CP1252')
+  end
 end
 
 When /^I send a PATCH request to "([^\"]*)" with the following:$/ do |path, body|
@@ -152,7 +164,9 @@ When /^I send a PATCH request to "([^\"]*)" with the following:$/ do |path, body
   else
   end
 
-  patch "//api.keygen.sh/#{@api_version}/#{path.sub(/^\//, '')}", body
+  Prosopite.scan do
+    patch "//api.keygen.sh/#{@api_version}/#{path.sub(/^\//, '')}", body
+  end
 end
 
 When /^I send a PUT request to "([^\"]*)" with the following:$/ do |path, body|
@@ -167,7 +181,9 @@ When /^I send a PUT request to "([^\"]*)" with the following:$/ do |path, body|
   else
   end
 
-  put "//api.keygen.sh/#{@api_version}/#{path.sub(/^\//, '')}", body
+  Prosopite.scan do
+    put "//api.keygen.sh/#{@api_version}/#{path.sub(/^\//, '')}", body
+  end
 end
 
 When /^I send a DELETE request to "([^\"]*)" with the following:$/ do |path, body|
@@ -182,7 +198,9 @@ When /^I send a DELETE request to "([^\"]*)" with the following:$/ do |path, bod
   else
   end
 
-  delete "//api.keygen.sh/#{@api_version}/#{path.sub(/^\//, '')}", body
+  Prosopite.scan do
+    delete "//api.keygen.sh/#{@api_version}/#{path.sub(/^\//, '')}", body
+  end
 end
 
 When /^I send a DELETE request to "([^\"]*)"$/ do |path|
@@ -196,7 +214,9 @@ When /^I send a DELETE request to "([^\"]*)"$/ do |path|
   else
   end
 
-  delete "//api.keygen.sh/#{@api_version}/#{path.sub(/^\//, '')}"
+  Prosopite.scan do
+    delete "//api.keygen.sh/#{@api_version}/#{path.sub(/^\//, '')}"
+  end
 
   # Wait for all async deletion workers to finish
   YankArtifactWorker.drain

--- a/features/support/bullet.rb
+++ b/features/support/bullet.rb
@@ -1,3 +1,1 @@
 # frozen_string_literal: true
-
-require 'bullet'

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -207,7 +207,7 @@ describe User, type: :model do
     end
   end
 
-  describe '.with_status' do
+  context 'with a variety of users' do
     before do
       # new user (active)
       create(:user, account:)
@@ -248,6 +248,12 @@ describe User, type: :model do
 
       # banned user (banned)
       create(:user, :banned, account:)
+    end
+
+    it 'should preload user statuses' do
+      statuses = nil
+      expect { statuses = User.preload(:any_active_license).collect(&:status) }.to make_database_queries(count: 2)
+      expect(statuses).to eq User.all.collect(&:status)
     end
 
     it 'should return active users' do


### PR DESCRIPTION
Resolves an N+1 issue caused by `User#status` for the users index when the collection contained old users. Also replaces Bullet with Prosopite because Bullet missed this, and I couldn't force the test failure, and it failed right away with Prosopite.