### PR TITLE
Add Sentry to exception logger

### DIFF
--- a/lib/keygen/logger.rb
+++ b/lib/keygen/logger.rb
@@ -6,6 +6,7 @@ module Keygen
       Rails.logger.error(context) if context.present?
       Rails.logger.error(e.message)
       Rails.logger.error(e.backtrace&.join("\n"))
+      Sentry.capture_exception(e)
     end
 
     def self.error(msg = nil, &block)


### PR DESCRIPTION
These errors should also be sent to Sentry, not just stderr.