### PR TITLE
Fix nullable foreign keys (again)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,7 @@ gem 'kaminari', '~> 1.2.0'
 gem 'active_record_union'
 gem 'active_record_distinct_on', '~> 1.6'
 gem 'activerecord_where_assoc', '~> 1.1.4'
+gem 'strong_migrations'
 
 # Pattern matching
 gem 'rails-pattern_matching'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -484,6 +484,8 @@ GEM
     statsd-ruby (1.5.0)
     stringio (3.0.8)
     stripe (5.48.0)
+    strong_migrations (1.8.0)
+      activerecord (>= 5.2)
     sys-uname (1.2.2)
       ffi (~> 1.1)
     temple (0.8.2)
@@ -578,6 +580,7 @@ DEPENDENCIES
   stackprof
   stripe (~> 5.43)
   stripe-ruby-mock!
+  strong_migrations
   timecop (~> 0.9.5)
   tracer
   typed_params (~> 1.1)

--- a/db/migrate/20240419171512_add_account_id_not_null_constraint_for_billings.rb
+++ b/db/migrate/20240419171512_add_account_id_not_null_constraint_for_billings.rb
@@ -1,0 +1,5 @@
+class AddAccountIdNotNullConstraintForBillings < ActiveRecord::Migration[7.1]
+  def up
+    add_check_constraint :billings, 'account_id IS NOT NULL', name: 'billings_account_id_null', validate: false
+  end
+end

--- a/db/migrate/20240419171603_validate_account_id_not_null_constraint_for_billings.rb
+++ b/db/migrate/20240419171603_validate_account_id_not_null_constraint_for_billings.rb
@@ -1,0 +1,8 @@
+class ValidateAccountIdNotNullConstraintForBillings < ActiveRecord::Migration[7.1]
+  def up
+    validate_check_constraint :billings, name: 'billings_account_id_null'
+
+    change_column_null :billings, :account_id, false
+    remove_check_constraint :billings, name: 'billings_account_id_null'
+  end
+end

--- a/db/migrate/20240419172554_add_account_id_not_null_constraint_for_keys.rb
+++ b/db/migrate/20240419172554_add_account_id_not_null_constraint_for_keys.rb
@@ -1,0 +1,5 @@
+class AddAccountIdNotNullConstraintForKeys < ActiveRecord::Migration[7.1]
+  def up
+    add_check_constraint :keys, 'account_id IS NOT NULL', name: 'keys_account_id_null', validate: false
+  end
+end

--- a/db/migrate/20240419172618_validate_account_id_not_null_constraint_for_keys.rb
+++ b/db/migrate/20240419172618_validate_account_id_not_null_constraint_for_keys.rb
@@ -1,0 +1,8 @@
+class ValidateAccountIdNotNullConstraintForKeys < ActiveRecord::Migration[7.1]
+  def up
+    validate_check_constraint :keys, name: 'keys_account_id_null'
+
+    change_column_null :keys, :account_id, false
+    remove_check_constraint :keys, name: 'keys_account_id_null'
+  end
+end

--- a/db/migrate/20240419172812_add_policy_id_not_null_constraint_for_keys.rb
+++ b/db/migrate/20240419172812_add_policy_id_not_null_constraint_for_keys.rb
@@ -1,0 +1,5 @@
+class AddPolicyIdNotNullConstraintForKeys < ActiveRecord::Migration[7.1]
+  def up
+    add_check_constraint :keys, 'policy_id IS NOT NULL', name: 'keys_policy_id_null', validate: false
+  end
+end

--- a/db/migrate/20240419172820_validate_policy_id_not_null_constraint_for_keys.rb
+++ b/db/migrate/20240419172820_validate_policy_id_not_null_constraint_for_keys.rb
@@ -1,0 +1,8 @@
+class ValidatePolicyIdNotNullConstraintForKeys < ActiveRecord::Migration[7.1]
+  def up
+    validate_check_constraint :keys, name: 'keys_policy_id_null'
+
+    change_column_null :keys, :policy_id, false
+    remove_check_constraint :keys, name: 'keys_policy_id_null'
+  end
+end

--- a/db/migrate/20240419172913_add_account_id_not_null_constraint_for_licenses.rb
+++ b/db/migrate/20240419172913_add_account_id_not_null_constraint_for_licenses.rb
@@ -1,0 +1,5 @@
+class AddAccountIdNotNullConstraintForLicenses < ActiveRecord::Migration[7.1]
+  def up
+    add_check_constraint :licenses, 'account_id IS NOT NULL', name: 'licenses_account_id_null', validate: false
+  end
+end

--- a/db/migrate/20240419172920_validate_account_id_not_null_constraint_for_licenses.rb
+++ b/db/migrate/20240419172920_validate_account_id_not_null_constraint_for_licenses.rb
@@ -1,0 +1,8 @@
+class ValidateAccountIdNotNullConstraintForLicenses < ActiveRecord::Migration[7.1]
+  def up
+    validate_check_constraint :licenses, name: 'licenses_account_id_null'
+
+    change_column_null :licenses, :account_id, false
+    remove_check_constraint :licenses, name: 'licenses_account_id_null'
+  end
+end

--- a/db/migrate/20240419172927_add_policy_id_not_null_constraint_for_licenses.rb
+++ b/db/migrate/20240419172927_add_policy_id_not_null_constraint_for_licenses.rb
@@ -1,0 +1,5 @@
+class AddPolicyIdNotNullConstraintForLicenses < ActiveRecord::Migration[7.1]
+  def up
+    add_check_constraint :licenses, 'policy_id IS NOT NULL', name: 'licenses_policy_id_null', validate: false
+  end
+end

--- a/db/migrate/20240419172935_validate_policy_id_not_null_constraint_for_licenses.rb
+++ b/db/migrate/20240419172935_validate_policy_id_not_null_constraint_for_licenses.rb
@@ -1,0 +1,8 @@
+class ValidatePolicyIdNotNullConstraintForLicenses < ActiveRecord::Migration[7.1]
+  def up
+    validate_check_constraint :licenses, name: 'licenses_policy_id_null'
+
+    change_column_null :licenses, :policy_id, false
+    remove_check_constraint :licenses, name: 'licenses_policy_id_null'
+  end
+end

--- a/db/migrate/20240419172942_add_product_id_not_null_constraint_for_licenses.rb
+++ b/db/migrate/20240419172942_add_product_id_not_null_constraint_for_licenses.rb
@@ -1,0 +1,5 @@
+class AddProductIdNotNullConstraintForLicenses < ActiveRecord::Migration[7.1]
+  def up
+    add_check_constraint :licenses, 'product_id IS NOT NULL', name: 'licenses_product_id_null', validate: false
+  end
+end

--- a/db/migrate/20240419172949_validate_product_id_not_null_constraint_for_licenses.rb
+++ b/db/migrate/20240419172949_validate_product_id_not_null_constraint_for_licenses.rb
@@ -1,0 +1,8 @@
+class ValidateProductIdNotNullConstraintForLicenses < ActiveRecord::Migration[7.1]
+  def up
+    validate_check_constraint :licenses, name: 'licenses_product_id_null'
+
+    change_column_null :licenses, :product_id, false
+    remove_check_constraint :licenses, name: 'licenses_product_id_null'
+  end
+end

--- a/db/migrate/20240419173148_add_account_id_not_null_constraint_for_machines.rb
+++ b/db/migrate/20240419173148_add_account_id_not_null_constraint_for_machines.rb
@@ -1,0 +1,5 @@
+class AddAccountIdNotNullConstraintForMachines < ActiveRecord::Migration[7.1]
+  def up
+    add_check_constraint :machines, 'account_id IS NOT NULL', name: 'machines_account_id_null', validate: false
+  end
+end

--- a/db/migrate/20240419173157_validate_account_id_not_null_constraint_for_machines.rb
+++ b/db/migrate/20240419173157_validate_account_id_not_null_constraint_for_machines.rb
@@ -1,0 +1,8 @@
+class ValidateAccountIdNotNullConstraintForMachines < ActiveRecord::Migration[7.1]
+  def up
+    validate_check_constraint :machines, name: 'machines_account_id_null'
+
+    change_column_null :machines, :account_id, false
+    remove_check_constraint :machines, name: 'machines_account_id_null'
+  end
+end

--- a/db/migrate/20240419173203_add_license_id_not_null_constraint_for_machines.rb
+++ b/db/migrate/20240419173203_add_license_id_not_null_constraint_for_machines.rb
@@ -1,0 +1,5 @@
+class AddLicenseIdNotNullConstraintForMachines < ActiveRecord::Migration[7.1]
+  def up
+    add_check_constraint :machines, 'license_id IS NOT NULL', name: 'machines_license_id_null', validate: false
+  end
+end

--- a/db/migrate/20240419173211_validate_license_id_not_null_constraint_for_machines.rb
+++ b/db/migrate/20240419173211_validate_license_id_not_null_constraint_for_machines.rb
@@ -1,0 +1,8 @@
+class ValidateLicenseIdNotNullConstraintForMachines < ActiveRecord::Migration[7.1]
+  def up
+    validate_check_constraint :machines, name: 'machines_license_id_null'
+
+    change_column_null :machines, :license_id, false
+    remove_check_constraint :machines, name: 'machines_license_id_null'
+  end
+end

--- a/db/migrate/20240419173355_add_account_id_not_null_constraint_for_policies.rb
+++ b/db/migrate/20240419173355_add_account_id_not_null_constraint_for_policies.rb
@@ -1,0 +1,5 @@
+class AddAccountIdNotNullConstraintForPolicies < ActiveRecord::Migration[7.1]
+  def up
+    add_check_constraint :policies, 'account_id IS NOT NULL', name: 'policies_account_id_null', validate: false
+  end
+end

--- a/db/migrate/20240419173405_validate_account_id_not_null_constraint_for_policies.rb
+++ b/db/migrate/20240419173405_validate_account_id_not_null_constraint_for_policies.rb
@@ -1,0 +1,8 @@
+class ValidateAccountIdNotNullConstraintForPolicies < ActiveRecord::Migration[7.1]
+  def up
+    validate_check_constraint :policies, name: 'policies_account_id_null'
+
+    change_column_null :policies, :account_id, false
+    remove_check_constraint :policies, name: 'policies_account_id_null'
+  end
+end

--- a/db/migrate/20240419173415_add_product_id_not_null_constraint_for_policies.rb
+++ b/db/migrate/20240419173415_add_product_id_not_null_constraint_for_policies.rb
@@ -1,0 +1,5 @@
+class AddProductIdNotNullConstraintForPolicies < ActiveRecord::Migration[7.1]
+  def up
+    add_check_constraint :policies, 'product_id IS NOT NULL', name: 'policies_product_id_null', validate: false
+  end
+end

--- a/db/migrate/20240419173436_validate_product_id_not_null_constraint_for_policies.rb
+++ b/db/migrate/20240419173436_validate_product_id_not_null_constraint_for_policies.rb
@@ -1,0 +1,8 @@
+class ValidateProductIdNotNullConstraintForPolicies < ActiveRecord::Migration[7.1]
+  def up
+    validate_check_constraint :policies, name: 'policies_product_id_null'
+
+    change_column_null :policies, :product_id, false
+    remove_check_constraint :policies, name: 'policies_product_id_null'
+  end
+end

--- a/db/migrate/20240419193421_add_account_id_not_null_constraint_for_products.rb
+++ b/db/migrate/20240419193421_add_account_id_not_null_constraint_for_products.rb
@@ -1,0 +1,5 @@
+class AddAccountIdNotNullConstraintForProducts < ActiveRecord::Migration[7.1]
+  def up
+    add_check_constraint :products, 'account_id IS NOT NULL', name: 'products_account_id_null', validate: false
+  end
+end

--- a/db/migrate/20240419193430_validate_account_id_not_null_constraint_for_products.rb
+++ b/db/migrate/20240419193430_validate_account_id_not_null_constraint_for_products.rb
@@ -1,0 +1,8 @@
+class ValidateAccountIdNotNullConstraintForProducts < ActiveRecord::Migration[7.1]
+  def up
+    validate_check_constraint :products, name: 'products_account_id_null'
+
+    change_column_null :products, :account_id, false
+    remove_check_constraint :products, name: 'products_account_id_null'
+  end
+end

--- a/db/migrate/20240419193540_add_resource_type_not_null_constraint_for_roles.rb
+++ b/db/migrate/20240419193540_add_resource_type_not_null_constraint_for_roles.rb
@@ -1,0 +1,5 @@
+class AddResourceTypeNotNullConstraintForRoles < ActiveRecord::Migration[7.1]
+  def up
+    add_check_constraint :roles, 'resource_type IS NOT NULL', name: 'roles_resource_type_null', validate: false
+  end
+end

--- a/db/migrate/20240419193552_validate_resource_type_not_null_constraint_for_roles.rb
+++ b/db/migrate/20240419193552_validate_resource_type_not_null_constraint_for_roles.rb
@@ -1,0 +1,8 @@
+class ValidateResourceTypeNotNullConstraintForRoles < ActiveRecord::Migration[7.1]
+  def up
+    validate_check_constraint :roles, name: 'roles_resource_type_null'
+
+    change_column_null :roles, :resource_type, false
+    remove_check_constraint :roles, name: 'roles_resource_type_null'
+  end
+end

--- a/db/migrate/20240419193601_add_resource_id_not_null_constraint_for_roles.rb
+++ b/db/migrate/20240419193601_add_resource_id_not_null_constraint_for_roles.rb
@@ -1,0 +1,5 @@
+class AddResourceIdNotNullConstraintForRoles < ActiveRecord::Migration[7.1]
+  def up
+    add_check_constraint :roles, 'resource_id IS NOT NULL', name: 'roles_resource_id_null', validate: false
+  end
+end

--- a/db/migrate/20240419193608_validate_resource_id_not_null_constraint_for_roles.rb
+++ b/db/migrate/20240419193608_validate_resource_id_not_null_constraint_for_roles.rb
@@ -1,0 +1,8 @@
+class ValidateResourceIdNotNullConstraintForRoles < ActiveRecord::Migration[7.1]
+  def up
+    validate_check_constraint :roles, name: 'roles_resource_id_null'
+
+    change_column_null :roles, :resource_id, false
+    remove_check_constraint :roles, name: 'roles_resource_id_null'
+  end
+end

--- a/db/migrate/20240419193742_add_account_id_not_null_constraint_for_tokens.rb
+++ b/db/migrate/20240419193742_add_account_id_not_null_constraint_for_tokens.rb
@@ -1,0 +1,5 @@
+class AddAccountIdNotNullConstraintForTokens < ActiveRecord::Migration[7.1]
+  def up
+    add_check_constraint :tokens, 'account_id IS NOT NULL', name: 'tokens_account_id_null', validate: false
+  end
+end

--- a/db/migrate/20240419193752_validate_account_id_not_null_constraint_for_tokens.rb
+++ b/db/migrate/20240419193752_validate_account_id_not_null_constraint_for_tokens.rb
@@ -1,0 +1,8 @@
+class ValidateAccountIdNotNullConstraintForTokens < ActiveRecord::Migration[7.1]
+  def up
+    validate_check_constraint :tokens, name: 'tokens_account_id_null'
+
+    change_column_null :tokens, :account_id, false
+    remove_check_constraint :tokens, name: 'tokens_account_id_null'
+  end
+end

--- a/db/migrate/20240419193807_add_bearer_type_not_null_constraint_for_tokens.rb
+++ b/db/migrate/20240419193807_add_bearer_type_not_null_constraint_for_tokens.rb
@@ -1,0 +1,5 @@
+class AddBearerTypeNotNullConstraintForTokens < ActiveRecord::Migration[7.1]
+  def up
+    add_check_constraint :tokens, 'bearer_type IS NOT NULL', name: 'tokens_bearer_type_null', validate: false
+  end
+end

--- a/db/migrate/20240419193814_validate_bearer_type_not_null_constraint_for_tokens.rb
+++ b/db/migrate/20240419193814_validate_bearer_type_not_null_constraint_for_tokens.rb
@@ -1,0 +1,8 @@
+class ValidateBearerTypeNotNullConstraintForTokens < ActiveRecord::Migration[7.1]
+  def up
+    validate_check_constraint :tokens, name: 'tokens_bearer_type_null'
+
+    change_column_null :tokens, :bearer_type, false
+    remove_check_constraint :tokens, name: 'tokens_bearer_type_null'
+  end
+end

--- a/db/migrate/20240419193822_add_bearer_id_not_null_constraint_for_tokens.rb
+++ b/db/migrate/20240419193822_add_bearer_id_not_null_constraint_for_tokens.rb
@@ -1,0 +1,5 @@
+class AddBearerIdNotNullConstraintForTokens < ActiveRecord::Migration[7.1]
+  def up
+    add_check_constraint :tokens, 'bearer_id IS NOT NULL', name: 'tokens_bearer_id_null', validate: false
+  end
+end

--- a/db/migrate/20240419193835_validate_bearer_id_not_null_constraint_for_tokens.rb
+++ b/db/migrate/20240419193835_validate_bearer_id_not_null_constraint_for_tokens.rb
@@ -1,0 +1,8 @@
+class ValidateBearerIdNotNullConstraintForTokens < ActiveRecord::Migration[7.1]
+  def up
+    validate_check_constraint :tokens, name: 'tokens_bearer_id_null'
+
+    change_column_null :tokens, :bearer_id, false
+    remove_check_constraint :tokens, name: 'tokens_bearer_id_null'
+  end
+end

--- a/db/migrate/20240419210925_add_account_id_not_null_constraint_for_users.rb
+++ b/db/migrate/20240419210925_add_account_id_not_null_constraint_for_users.rb
@@ -1,0 +1,5 @@
+class AddAccountIdNotNullConstraintForUsers < ActiveRecord::Migration[7.1]
+  def up
+    add_check_constraint :users, 'account_id IS NOT NULL', name: 'users_account_id_null', validate: false
+  end
+end

--- a/db/migrate/20240419210932_validate_account_id_not_null_constraint_for_users.rb
+++ b/db/migrate/20240419210932_validate_account_id_not_null_constraint_for_users.rb
@@ -1,0 +1,8 @@
+class ValidateAccountIdNotNullConstraintForUsers < ActiveRecord::Migration[7.1]
+  def up
+    validate_check_constraint :users, name: 'users_account_id_null'
+
+    change_column_null :users, :account_id, false
+    remove_check_constraint :users, name: 'users_account_id_null'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_03_173726) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_19_210932) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_stat_statements"
@@ -61,7 +61,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_03_173726) do
     t.string "card_brand"
     t.string "card_last4"
     t.string "state"
-    t.uuid "account_id"
+    t.uuid "account_id", null: false
     t.string "referral_id"
     t.datetime "card_added_at", precision: nil
     t.index ["account_id", "created_at"], name: "index_billings_on_account_id_and_created_at"
@@ -168,8 +168,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_03_173726) do
     t.string "key"
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
-    t.uuid "policy_id"
-    t.uuid "account_id"
+    t.uuid "policy_id", null: false
+    t.uuid "account_id", null: false
     t.uuid "environment_id"
     t.index "to_tsvector('simple'::regconfig, COALESCE((id)::text, ''::text))", name: "keys_tsv_id_idx", using: :gist
     t.index "to_tsvector('simple'::regconfig, \"left\"(COALESCE((key)::text, ''::text), 128))", name: "keys_tsv_key_idx", using: :gist
@@ -201,8 +201,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_03_173726) do
     t.datetime "updated_at", precision: nil, null: false
     t.jsonb "metadata"
     t.uuid "user_id"
-    t.uuid "policy_id"
-    t.uuid "account_id"
+    t.uuid "policy_id", null: false
+    t.uuid "account_id", null: false
     t.boolean "suspended", default: false
     t.datetime "last_check_in_at", precision: nil
     t.datetime "last_expiration_event_sent_at", precision: nil
@@ -224,7 +224,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_03_173726) do
     t.uuid "environment_id"
     t.string "last_validated_checksum"
     t.string "last_validated_version"
-    t.uuid "product_id"
+    t.uuid "product_id", null: false
     t.index "account_id, md5((key)::text)", name: "licenses_account_id_key_unique_idx", unique: true
     t.index "to_tsvector('simple'::regconfig, COALESCE((id)::text, ''::text))", name: "licenses_tsv_id_idx", using: :gist
     t.index "to_tsvector('simple'::regconfig, COALESCE((metadata)::text, ''::text))", name: "licenses_tsv_metadata_idx", using: :gist
@@ -284,8 +284,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_03_173726) do
     t.datetime "updated_at", precision: nil, null: false
     t.string "name"
     t.jsonb "metadata"
-    t.uuid "account_id"
-    t.uuid "license_id"
+    t.uuid "account_id", null: false
+    t.uuid "license_id", null: false
     t.datetime "last_heartbeat_at", precision: nil
     t.integer "cores"
     t.datetime "last_death_event_sent_at", precision: nil
@@ -366,8 +366,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_03_173726) do
     t.boolean "encrypted", default: false
     t.boolean "protected"
     t.jsonb "metadata"
-    t.uuid "product_id"
-    t.uuid "account_id"
+    t.uuid "product_id", null: false
+    t.uuid "account_id", null: false
     t.string "check_in_interval"
     t.integer "check_in_interval_count"
     t.boolean "require_check_in", default: false
@@ -433,7 +433,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_03_173726) do
     t.datetime "updated_at", precision: nil, null: false
     t.jsonb "platforms"
     t.jsonb "metadata"
-    t.uuid "account_id"
+    t.uuid "account_id", null: false
     t.string "url"
     t.string "distribution_strategy"
     t.uuid "environment_id"
@@ -696,10 +696,10 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_03_173726) do
 
   create_table "roles", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
     t.string "name"
-    t.string "resource_type"
+    t.string "resource_type", null: false
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
-    t.uuid "resource_id"
+    t.uuid "resource_id", null: false
     t.index ["created_at"], name: "index_roles_on_created_at", order: :desc
     t.index ["id", "created_at"], name: "index_roles_on_id_and_created_at", unique: true
     t.index ["name", "created_at"], name: "index_roles_on_name_and_created_at"
@@ -734,12 +734,12 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_03_173726) do
 
   create_table "tokens", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
     t.string "digest"
-    t.string "bearer_type"
+    t.string "bearer_type", null: false
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.datetime "expiry", precision: nil
-    t.uuid "bearer_id"
-    t.uuid "account_id"
+    t.uuid "bearer_id", null: false
+    t.uuid "account_id", null: false
     t.integer "max_activations"
     t.integer "max_deactivations"
     t.integer "activations", default: 0
@@ -762,7 +762,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_03_173726) do
     t.string "password_reset_token"
     t.datetime "password_reset_sent_at", precision: nil
     t.jsonb "metadata"
-    t.uuid "account_id"
+    t.uuid "account_id", null: false
     t.string "first_name"
     t.string "last_name"
     t.datetime "stdout_unsubscribed_at", precision: nil


### PR DESCRIPTION
I guess I gotta do everything twice these days. I shouldn't have been too hasty to deploy #814, since changing a column to `NOT NULL` in Postgres locks the entire table for _reads and writes_. This took down production for a few minutes until I could kill the locking queries and revert things. This new PR follows recommendations in [`strong_migrations`](https://github.com/ankane/strong_migrations?tab=readme-ov-file#setting-not-null-on-an-existing-column).