### PR TITLE
fix: use postgresql-client in the production image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ COPY . /app
 
 RUN apk add --no-cache \
   bash \
-  postgresql-dev \
+  postgresql-client \
   tzdata \
   libc6-compat
 


### PR DESCRIPTION
The production image doesn't need the development files of Postgres. By replacing it with `postgresql-client`, the size of the container image is reduced significantly.

This reduces the size of the image by 512 MB

- After `206MB`
- Before `718MB`