### PR TITLE
Update licenses.product_id to be NOT NULL

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,7 @@ gem 'kaminari', '~> 1.2.0'
 gem 'active_record_union'
 gem 'active_record_distinct_on', '~> 1.6'
 gem 'activerecord_where_assoc', '~> 1.1.4'
+gem 'strong_migrations'
 
 # Pattern matching
 gem 'rails-pattern_matching'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -484,6 +484,8 @@ GEM
     statsd-ruby (1.5.0)
     stringio (3.0.8)
     stripe (5.48.0)
+    strong_migrations (1.8.0)
+      activerecord (>= 5.2)
     sys-uname (1.2.2)
       ffi (~> 1.1)
     temple (0.8.2)
@@ -578,6 +580,7 @@ DEPENDENCIES
   stackprof
   stripe (~> 5.43)
   stripe-ruby-mock!
+  strong_migrations
   timecop (~> 0.9.5)
   tracer
   typed_params (~> 1.1)

--- a/db/migrate/20240419172942_add_product_id_not_null_constraint_for_licenses.rb
+++ b/db/migrate/20240419172942_add_product_id_not_null_constraint_for_licenses.rb
@@ -1,0 +1,9 @@
+class AddProductIdNotNullConstraintForLicenses < ActiveRecord::Migration[7.1]
+  def up
+    log_level_was, ActiveRecord::Base.logger.level = ActiveRecord::Base.logger.level, Logger::DEBUG
+
+    add_check_constraint :licenses, 'product_id IS NOT NULL', name: 'licenses_product_id_not_null', validate: false
+  ensure
+    ActiveRecord::Base.logger.level = log_level_was
+  end
+end

--- a/db/migrate/20240419172949_validate_product_id_not_null_constraint_for_licenses.rb
+++ b/db/migrate/20240419172949_validate_product_id_not_null_constraint_for_licenses.rb
@@ -1,0 +1,9 @@
+class ValidateProductIdNotNullConstraintForLicenses < ActiveRecord::Migration[7.1]
+  def up
+    log_level_was, ActiveRecord::Base.logger.level = ActiveRecord::Base.logger.level, Logger::DEBUG
+
+    validate_check_constraint :licenses, name: 'licenses_product_id_not_null'
+  ensure
+    ActiveRecord::Base.logger.level = log_level_was
+  end
+end

--- a/db/migrate/20240420043710_change_product_id_not_null_for_licenses.rb
+++ b/db/migrate/20240420043710_change_product_id_not_null_for_licenses.rb
@@ -1,0 +1,10 @@
+class ChangeProductIdNotNullForLicenses < ActiveRecord::Migration[7.1]
+  def up
+    log_level_was, ActiveRecord::Base.logger.level = ActiveRecord::Base.logger.level, Logger::DEBUG
+
+    change_column_null :licenses, :product_id, false
+    remove_check_constraint :licenses, name: 'licenses_product_id_not_null'
+  ensure
+    ActiveRecord::Base.logger.level = log_level_was
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_03_173726) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_20_043710) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_stat_statements"
@@ -224,7 +224,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_03_173726) do
     t.uuid "environment_id"
     t.string "last_validated_checksum"
     t.string "last_validated_version"
-    t.uuid "product_id"
+    t.uuid "product_id", null: false
     t.index "account_id, md5((key)::text)", name: "licenses_account_id_key_unique_idx", unique: true
     t.index "to_tsvector('simple'::regconfig, COALESCE((id)::text, ''::text))", name: "licenses_tsv_id_idx", using: :gist
     t.index "to_tsvector('simple'::regconfig, COALESCE((metadata)::text, ''::text))", name: "licenses_tsv_metadata_idx", using: :gist


### PR DESCRIPTION
Follow up to #811. Extracted from #815. Adds `strong_migrations` for all future migrations.

Ref: https://gist.github.com/ezekg/3bbc5e91d9f1211115c956a7f09d924b