### PR TITLE
perf: optimizations for the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,14 +63,11 @@ ENV KEYGEN_EDITION="CE" \
     PORT="3000" \
     BIND="0.0.0.0"
 
-RUN \
-  chmod +x /app/scripts/entrypoint.sh && \
+RUN chmod +x /app/scripts/entrypoint.sh && \
   adduser -h /app -g keygen -u 1000 -s /bin/bash -D keygen && \
   chown -R keygen:keygen /app
 
 USER keygen
-
-EXPOSE $PORT
 
 ENTRYPOINT ["/app/scripts/entrypoint.sh"]
 CMD ["web"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,17 +24,13 @@ RUN apk add --no-cache \
   tzdata \
   openssl \
   postgresql-dev \
-  libc6-compat
-
-RUN bundle install --jobs 4 --retry 5 && \
+  libc6-compat && \
+  bundle install --jobs 4 --retry 5 && \
   chmod -R a+r /usr/local/bundle
 
 # Final stage
 FROM base
 LABEL maintainer="keygen.sh <oss@keygen.sh>"
-
-WORKDIR /app
-COPY . /app
 
 RUN apk add --no-cache \
   bash \
@@ -42,18 +38,22 @@ RUN apk add --no-cache \
   tzdata \
   libc6-compat
 
+COPY --from=build --chown=keygen:keygen \
+  /usr/local/bundle/ /usr/local/bundle
+
+WORKDIR /app
+COPY . /app
+
 ENV KEYGEN_EDITION="CE" \
     KEYGEN_MODE="singleplayer" \
     RAILS_LOG_TO_STDOUT="1" \
     PORT="3000" \
     BIND="0.0.0.0"
 
-RUN chmod +x /app/scripts/entrypoint.sh && \
+RUN \
+  chmod +x /app/scripts/entrypoint.sh && \
   adduser -h /app -g keygen -u 1000 -s /bin/bash -D keygen && \
   chown -R keygen:keygen /app
-
-COPY --from=build --chown=keygen:keygen \
-  /usr/local/bundle/ /usr/local/bundle
 
 USER keygen
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,5 +70,7 @@ RUN \
 
 USER keygen
 
+EXPOSE $PORT
+
 ENTRYPOINT ["/app/scripts/entrypoint.sh"]
 CMD ["web"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,10 @@ RUN apk add --no-cache \
   bash \
   postgresql-client \
   tzdata \
-  libc6-compat
+  libc6-compat && \
+  adduser -h /app -g keygen -u 1000 -s /bin/bash -D keygen
+
+USER keygen
 
 COPY --from=build --chown=keygen:keygen \
   /usr/local/bundle/ /usr/local/bundle
@@ -57,17 +60,14 @@ COPY --from=build --chown=keygen:keygen \
 WORKDIR /app
 COPY . /app
 
+RUN chmod +x /app/scripts/entrypoint.sh && \
+  chown -R keygen:keygen /app
+
 ENV KEYGEN_EDITION="CE" \
     KEYGEN_MODE="singleplayer" \
     RAILS_LOG_TO_STDOUT="1" \
     PORT="3000" \
     BIND="0.0.0.0"
-
-RUN chmod +x /app/scripts/entrypoint.sh && \
-  adduser -h /app -g keygen -u 1000 -s /bin/bash -D keygen && \
-  chown -R keygen:keygen /app
-
-USER keygen
 
 ENTRYPOINT ["/app/scripts/entrypoint.sh"]
 CMD ["web"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,12 @@ RUN apk add --no-cache \
   openssl \
   postgresql-dev \
   libc6-compat && \
-  bundle install --jobs 4 --retry 5 && \
-  chmod -R a+r /usr/local/bundle
+  bundle config --global without "${BUNDLE_WITHOUT}"  && \
+  bundle config --global path "${BUNDLE_PATH}" && \
+  bundle config --global deployment "${BUNDLE_DEPLOYMENT}" && \
+  bundle config --global retry 5 && \
+  bundle install && \
+  chmod -R a+r "${BUNDLE_PATH}"
 
 # Final stage
 FROM base

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,15 @@ RUN apk add --no-cache \
   bundle config --global deployment "${BUNDLE_DEPLOYMENT}" && \
   bundle config --global retry 5 && \
   bundle install && \
+  find /usr/local/bundle/ \
+    \( \
+      -name "*.c" -o \
+      -name "*.o" -o \
+      -name "*.a" -o \
+      -name "*.h" -o \
+      -name "Makefile" -o \
+      -name "*.md" \
+    \) -delete && \
   chmod -R a+r "${BUNDLE_PATH}"
 
 # Final stage


### PR DESCRIPTION
- [fix: optimize the RUN commands order in Docker](https://github.com/keygen-sh/keygen-api/commit/77ec406989a928679ef6ccf9b0e9329634e81b57): reorders and merges the RUN commands to reduce layer sizes and also speed up the builds when a file changes during development
- [fix: use bundle config for setting bundle options](https://github.com/keygen-sh/keygen-api/commit/96775ddbf9913d0e608e4f74b091b789b7cd7b5f): uses `bundle config` for setting the bundle settings, which is the recommended approach as per bundle's documentation. It also allows the bundle to use all the CPU cores during the builds.
- [fix: remove unused C/C++ build remainders](https://github.com/keygen-sh/keygen-api/commit/3ca9ba99c9b1d7049328816ceeaae0e2ef6a8704): removes some C/C++ build remainders after bundle install
- ~[fix: expose the specified port in docker](https://github.com/keygen-sh/keygen-api/pull/813/commits/fb5932a42aba1bfe116aaf81dec04025562b96d3)~

These reduce the docker size image by 10 MB (5%).
