### PR TITLE
Update licenses.account_id to be NOT NULL

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -58,6 +58,10 @@ module Keygen
     # See above comment about having to use this multiple
     config.middleware.use Keygen::Middleware::RequestErrorWrapper
 
+    # Use the lowest log level to ensure availability of diagnostic information
+    # when problems arise.
+    config.log_level = ENV.fetch('RAILS_LOG_LEVEL') { :info }.to_sym
+
     # FIXME(ezekg) Should we migrate to credentials?
     config.active_record.encryption.primary_key         = ENV.fetch('ENCRYPTION_PRIMARY_KEY')
     config.active_record.encryption.deterministic_key   = ENV.fetch('ENCRYPTION_DETERMINISTIC_KEY')

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -68,10 +68,6 @@ Rails.application.configure do
     redirect: { exclude: -> req { req.path =~ %r(^/v\d+/health) } },
   }
 
-  # Use the lowest log level to ensure availability of diagnostic information
-  # when problems arise.
-  config.log_level = ENV.fetch('RAILS_LOG_LEVEL') { :info }.to_sym
-
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]
 

--- a/config/initializers/strong_migrations.rb
+++ b/config/initializers/strong_migrations.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+StrongMigrations.tap do |config|
+  config.lock_timeout      = 10.seconds
+  config.statement_timeout = 1.hour
+end

--- a/config/initializers/strong_migrations.rb
+++ b/config/initializers/strong_migrations.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 StrongMigrations.tap do |config|
+  # migrations created prior to installing the gem are safe
+  config.start_after = 20240403173726
+
+  # timeouts
   config.lock_timeout      = 10.seconds
   config.statement_timeout = 1.hour
 end

--- a/config/initializers/verbose_migrations.rb
+++ b/config/initializers/verbose_migrations.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require_dependency Rails.root / 'lib' / 'verbose_migrations'

--- a/db/migrate/20240420053540_add_account_id_not_null_constraint_for_licenses.rb
+++ b/db/migrate/20240420053540_add_account_id_not_null_constraint_for_licenses.rb
@@ -1,0 +1,9 @@
+class AddAccountIdNotNullConstraintForLicenses < ActiveRecord::Migration[7.1]
+  def up
+    log_level_was, ActiveRecord::Base.logger.level = ActiveRecord::Base.logger.level, Logger::DEBUG
+
+    add_check_constraint :licenses, 'account_id IS NOT NULL', name: 'licenses_account_id_not_null', validate: false
+  ensure
+    ActiveRecord::Base.logger.level = log_level_was
+  end
+end

--- a/db/migrate/20240420053540_add_account_id_not_null_constraint_for_licenses.rb
+++ b/db/migrate/20240420053540_add_account_id_not_null_constraint_for_licenses.rb
@@ -1,9 +1,7 @@
 class AddAccountIdNotNullConstraintForLicenses < ActiveRecord::Migration[7.1]
-  def up
-    log_level_was, ActiveRecord::Base.logger.level = ActiveRecord::Base.logger.level, Logger::DEBUG
+  verbose!
 
+  def up
     add_check_constraint :licenses, 'account_id IS NOT NULL', name: 'licenses_account_id_not_null', validate: false
-  ensure
-    ActiveRecord::Base.logger.level = log_level_was
   end
 end

--- a/db/migrate/20240420053552_validate_account_id_not_null_constraint_for_licenses.rb
+++ b/db/migrate/20240420053552_validate_account_id_not_null_constraint_for_licenses.rb
@@ -1,9 +1,7 @@
 class ValidateAccountIdNotNullConstraintForLicenses < ActiveRecord::Migration[7.1]
-  def up
-    log_level_was, ActiveRecord::Base.logger.level = ActiveRecord::Base.logger.level, Logger::DEBUG
+  verbose!
 
+  def up
     validate_check_constraint :licenses, name: 'licenses_account_id_not_null'
-  ensure
-    ActiveRecord::Base.logger.level = log_level_was
   end
 end

--- a/db/migrate/20240420053552_validate_account_id_not_null_constraint_for_licenses.rb
+++ b/db/migrate/20240420053552_validate_account_id_not_null_constraint_for_licenses.rb
@@ -1,0 +1,9 @@
+class ValidateAccountIdNotNullConstraintForLicenses < ActiveRecord::Migration[7.1]
+  def up
+    log_level_was, ActiveRecord::Base.logger.level = ActiveRecord::Base.logger.level, Logger::DEBUG
+
+    validate_check_constraint :licenses, name: 'licenses_account_id_not_null'
+  ensure
+    ActiveRecord::Base.logger.level = log_level_was
+  end
+end

--- a/db/migrate/20240420053607_change_account_id_not_null_for_licenses.rb
+++ b/db/migrate/20240420053607_change_account_id_not_null_for_licenses.rb
@@ -1,10 +1,8 @@
 class ChangeAccountIdNotNullForLicenses < ActiveRecord::Migration[7.1]
-  def up
-    log_level_was, ActiveRecord::Base.logger.level = ActiveRecord::Base.logger.level, Logger::DEBUG
+  verbose!
 
+  def up
     change_column_null :licenses, :account_id, false
     remove_check_constraint :licenses, name: 'licenses_account_id_not_null'
-  ensure
-    ActiveRecord::Base.logger.level = log_level_was
   end
 end

--- a/db/migrate/20240420053607_change_account_id_not_null_for_licenses.rb
+++ b/db/migrate/20240420053607_change_account_id_not_null_for_licenses.rb
@@ -1,0 +1,10 @@
+class ChangeAccountIdNotNullForLicenses < ActiveRecord::Migration[7.1]
+  def up
+    log_level_was, ActiveRecord::Base.logger.level = ActiveRecord::Base.logger.level, Logger::DEBUG
+
+    change_column_null :licenses, :account_id, false
+    remove_check_constraint :licenses, name: 'licenses_account_id_not_null'
+  ensure
+    ActiveRecord::Base.logger.level = log_level_was
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_20_043710) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_20_053607) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_stat_statements"
@@ -202,7 +202,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_20_043710) do
     t.jsonb "metadata"
     t.uuid "user_id"
     t.uuid "policy_id"
-    t.uuid "account_id"
+    t.uuid "account_id", null: false
     t.boolean "suspended", default: false
     t.datetime "last_check_in_at", precision: nil
     t.datetime "last_expiration_event_sent_at", precision: nil

--- a/lib/verbose_migrations.rb
+++ b/lib/verbose_migrations.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'logger'
+
+module VerboseMigrations
+  module MigrationExtension
+    cattr_accessor :verbose_logger, default: nil
+    cattr_accessor :verbosity,      default: nil
+
+    def verbose? = verbosity.present? && verbose_logger.present?
+    def verbose!(logger: ActiveRecord::Base.logger, level: Logger::DEBUG)
+      self.verbose_logger = logger
+      self.verbosity      = level
+    end
+
+    def migrate(...)
+      verbosity_was, verbose_logger.level = verbose_logger.level, verbosity if verbose?
+
+      super
+    ensure
+      verbose_logger.level = verbosity_was if verbose?
+    end
+  end
+
+  ActiveSupport.on_load :active_record do
+    ActiveRecord::Migration.prepend(MigrationExtension)
+  end
+end


### PR DESCRIPTION
Part of #818. Extracted from #815. Updates config for `strong_migrations` to add default timeouts. Adds `verbose_migrations`.