### PR TITLE
Fix release and artifact scopes for licenses and users

### DIFF
--- a/app/models/entitlement.rb
+++ b/app/models/entitlement.rb
@@ -25,13 +25,13 @@ class Entitlement < ApplicationRecord
   scope :accessible_by, -> accessor {
     case accessor
     in role: Role(:admin | :product)
-      self.all
+      all
     in role: Role(:environment)
-      self.for_environment(accessor)
+      for_environment(accessor)
     in role: Role(:user | :license)
-      self.merge(accessor.entitlements)
+      merge(accessor.entitlements)
     else
-      self.none
+      none
     end
   }
 

--- a/app/models/environment.rb
+++ b/app/models/environment.rb
@@ -76,11 +76,11 @@ class Environment < ApplicationRecord
   scope :accessible_by, -> accessor {
     case accessor
     in role: Role(:admin)
-      self.all
+      all
     in role: Role(:environment)
-      self.where(id: accessor)
+      where(id: accessor)
     else
-      self.none
+      none
     end
   }
 

--- a/app/models/group_owner.rb
+++ b/app/models/group_owner.rb
@@ -20,18 +20,18 @@ class GroupOwner < ApplicationRecord
   scope :accessible_by, -> accessor {
     case accessor
     in role: Role(:admin | :product)
-      self.all
+      all
     in role: Role(:environment)
-      self.for_environment(accessor.id)
+      for_environment(accessor.id)
     in role: Role(:user)
-      self.where(group_id: accessor.group_id)
-          .or(
-            where(group_id: accessor.group_ids),
-          )
+      where(group_id: accessor.group_id)
+        .or(
+          where(group_id: accessor.group_ids),
+        )
     in role: Role(:license)
-      self.where(group_id: accessor.group_id)
+      where(group_id: accessor.group_id)
     else
-      self.none
+      none
     end
   }
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -107,9 +107,7 @@ class Product < ApplicationRecord
     joins(:licenses).where(licenses: { id: })
                     .licensed
                     .distinct
-                    .union(
-                      self.open,
-                    )
+                    .union(open)
                     .reorder(
                       created_at: DEFAULT_SORT_ORDER,
                     )

--- a/app/models/release_arch.rb
+++ b/app/models/release_arch.rb
@@ -47,9 +47,7 @@ class ReleaseArch < ApplicationRecord
         licenses: { id: License.for_user(user) },
       )
       .distinct
-      .union(
-        self.open
-      )
+      .union(open)
       .reorder(
         created_at: DEFAULT_SORT_ORDER,
       )
@@ -63,9 +61,7 @@ class ReleaseArch < ApplicationRecord
         licenses: { id: license },
       )
       .distinct
-      .union(
-        self.open
-      )
+      .union(open)
       .reorder(
         created_at: DEFAULT_SORT_ORDER,
       )

--- a/app/models/release_channel.rb
+++ b/app/models/release_channel.rb
@@ -53,9 +53,7 @@ class ReleaseChannel < ApplicationRecord
         licenses: { id: License.for_user(user) },
       )
       .distinct
-      .union(
-        self.open
-      )
+      .union(open)
       .reorder(
         created_at: DEFAULT_SORT_ORDER,
       )
@@ -69,9 +67,7 @@ class ReleaseChannel < ApplicationRecord
         licenses: { id: license },
       )
       .distinct
-      .union(
-        self.open
-      )
+      .union(open)
       .reorder(
         created_at: DEFAULT_SORT_ORDER,
       )

--- a/app/models/release_engine.rb
+++ b/app/models/release_engine.rb
@@ -51,9 +51,7 @@ class ReleaseEngine < ApplicationRecord
         licenses: { id: License.for_user(user) },
       )
       .distinct
-      .union(
-        self.open
-      )
+      .union(open)
       .reorder(
         created_at: DEFAULT_SORT_ORDER,
       )
@@ -67,9 +65,7 @@ class ReleaseEngine < ApplicationRecord
         licenses: { id: license },
       )
       .distinct
-      .union(
-        self.open
-      )
+      .union(open)
       .reorder(
         created_at: DEFAULT_SORT_ORDER,
       )

--- a/app/models/release_entitlement_constraint.rb
+++ b/app/models/release_entitlement_constraint.rb
@@ -42,17 +42,17 @@ class ReleaseEntitlementConstraint < ApplicationRecord
   scope :accessible_by, -> accessor {
     case accessor
     in role: Role(:admin)
-      self.all
+      all
     in role: Role(:environment)
-      self.for_environment(accessor.id)
+      for_environment(accessor.id)
     in role: Role(:product)
-      self.for_product(accessor.id)
+      for_product(accessor.id)
     in role: Role(:license)
-      self.for_license(accessor.id)
+      for_license(accessor.id)
     in role: Role(:user)
-      self.for_user(accessor.id)
+      for_user(accessor.id)
     else
-      self.none
+      none
     end
   }
 
@@ -68,9 +68,7 @@ class ReleaseEntitlementConstraint < ApplicationRecord
         licenses: { id: License.for_user(user) },
       )
       .distinct
-      .union(
-        self.open
-      )
+      .union(open)
       .reorder(
         created_at: DEFAULT_SORT_ORDER,
       )
@@ -84,9 +82,7 @@ class ReleaseEntitlementConstraint < ApplicationRecord
         licenses: { id: license },
       )
       .distinct
-      .union(
-        self.open
-      )
+      .union(open)
       .reorder(
         created_at: DEFAULT_SORT_ORDER,
       )

--- a/app/models/release_package.rb
+++ b/app/models/release_package.rb
@@ -59,9 +59,7 @@ class ReleasePackage < ApplicationRecord
         licenses: { id: License.for_user(user) },
       )
       .distinct
-      .union(
-        self.open,
-      )
+      .union(open)
       .reorder(
         created_at: DEFAULT_SORT_ORDER,
       )
@@ -74,9 +72,7 @@ class ReleasePackage < ApplicationRecord
         product: { distribution_strategy: ['LICENSED', nil] },
         licenses: { id: },
       )
-      .union(
-        self.open,
-      )
+      .union(open)
       .reorder(
         created_at: DEFAULT_SORT_ORDER,
       )

--- a/app/models/release_platform.rb
+++ b/app/models/release_platform.rb
@@ -47,9 +47,7 @@ class ReleasePlatform < ApplicationRecord
         licenses: { id: License.for_user(user) },
       )
       .distinct
-      .union(
-        self.open
-      )
+      .union(open)
       .reorder(
         created_at: DEFAULT_SORT_ORDER,
       )
@@ -63,9 +61,7 @@ class ReleasePlatform < ApplicationRecord
         licenses: { id: license },
       )
       .distinct
-      .union(
-        self.open
-      )
+      .union(open)
       .reorder(
         created_at: DEFAULT_SORT_ORDER,
       )

--- a/app/models/token.rb
+++ b/app/models/token.rb
@@ -97,29 +97,29 @@ class Token < ApplicationRecord
   scope :accessible_by, -> accessor {
     case accessor
     in role: Role(:admin)
-      self.all
+      all
     in role: Role(:environment)
-      self.for_environment(accessor)
-          .where.not(
-            bearer: accessor.admins.reorder(nil),
-          )
-          .or(
-            where(bearer: accessor)
-          )
+      for_environment(accessor)
+        .where.not(
+          bearer: accessor.admins.reorder(nil),
+        )
+        .or(
+          where(bearer: accessor),
+        )
     in role: Role(:product)
-      self.for_product(accessor.id)
-          .or(
-            where(bearer: accessor.licenses.reorder(nil)),
-          )
-          .or(
-            where(bearer: accessor.users.reorder(nil)),
-          )
+      for_product(accessor.id)
+        .or(
+          where(bearer: accessor.licenses.reorder(nil)),
+        )
+        .or(
+          where(bearer: accessor.users.reorder(nil)),
+        )
     in role: Role(:user)
-      self.for_user(accessor.id)
+      for_user(accessor.id)
     in role: Role(:license)
-      self.for_license(accessor.id)
+      for_license(accessor.id)
     else
-      self.none
+      none
     end
   }
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -281,15 +281,15 @@ class User < ApplicationRecord
   scope :accessible_by, -> accessor {
     case accessor
     in role: Role(:admin | :product) # give products the ability to read all users
-      self.all
+      all
     in role: Role(:environment)
-      self.for_environment(accessor.id)
+      for_environment(accessor.id)
     in role: Role(:user)
-      self.for_user(accessor.id)
+      for_user(accessor.id)
     in role: Role(:license)
-      self.for_license(accessor.id)
+      for_license(accessor.id)
     else
-      self.none
+      none
     end
   }
 

--- a/app/policies/release_artifact_policy.rb
+++ b/app/policies/release_artifact_policy.rb
@@ -23,9 +23,9 @@ class ReleaseArtifactPolicy < ApplicationPolicy
               .published
               .uploaded
     else
-      relation.open
-              .published
-              .uploaded
+      relation.open.without_constraints
+                   .published
+                   .uploaded
     end
   end
 

--- a/features/api/v1/artifacts/index.feature
+++ b/features/api/v1/artifacts/index.feature
@@ -1653,3 +1653,286 @@ Feature: List release artifacts
     When I send a GET request to "/accounts/test1/artifacts"
     Then the response status should be "200"
     And the response body should be an array with 3 "artifacts"
+
+  Scenario: License retrieves their artifacts with an expired license (REVOKE_ACCESS)
+    Given the current account is "test1"
+    And the current account has 1 "product"
+    And the current account has 3 "releases" for the last "product"
+    And the first "release" has the following attributes:
+      """
+      { "createdAt": "2024-04-01T00:00:00Z" }
+      """
+    And the second "release" has the following attributes:
+      """
+      { "createdAt": "2024-04-02T00:00:00Z" }
+      """
+    And the third "release" has the following attributes:
+      """
+      { "createdAt": "2024-04-03T00:00:00Z" }
+      """
+    And the current account has 1 "artifact" for each "release"
+    And the current account has 1 "policy" for the last "product"
+    And the last "policy" has the following attributes:
+      """
+      { "expirationStrategy": "REVOKE_ACCESS", "authenticationStrategy": "LICENSE" }
+      """
+    And the current account has 1 "license" for the last "policy"
+    And the last "license" has the following attributes:
+      """
+      { "expiry": "2024-04-02T00:00:00Z" }
+      """
+    And I am the last license of account "test1"
+    And I authenticate with my key
+    When I send a GET request to "/accounts/test1/artifacts"
+    Then the response status should be "403"
+
+  Scenario: License retrieves their artifacts with an expired license (RESTRICT_ACCESS)
+    Given the current account is "test1"
+    And the current account has 1 "product"
+    And the current account has 3 "releases" for the last "product"
+    And the first "release" has the following attributes:
+      """
+      { "createdAt": "2024-04-01T00:00:00Z" }
+      """
+    And the second "release" has the following attributes:
+      """
+      { "createdAt": "2024-04-02T00:00:00Z" }
+      """
+    And the third "release" has the following attributes:
+      """
+      { "createdAt": "2024-04-03T00:00:00Z" }
+      """
+    And the current account has 1 "artifact" for each "release"
+    And the current account has 1 "policy" for the last "product"
+    And the last "policy" has the following attributes:
+      """
+      { "expirationStrategy": "RESTRICT_ACCESS", "authenticationStrategy": "LICENSE" }
+      """
+    And the current account has 1 "license" for the last "policy"
+    And the last "license" has the following attributes:
+      """
+      { "expiry": "2024-04-02T00:00:00Z" }
+      """
+    And I am the last license of account "test1"
+    And I authenticate with my key
+    When I send a GET request to "/accounts/test1/artifacts"
+    Then the response status should be "200"
+    And the response body should be an array with 2 "artifacts"
+
+  Scenario: License retrieves their artifacts with an expired license (MAINTAIN_ACCESS)
+    Given the current account is "test1"
+    And the current account has 1 "product"
+    And the current account has 3 "releases" for the last "product"
+    And the first "release" has the following attributes:
+      """
+      { "createdAt": "2024-04-01T00:00:00Z" }
+      """
+    And the second "release" has the following attributes:
+      """
+      { "createdAt": "2024-04-02T00:00:00Z" }
+      """
+    And the third "release" has the following attributes:
+      """
+      { "createdAt": "2024-04-03T00:00:00Z" }
+      """
+    And the current account has 1 "artifact" for each "release"
+    And the current account has 1 "policy" for the last "product"
+    And the last "policy" has the following attributes:
+      """
+      { "expirationStrategy": "MAINTAIN_ACCESS", "authenticationStrategy": "LICENSE" }
+      """
+    And the current account has 1 "license" for the last "policy"
+    And the last "license" has the following attributes:
+      """
+      { "expiry": "2024-04-02T00:00:00Z" }
+      """
+    And I am the last license of account "test1"
+    And I authenticate with my key
+    When I send a GET request to "/accounts/test1/artifacts"
+    Then the response status should be "200"
+    And the response body should be an array with 2 "artifacts"
+
+  Scenario: License retrieves their artifacts with an expired license (ALLOW_ACCESS)
+    Given the current account is "test1"
+    And the current account has 1 "product"
+    And the current account has 3 "releases" for the last "product"
+    And the first "release" has the following attributes:
+      """
+      { "createdAt": "2024-04-01T00:00:00Z" }
+      """
+    And the second "release" has the following attributes:
+      """
+      { "createdAt": "2024-04-02T00:00:00Z" }
+      """
+    And the third "release" has the following attributes:
+      """
+      { "createdAt": "2024-04-03T00:00:00Z" }
+      """
+    And the current account has 1 "artifact" for each "release"
+    And the current account has 1 "policy" for the last "product"
+    And the last "policy" has the following attributes:
+      """
+      { "expirationStrategy": "ALLOW_ACCESS", "authenticationStrategy": "LICENSE" }
+      """
+    And the current account has 1 "license" for the last "policy"
+    And the last "license" has the following attributes:
+      """
+      { "expiry": "2024-04-02T00:00:00Z" }
+      """
+    And I am the last license of account "test1"
+    And I authenticate with my key
+    When I send a GET request to "/accounts/test1/artifacts"
+    Then the response status should be "200"
+    And the response body should be an array with 3 "artifacts"
+
+  Scenario: User retrieves their artifacts with an expired license (REVOKE_ACCESS)
+    Given the current account is "test1"
+    And the current account has 1 "user"
+    And the current account has 2 "products"
+    And the current account has 3 "releases" for the first "product"
+    And the current account has 5 "releases" for the second "product"
+    And the first "release" has the following attributes:
+      """
+      { "createdAt": "2024-04-01T00:00:00Z" }
+      """
+    And the second "release" has the following attributes:
+      """
+      { "createdAt": "2024-04-02T00:00:00Z" }
+      """
+    And the third "release" has the following attributes:
+      """
+      { "createdAt": "2024-04-03T00:00:00Z" }
+      """
+    And the current account has 1 "artifact" for each "release"
+    And the current account has 1 "policy" for the first "product"
+    And the current account has 1 "policy" for the second "product"
+    And the first "policy" has the following attributes:
+      """
+      { "expirationStrategy": "REVOKE_ACCESS", "authenticationStrategy": "LICENSE" }
+      """
+    And the current account has 1 "license" for the first "policy"
+    And the current account has 1 "license" for the second "policy" and the last "user" as "owner"
+    And the first "license" has the following attributes:
+      """
+      { "expiry": "2024-04-02T00:00:00Z" }
+      """
+    And the current account has 1 "license-user" for the first "license" and the last "user"
+    And I am the last user of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/artifacts"
+    Then the response status should be "200"
+    And the response body should be an array with 5 "artifacts"
+
+  Scenario: User retrieves their artifacts with an expired license (RESTRICT_ACCESS)
+    Given the current account is "test1"
+    And the current account has 1 "user"
+    And the current account has 2 "products"
+    And the current account has 3 "releases" for the first "product"
+    And the current account has 5 "releases" for the second "product"
+    And the first "release" has the following attributes:
+      """
+      { "createdAt": "2024-04-01T00:00:00Z" }
+      """
+    And the second "release" has the following attributes:
+      """
+      { "createdAt": "2024-04-02T00:00:00Z" }
+      """
+    And the third "release" has the following attributes:
+      """
+      { "createdAt": "2024-04-03T00:00:00Z" }
+      """
+    And the current account has 1 "artifact" for each "release"
+    And the current account has 1 "policy" for the first "product"
+    And the current account has 1 "policy" for the second "product"
+    And the first "policy" has the following attributes:
+      """
+      { "expirationStrategy": "RESTRICT_ACCESS", "authenticationStrategy": "LICENSE" }
+      """
+    And the current account has 1 "license" for the first "policy"
+    And the current account has 1 "license" for the second "policy" and the last "user" as "owner"
+    And the first "license" has the following attributes:
+      """
+      { "expiry": "2024-04-02T00:00:00Z" }
+      """
+    And the current account has 1 "license-user" for the first "license" and the last "user"
+    And I am the last user of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/artifacts"
+    Then the response status should be "200"
+    And the response body should be an array with 7 "artifacts"
+
+  Scenario: User retrieves their artifacts with an expired license (MAINTAIN_ACCESS)
+    Given the current account is "test1"
+    And the current account has 1 "user"
+    And the current account has 2 "products"
+    And the current account has 3 "releases" for the first "product"
+    And the current account has 5 "releases" for the second "product"
+    And the first "release" has the following attributes:
+      """
+      { "createdAt": "2024-04-01T00:00:00Z" }
+      """
+    And the second "release" has the following attributes:
+      """
+      { "createdAt": "2024-04-02T00:00:00Z" }
+      """
+    And the third "release" has the following attributes:
+      """
+      { "createdAt": "2024-04-03T00:00:00Z" }
+      """
+    And the current account has 1 "artifact" for each "release"
+    And the current account has 1 "policy" for the first "product"
+    And the current account has 1 "policy" for the second "product"
+    And the first "policy" has the following attributes:
+      """
+      { "expirationStrategy": "MAINTAIN_ACCESS", "authenticationStrategy": "LICENSE" }
+      """
+    And the current account has 1 "license" for the first "policy"
+    And the current account has 1 "license" for the second "policy" and the last "user" as "owner"
+    And the first "license" has the following attributes:
+      """
+      { "expiry": "2024-04-02T00:00:00Z" }
+      """
+    And the current account has 1 "license-user" for the first "license" and the last "user"
+    And I am the last user of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/artifacts"
+    Then the response status should be "200"
+    And the response body should be an array with 7 "artifacts"
+
+  Scenario: User retrieves their artifacts with an expired license (ALLOW_ACCESS)
+    Given the current account is "test1"
+    And the current account has 1 "user"
+    And the current account has 2 "products"
+    And the current account has 3 "releases" for the first "product"
+    And the current account has 5 "releases" for the second "product"
+    And the first "release" has the following attributes:
+      """
+      { "createdAt": "2024-04-01T00:00:00Z" }
+      """
+    And the second "release" has the following attributes:
+      """
+      { "createdAt": "2024-04-02T00:00:00Z" }
+      """
+    And the third "release" has the following attributes:
+      """
+      { "createdAt": "2024-04-03T00:00:00Z" }
+      """
+    And the current account has 1 "artifact" for each "release"
+    And the current account has 1 "policy" for the first "product"
+    And the current account has 1 "policy" for the second "product"
+    And the first "policy" has the following attributes:
+      """
+      { "expirationStrategy": "ALLOW_ACCESS", "authenticationStrategy": "LICENSE" }
+      """
+    And the current account has 1 "license" for the first "policy"
+    And the current account has 1 "license" for the second "policy" and the last "user" as "owner"
+    And the first "license" has the following attributes:
+      """
+      { "expiry": "2024-04-02T00:00:00Z" }
+      """
+    And the current account has 1 "license-user" for the first "license" and the last "user"
+    And I am the last user of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/artifacts"
+    Then the response status should be "200"
+    And the response body should be an array with 8 "artifacts"

--- a/features/api/v1/artifacts/show.feature
+++ b/features/api/v1/artifacts/show.feature
@@ -1351,14 +1351,7 @@ Feature: Show release artifact
     And I am a license of account "test1"
     And I use an authentication token
     When I send a GET request to "/accounts/test1/artifacts/$0"
-    Then the response status should be "403"
-    And the first error should have the following properties:
-      """
-      {
-        "title": "Access denied",
-        "detail": "You do not have permission to complete the request (license expiry falls outside of access window)"
-      }
-      """
+    Then the response status should be "404"
 
   Scenario: License retrieves an artifact for a LICENSED release with an expired license for it (revoke access)
     Given the current account is "test1"
@@ -1382,14 +1375,7 @@ Feature: Show release artifact
     And I am a license of account "test1"
     And I use an authentication token
     When I send a GET request to "/accounts/test1/artifacts/$0"
-    Then the response status should be "403"
-    And the first error should have the following properties:
-      """
-      {
-        "title": "Access denied",
-        "detail": "You do not have permission to complete the request (license is expired)"
-      }
-      """
+    Then the response status should be "404"
 
   Scenario: License retrieves an artifact for a LICENSED release with an expired license for it (expired before release, maintain access)
     Given the current account is "test1"
@@ -1413,14 +1399,7 @@ Feature: Show release artifact
     And I am a license of account "test1"
     And I use an authentication token
     When I send a GET request to "/accounts/test1/artifacts/$0"
-    Then the response status should be "403"
-    And the first error should have the following properties:
-      """
-      {
-        "title": "Access denied",
-        "detail": "You do not have permission to complete the request (license expiry falls outside of access window)"
-      }
-      """
+    Then the response status should be "404"
 
   Scenario: License retrieves an artifact for a LICENSED release with an expired license for it (expired after release, maintain access)
     Given the current account is "test1"

--- a/features/api/v1/engines/tauri/upgrade.feature
+++ b/features/api/v1/engines/tauri/upgrade.feature
@@ -337,7 +337,7 @@ Feature: Tauri upgrade package
     And I am a license of account "test1"
     And I authenticate with my key
     When I send a GET request to "/accounts/test1/engines/tauri/app1?platform=darwin&arch=x86_64&version=1.0.0"
-    Then the response status should be "403"
+    Then the response status should be "204"
 
   Scenario: License retrieves an upgrade that has entitlement constraints (has entitlements)
     Given the current account has 3 "entitlements"

--- a/features/api/v1/products/relationships/artifacts.feature
+++ b/features/api/v1/products/relationships/artifacts.feature
@@ -370,7 +370,8 @@ Feature: Product artifacts relationship
     And I am a user of account "test1"
     And I use an authentication token
     When I send a GET request to "/accounts/test1/products/$0/artifacts"
-    Then the response status should be "403"
+    Then the response status should be "200"
+    And the response body should be an array with 0 "artifacts"
 
   Scenario: User attempts to retrieve the artifacts for a product (unlicensed)
     Given the current account is "test1"
@@ -412,7 +413,8 @@ Feature: Product artifacts relationship
     And I am a license of account "test1"
     And I use an authentication token
     When I send a GET request to "/accounts/test1/products/$0/artifacts"
-    Then the response status should be "403"
+    Then the response status should be "200"
+    And the response body should be an array with 0 "artifacts"
 
   Scenario: License attempts to retrieve the artifacts for a different product
    Given the current account is "test1"

--- a/features/api/v1/releases/actions/v1x0/upgrades.feature
+++ b/features/api/v1/releases/actions/v1x0/upgrades.feature
@@ -314,26 +314,26 @@ Feature: Release upgrade actions
       }
       """
 
-  Scenario: License retrieves an upgrade for a release of their product (expired, but access restricted)
+  Scenario: License retrieves an upgrade for a release of their product (expired, out of date, but access restricted)
     Given the current account is "test1"
     And the current account has the following "product" rows:
       | id                                   | name     |
       | 6198261a-48b5-4445-a045-9fed4afc7735 | Test App |
     And the current account has the following "release" rows:
-      | id                                   | product_id                           | version      | channel |
-      | e314ba5d-c760-4e54-81c4-fa01af68ff66 | 6198261a-48b5-4445-a045-9fed4afc7735 | 1.0.0        | stable  |
-      | e26e9fef-d1ce-43d3-a15c-c8fc94429709 | 6198261a-48b5-4445-a045-9fed4afc7735 | 1.2.0        | stable  |
-      | ff04d1c4-cc04-4d19-985a-cb113827b821 | 6198261a-48b5-4445-a045-9fed4afc7735 | 1.0.1        | stable  |
-      | c8b55f91-e66f-4093-ae4d-7f3d390eae8d | 6198261a-48b5-4445-a045-9fed4afc7735 | 1.1.0        | stable  |
-      | dde54ea8-731d-4375-9d57-186ef01f3fcb | 6198261a-48b5-4445-a045-9fed4afc7735 | 1.3.0        | stable  |
-      | a7fad100-04eb-418f-8af9-e5eac497ad5a | 6198261a-48b5-4445-a045-9fed4afc7735 | 2.0.0-beta.1 | beta    |
+      | id                                   | product_id                           | created_at           | version      | channel |
+      | e314ba5d-c760-4e54-81c4-fa01af68ff66 | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-01-01T00:00:00Z | 1.0.0        | stable  |
+      | e26e9fef-d1ce-43d3-a15c-c8fc94429709 | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-03-01T00:00:00Z | 1.2.0        | stable  |
+      | ff04d1c4-cc04-4d19-985a-cb113827b821 | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-01-02T00:00:00Z | 1.0.1        | stable  |
+      | c8b55f91-e66f-4093-ae4d-7f3d390eae8d | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-02-01T00:00:00Z | 1.1.0        | stable  |
+      | dde54ea8-731d-4375-9d57-186ef01f3fcb | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-04-01T00:00:00Z | 1.3.0        | stable  |
+      | a7fad100-04eb-418f-8af9-e5eac497ad5a | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-05-01T00:00:00Z | 2.0.0-beta.1 | beta    |
     And the current account has the following "artifact" rows:
       | release_id                           | filename                  | filetype | platform |
       | e314ba5d-c760-4e54-81c4-fa01af68ff66 | Test-App-1.0.0.dmg        | dmg      | macos    |
       | e26e9fef-d1ce-43d3-a15c-c8fc94429709 | Test-App-1.2.0.dmg        | dmg      | macos    |
       | ff04d1c4-cc04-4d19-985a-cb113827b821 | Test-App-1.0.1.zip        | zip      | macos    |
       | c8b55f91-e66f-4093-ae4d-7f3d390eae8d | Test-App-1.1.0.zip        | zip      | macos    |
-      | dde54ea8-731d-4375-9d57-186ef01f3fcb | Test-App-1.3.0.zip        | zip      | macos    |
+      | dde54ea8-731d-4375-9d57-186ef01f3fcb | Test-App-1.3.0.dmg        | dmg      | macos    |
       | a7fad100-04eb-418f-8af9-e5eac497ad5a | Test-App-2.0.0-beta.1.zip | zip      | macos    |
     And the current account has 1 "policy" for the first "product"
     And the first "policy" has the following attributes:
@@ -343,12 +343,57 @@ Feature: Release upgrade actions
     And the current account has 1 "license" for the first "policy"
     And the first "license" has the following attributes:
       """
-      { "expiry": "$time.2.months.ago" }
+      { "expiry": "2024-03-01T00:00:00Z" }
       """
     And I am a license of account "test1"
     And I use an authentication token
     And I use API version "1.0"
-    When I send a GET request to "/accounts/test1/releases/$2/actions/upgrade"
+    When I send a GET request to "/accounts/test1/releases/e314ba5d-c760-4e54-81c4-fa01af68ff66/actions/upgrade"
+    Then the response status should be "303"
+    And the response body should be an "artifact"
+    And the response body should contain meta which includes the following:
+      """
+      {
+        "current": "1.0.0",
+        "next": "1.2.0"
+      }
+      """
+
+  Scenario: License retrieves an upgrade for a release of their product (expired, up to date, but access restricted)
+    Given the current account is "test1"
+    And the current account has the following "product" rows:
+      | id                                   | name     |
+      | 6198261a-48b5-4445-a045-9fed4afc7735 | Test App |
+    And the current account has the following "release" rows:
+      | id                                   | product_id                           | created_at           | version      | channel |
+      | e314ba5d-c760-4e54-81c4-fa01af68ff66 | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-01-01T00:00:00Z | 1.0.0        | stable  |
+      | e26e9fef-d1ce-43d3-a15c-c8fc94429709 | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-03-01T00:00:00Z | 1.2.0        | stable  |
+      | ff04d1c4-cc04-4d19-985a-cb113827b821 | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-01-02T00:00:00Z | 1.0.1        | stable  |
+      | c8b55f91-e66f-4093-ae4d-7f3d390eae8d | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-02-01T00:00:00Z | 1.1.0        | stable  |
+      | dde54ea8-731d-4375-9d57-186ef01f3fcb | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-04-01T00:00:00Z | 1.3.0        | stable  |
+      | a7fad100-04eb-418f-8af9-e5eac497ad5a | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-05-01T00:00:00Z | 2.0.0-beta.1 | beta    |
+    And the current account has the following "artifact" rows:
+      | release_id                           | filename                  | filetype | platform |
+      | e314ba5d-c760-4e54-81c4-fa01af68ff66 | Test-App-1.0.0.dmg        | dmg      | macos    |
+      | e26e9fef-d1ce-43d3-a15c-c8fc94429709 | Test-App-1.2.0.dmg        | dmg      | macos    |
+      | ff04d1c4-cc04-4d19-985a-cb113827b821 | Test-App-1.0.1.zip        | zip      | macos    |
+      | c8b55f91-e66f-4093-ae4d-7f3d390eae8d | Test-App-1.1.0.zip        | zip      | macos    |
+      | dde54ea8-731d-4375-9d57-186ef01f3fcb | Test-App-1.3.0.dmg        | dmg      | macos    |
+      | a7fad100-04eb-418f-8af9-e5eac497ad5a | Test-App-2.0.0-beta.1.zip | zip      | macos    |
+    And the current account has 1 "policy" for the first "product"
+    And the first "policy" has the following attributes:
+      """
+      { "expirationStrategy": "RESTRICT_ACCESS" }
+      """
+    And the current account has 1 "license" for the first "policy"
+    And the first "license" has the following attributes:
+      """
+      { "expiry": "2024-03-01T00:00:00Z" }
+      """
+    And I am a license of account "test1"
+    And I use an authentication token
+    And I use API version "1.0"
+    When I send a GET request to "/accounts/test1/releases/e26e9fef-d1ce-43d3-a15c-c8fc94429709/actions/upgrade"
     Then the response status should be "204"
 
   Scenario: License retrieves an upgrade for a release of their product (expired, but access revoked)
@@ -357,20 +402,20 @@ Feature: Release upgrade actions
       | id                                   | name     |
       | 6198261a-48b5-4445-a045-9fed4afc7735 | Test App |
     And the current account has the following "release" rows:
-      | id                                   | product_id                           | version      | channel |
-      | e314ba5d-c760-4e54-81c4-fa01af68ff66 | 6198261a-48b5-4445-a045-9fed4afc7735 | 1.0.0        | stable  |
-      | e26e9fef-d1ce-43d3-a15c-c8fc94429709 | 6198261a-48b5-4445-a045-9fed4afc7735 | 1.2.0        | stable  |
-      | ff04d1c4-cc04-4d19-985a-cb113827b821 | 6198261a-48b5-4445-a045-9fed4afc7735 | 1.0.1        | stable  |
-      | c8b55f91-e66f-4093-ae4d-7f3d390eae8d | 6198261a-48b5-4445-a045-9fed4afc7735 | 1.1.0        | stable  |
-      | dde54ea8-731d-4375-9d57-186ef01f3fcb | 6198261a-48b5-4445-a045-9fed4afc7735 | 1.3.0        | stable  |
-      | a7fad100-04eb-418f-8af9-e5eac497ad5a | 6198261a-48b5-4445-a045-9fed4afc7735 | 2.0.0-beta.1 | beta    |
+      | id                                   | product_id                           | created_at           | version      | channel |
+      | e314ba5d-c760-4e54-81c4-fa01af68ff66 | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-01-01T00:00:00Z | 1.0.0        | stable  |
+      | e26e9fef-d1ce-43d3-a15c-c8fc94429709 | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-03-01T00:00:00Z | 1.2.0        | stable  |
+      | ff04d1c4-cc04-4d19-985a-cb113827b821 | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-01-02T00:00:00Z | 1.0.1        | stable  |
+      | c8b55f91-e66f-4093-ae4d-7f3d390eae8d | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-02-01T00:00:00Z | 1.1.0        | stable  |
+      | dde54ea8-731d-4375-9d57-186ef01f3fcb | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-04-01T00:00:00Z | 1.3.0        | stable  |
+      | a7fad100-04eb-418f-8af9-e5eac497ad5a | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-05-01T00:00:00Z | 2.0.0-beta.1 | beta    |
     And the current account has the following "artifact" rows:
       | release_id                           | filename                  | filetype | platform |
       | e314ba5d-c760-4e54-81c4-fa01af68ff66 | Test-App-1.0.0.dmg        | dmg      | macos    |
       | e26e9fef-d1ce-43d3-a15c-c8fc94429709 | Test-App-1.2.0.dmg        | dmg      | macos    |
       | ff04d1c4-cc04-4d19-985a-cb113827b821 | Test-App-1.0.1.zip        | zip      | macos    |
       | c8b55f91-e66f-4093-ae4d-7f3d390eae8d | Test-App-1.1.0.zip        | zip      | macos    |
-      | dde54ea8-731d-4375-9d57-186ef01f3fcb | Test-App-1.3.0.zip        | zip      | macos    |
+      | dde54ea8-731d-4375-9d57-186ef01f3fcb | Test-App-1.3.0.dmg        | dmg      | macos    |
       | a7fad100-04eb-418f-8af9-e5eac497ad5a | Test-App-2.0.0-beta.1.zip | zip      | macos    |
     And the current account has 1 "policy" for the first "product"
     And the first "policy" has the following attributes:
@@ -380,34 +425,34 @@ Feature: Release upgrade actions
     And the current account has 1 "license" for the first "policy"
     And the first "license" has the following attributes:
       """
-      { "expiry": "$time.6.months.ago" }
+      { "expiry": "2024-03-01T00:00:00Z" }
       """
     And I am a license of account "test1"
     And I use an authentication token
     And I use API version "1.0"
-    When I send a GET request to "/accounts/test1/releases/$2/actions/upgrade"
-    Then the response status should be "204"
+    When I send a GET request to "/accounts/test1/releases/e314ba5d-c760-4e54-81c4-fa01af68ff66/actions/upgrade"
+    Then the response status should be "404"
 
-  Scenario: License retrieves an upgrade for a release of their product (expired, access maintained)
+  Scenario: License retrieves an upgrade for a release of their product (expired, out of date, access maintained)
     Given the current account is "test1"
     And the current account has the following "product" rows:
       | id                                   | name     |
       | 6198261a-48b5-4445-a045-9fed4afc7735 | Test App |
     And the current account has the following "release" rows:
-      | id                                   | product_id                           | version      | channel |
-      | e314ba5d-c760-4e54-81c4-fa01af68ff66 | 6198261a-48b5-4445-a045-9fed4afc7735 | 1.0.0        | stable  |
-      | e26e9fef-d1ce-43d3-a15c-c8fc94429709 | 6198261a-48b5-4445-a045-9fed4afc7735 | 1.2.0        | stable  |
-      | ff04d1c4-cc04-4d19-985a-cb113827b821 | 6198261a-48b5-4445-a045-9fed4afc7735 | 1.0.1        | stable  |
-      | c8b55f91-e66f-4093-ae4d-7f3d390eae8d | 6198261a-48b5-4445-a045-9fed4afc7735 | 1.1.0        | stable  |
-      | dde54ea8-731d-4375-9d57-186ef01f3fcb | 6198261a-48b5-4445-a045-9fed4afc7735 | 1.3.0        | stable  |
-      | a7fad100-04eb-418f-8af9-e5eac497ad5a | 6198261a-48b5-4445-a045-9fed4afc7735 | 2.0.0-beta.1 | beta    |
+      | id                                   | product_id                           | created_at           | version      | channel |
+      | e314ba5d-c760-4e54-81c4-fa01af68ff66 | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-01-01T00:00:00Z | 1.0.0        | stable  |
+      | e26e9fef-d1ce-43d3-a15c-c8fc94429709 | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-03-01T00:00:00Z | 1.2.0        | stable  |
+      | ff04d1c4-cc04-4d19-985a-cb113827b821 | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-01-02T00:00:00Z | 1.0.1        | stable  |
+      | c8b55f91-e66f-4093-ae4d-7f3d390eae8d | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-02-01T00:00:00Z | 1.1.0        | stable  |
+      | dde54ea8-731d-4375-9d57-186ef01f3fcb | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-04-01T00:00:00Z | 1.3.0        | stable  |
+      | a7fad100-04eb-418f-8af9-e5eac497ad5a | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-05-01T00:00:00Z | 2.0.0-beta.1 | beta    |
     And the current account has the following "artifact" rows:
       | release_id                           | filename                  | filetype | platform |
       | e314ba5d-c760-4e54-81c4-fa01af68ff66 | Test-App-1.0.0.dmg        | dmg      | macos    |
       | e26e9fef-d1ce-43d3-a15c-c8fc94429709 | Test-App-1.2.0.dmg        | dmg      | macos    |
       | ff04d1c4-cc04-4d19-985a-cb113827b821 | Test-App-1.0.1.zip        | zip      | macos    |
       | c8b55f91-e66f-4093-ae4d-7f3d390eae8d | Test-App-1.1.0.zip        | zip      | macos    |
-      | dde54ea8-731d-4375-9d57-186ef01f3fcb | Test-App-1.3.0.zip        | zip      | macos    |
+      | dde54ea8-731d-4375-9d57-186ef01f3fcb | Test-App-1.3.0.dmg        | dmg      | macos    |
       | a7fad100-04eb-418f-8af9-e5eac497ad5a | Test-App-2.0.0-beta.1.zip | zip      | macos    |
     And the current account has 1 "policy" for the first "product"
     And the first "policy" has the following attributes:
@@ -417,12 +462,57 @@ Feature: Release upgrade actions
     And the current account has 1 "license" for the first "policy"
     And the first "license" has the following attributes:
       """
-      { "expiry": "$time.2.months.ago" }
+      { "expiry": "2024-03-01T00:00:00Z" }
       """
     And I am a license of account "test1"
     And I use an authentication token
     And I use API version "1.0"
-    When I send a GET request to "/accounts/test1/releases/$2/actions/upgrade"
+    When I send a GET request to "/accounts/test1/releases/ff04d1c4-cc04-4d19-985a-cb113827b821/actions/upgrade"
+    Then the response status should be "303"
+    And the response body should be an "artifact"
+    And the response body should contain meta which includes the following:
+      """
+      {
+        "current": "1.0.1",
+        "next": "1.1.0"
+      }
+      """
+
+  Scenario: License retrieves an upgrade for a release of their product (expired, up to date, access maintained)
+    Given the current account is "test1"
+    And the current account has the following "product" rows:
+      | id                                   | name     |
+      | 6198261a-48b5-4445-a045-9fed4afc7735 | Test App |
+    And the current account has the following "release" rows:
+      | id                                   | product_id                           | created_at           | version      | channel |
+      | e314ba5d-c760-4e54-81c4-fa01af68ff66 | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-01-01T00:00:00Z | 1.0.0        | stable  |
+      | e26e9fef-d1ce-43d3-a15c-c8fc94429709 | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-03-01T00:00:00Z | 1.2.0        | stable  |
+      | ff04d1c4-cc04-4d19-985a-cb113827b821 | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-01-02T00:00:00Z | 1.0.1        | stable  |
+      | c8b55f91-e66f-4093-ae4d-7f3d390eae8d | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-02-01T00:00:00Z | 1.1.0        | stable  |
+      | dde54ea8-731d-4375-9d57-186ef01f3fcb | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-04-01T00:00:00Z | 1.3.0        | stable  |
+      | a7fad100-04eb-418f-8af9-e5eac497ad5a | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-05-01T00:00:00Z | 2.0.0-beta.1 | beta    |
+    And the current account has the following "artifact" rows:
+      | release_id                           | filename                  | filetype | platform |
+      | e314ba5d-c760-4e54-81c4-fa01af68ff66 | Test-App-1.0.0.dmg        | dmg      | macos    |
+      | e26e9fef-d1ce-43d3-a15c-c8fc94429709 | Test-App-1.2.0.dmg        | dmg      | macos    |
+      | ff04d1c4-cc04-4d19-985a-cb113827b821 | Test-App-1.0.1.zip        | zip      | macos    |
+      | c8b55f91-e66f-4093-ae4d-7f3d390eae8d | Test-App-1.1.0.zip        | zip      | macos    |
+      | dde54ea8-731d-4375-9d57-186ef01f3fcb | Test-App-1.3.0.dmg        | dmg      | macos    |
+      | a7fad100-04eb-418f-8af9-e5eac497ad5a | Test-App-2.0.0-beta.1.zip | zip      | macos    |
+    And the current account has 1 "policy" for the first "product"
+    And the first "policy" has the following attributes:
+      """
+      { "expirationStrategy": "MAINTAIN_ACCESS" }
+      """
+    And the current account has 1 "license" for the first "policy"
+    And the first "license" has the following attributes:
+      """
+      { "expiry": "2024-03-01T00:00:00Z" }
+      """
+    And I am a license of account "test1"
+    And I use an authentication token
+    And I use API version "1.0"
+    When I send a GET request to "/accounts/test1/releases/e26e9fef-d1ce-43d3-a15c-c8fc94429709/actions/upgrade"
     Then the response status should be "204"
 
   Scenario: License retrieves an upgrade for a release of their product (expired, access allowed)
@@ -431,20 +521,20 @@ Feature: Release upgrade actions
       | id                                   | name     |
       | 6198261a-48b5-4445-a045-9fed4afc7735 | Test App |
     And the current account has the following "release" rows:
-      | id                                   | product_id                           | version      | channel |
-      | e314ba5d-c760-4e54-81c4-fa01af68ff66 | 6198261a-48b5-4445-a045-9fed4afc7735 | 1.0.0        | stable  |
-      | e26e9fef-d1ce-43d3-a15c-c8fc94429709 | 6198261a-48b5-4445-a045-9fed4afc7735 | 1.2.0        | stable  |
-      | ff04d1c4-cc04-4d19-985a-cb113827b821 | 6198261a-48b5-4445-a045-9fed4afc7735 | 1.0.1        | stable  |
-      | c8b55f91-e66f-4093-ae4d-7f3d390eae8d | 6198261a-48b5-4445-a045-9fed4afc7735 | 1.1.0        | stable  |
-      | dde54ea8-731d-4375-9d57-186ef01f3fcb | 6198261a-48b5-4445-a045-9fed4afc7735 | 1.3.0        | stable  |
-      | a7fad100-04eb-418f-8af9-e5eac497ad5a | 6198261a-48b5-4445-a045-9fed4afc7735 | 2.0.0-beta.1 | beta    |
+      | id                                   | product_id                           | created_at           | version      | channel |
+      | e314ba5d-c760-4e54-81c4-fa01af68ff66 | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-01-01T00:00:00Z | 1.0.0        | stable  |
+      | e26e9fef-d1ce-43d3-a15c-c8fc94429709 | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-03-01T00:00:00Z | 1.2.0        | stable  |
+      | ff04d1c4-cc04-4d19-985a-cb113827b821 | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-01-02T00:00:00Z | 1.0.1        | stable  |
+      | c8b55f91-e66f-4093-ae4d-7f3d390eae8d | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-02-01T00:00:00Z | 1.1.0        | stable  |
+      | dde54ea8-731d-4375-9d57-186ef01f3fcb | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-04-01T00:00:00Z | 1.3.0        | stable  |
+      | a7fad100-04eb-418f-8af9-e5eac497ad5a | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-05-01T00:00:00Z | 2.0.0-beta.1 | beta    |
     And the current account has the following "artifact" rows:
       | release_id                           | filename                  | filetype | platform |
       | e314ba5d-c760-4e54-81c4-fa01af68ff66 | Test-App-1.0.0.dmg        | dmg      | macos    |
       | e26e9fef-d1ce-43d3-a15c-c8fc94429709 | Test-App-1.2.0.dmg        | dmg      | macos    |
       | ff04d1c4-cc04-4d19-985a-cb113827b821 | Test-App-1.0.1.zip        | zip      | macos    |
       | c8b55f91-e66f-4093-ae4d-7f3d390eae8d | Test-App-1.1.0.zip        | zip      | macos    |
-      | dde54ea8-731d-4375-9d57-186ef01f3fcb | Test-App-1.3.0.zip        | zip      | macos    |
+      | dde54ea8-731d-4375-9d57-186ef01f3fcb | Test-App-1.3.0.dmg        | dmg      | macos    |
       | a7fad100-04eb-418f-8af9-e5eac497ad5a | Test-App-2.0.0-beta.1.zip | zip      | macos    |
     And the current account has 1 "policy" for the first "product"
     And the first "policy" has the following attributes:
@@ -454,18 +544,18 @@ Feature: Release upgrade actions
     And the current account has 1 "license" for the first "policy"
     And the first "license" has the following attributes:
       """
-      { "expiry": "$time.2.months.ago" }
+      { "expiry": "2024-03-01T00:00:00Z" }
       """
     And I am a license of account "test1"
     And I use an authentication token
     And I use API version "1.0"
-    When I send a GET request to "/accounts/test1/releases/$2/actions/upgrade"
+    When I send a GET request to "/accounts/test1/releases/e26e9fef-d1ce-43d3-a15c-c8fc94429709/actions/upgrade"
     Then the response status should be "303"
     And the response body should be an "artifact"
     And the response body should contain meta which includes the following:
       """
       {
-        "current": "1.0.1",
+        "current": "1.2.0",
         "next": "1.3.0"
       }
       """
@@ -509,20 +599,20 @@ Feature: Release upgrade actions
       | id                                   | name     |
       | 6198261a-48b5-4445-a045-9fed4afc7735 | Test App |
     And the current account has the following "release" rows:
-      | id                                   | product_id                           | version      | channel |
-      | e314ba5d-c760-4e54-81c4-fa01af68ff66 | 6198261a-48b5-4445-a045-9fed4afc7735 | 1.0.0        | stable  |
-      | e26e9fef-d1ce-43d3-a15c-c8fc94429709 | 6198261a-48b5-4445-a045-9fed4afc7735 | 1.2.0        | stable  |
-      | ff04d1c4-cc04-4d19-985a-cb113827b821 | 6198261a-48b5-4445-a045-9fed4afc7735 | 1.0.1        | stable  |
-      | c8b55f91-e66f-4093-ae4d-7f3d390eae8d | 6198261a-48b5-4445-a045-9fed4afc7735 | 1.1.0        | stable  |
-      | dde54ea8-731d-4375-9d57-186ef01f3fcb | 6198261a-48b5-4445-a045-9fed4afc7735 | 1.3.0        | stable  |
-      | a7fad100-04eb-418f-8af9-e5eac497ad5a | 6198261a-48b5-4445-a045-9fed4afc7735 | 2.0.0-beta.1 | beta    |
+      | id                                   | product_id                           | created_at           | version      | channel |
+      | e314ba5d-c760-4e54-81c4-fa01af68ff66 | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-01-01T00:00:00Z | 1.0.0        | stable  |
+      | e26e9fef-d1ce-43d3-a15c-c8fc94429709 | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-03-01T00:00:00Z | 1.2.0        | stable  |
+      | ff04d1c4-cc04-4d19-985a-cb113827b821 | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-01-02T00:00:00Z | 1.0.1        | stable  |
+      | c8b55f91-e66f-4093-ae4d-7f3d390eae8d | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-02-01T00:00:00Z | 1.1.0        | stable  |
+      | dde54ea8-731d-4375-9d57-186ef01f3fcb | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-04-01T00:00:00Z | 1.3.0        | stable  |
+      | a7fad100-04eb-418f-8af9-e5eac497ad5a | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-05-01T00:00:00Z | 2.0.0-beta.1 | beta    |
     And the current account has the following "artifact" rows:
       | release_id                           | filename                  | filetype | platform |
       | e314ba5d-c760-4e54-81c4-fa01af68ff66 | Test-App-1.0.0.dmg        | dmg      | macos    |
       | e26e9fef-d1ce-43d3-a15c-c8fc94429709 | Test-App-1.2.0.dmg        | dmg      | macos    |
       | ff04d1c4-cc04-4d19-985a-cb113827b821 | Test-App-1.0.1.zip        | zip      | macos    |
       | c8b55f91-e66f-4093-ae4d-7f3d390eae8d | Test-App-1.1.0.zip        | zip      | macos    |
-      | dde54ea8-731d-4375-9d57-186ef01f3fcb | Test-App-1.3.0.zip        | zip      | macos    |
+      | dde54ea8-731d-4375-9d57-186ef01f3fcb | Test-App-1.3.0.dmg        | dmg      | macos    |
       | a7fad100-04eb-418f-8af9-e5eac497ad5a | Test-App-2.0.0-beta.1.zip | zip      | macos    |
     And the current account has 1 "policy" for the first "product"
     And the first "policy" has the following attributes:
@@ -535,12 +625,12 @@ Feature: Release upgrade actions
     And the current account has 1 "license" for the first "policy"
     And the first "license" has the following attributes:
       """
-      { "expiry": "$time.2.months.ago" }
+      { "expiry": "2024-03-01T00:00:00Z" }
       """
     And I am a license of account "test1"
     And I authenticate with my key
     And I use API version "1.0"
-    When I send a GET request to "/accounts/test1/releases/$2/actions/upgrade"
+    When I send a GET request to "/accounts/test1/releases/e26e9fef-d1ce-43d3-a15c-c8fc94429709/actions/upgrade"
     Then the response status should be "204"
 
   Scenario: License retrieves an upgrade for a release of their product (key auth, expired, but access revoked)
@@ -549,20 +639,20 @@ Feature: Release upgrade actions
       | id                                   | name     |
       | 6198261a-48b5-4445-a045-9fed4afc7735 | Test App |
     And the current account has the following "release" rows:
-      | id                                   | product_id                           | version      | channel |
-      | e314ba5d-c760-4e54-81c4-fa01af68ff66 | 6198261a-48b5-4445-a045-9fed4afc7735 | 1.0.0        | stable  |
-      | e26e9fef-d1ce-43d3-a15c-c8fc94429709 | 6198261a-48b5-4445-a045-9fed4afc7735 | 1.2.0        | stable  |
-      | ff04d1c4-cc04-4d19-985a-cb113827b821 | 6198261a-48b5-4445-a045-9fed4afc7735 | 1.0.1        | stable  |
-      | c8b55f91-e66f-4093-ae4d-7f3d390eae8d | 6198261a-48b5-4445-a045-9fed4afc7735 | 1.1.0        | stable  |
-      | dde54ea8-731d-4375-9d57-186ef01f3fcb | 6198261a-48b5-4445-a045-9fed4afc7735 | 1.3.0        | stable  |
-      | a7fad100-04eb-418f-8af9-e5eac497ad5a | 6198261a-48b5-4445-a045-9fed4afc7735 | 2.0.0-beta.1 | beta    |
+      | id                                   | product_id                           | created_at           | version      | channel |
+      | e314ba5d-c760-4e54-81c4-fa01af68ff66 | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-01-01T00:00:00Z | 1.0.0        | stable  |
+      | e26e9fef-d1ce-43d3-a15c-c8fc94429709 | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-03-01T00:00:00Z | 1.2.0        | stable  |
+      | ff04d1c4-cc04-4d19-985a-cb113827b821 | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-01-02T00:00:00Z | 1.0.1        | stable  |
+      | c8b55f91-e66f-4093-ae4d-7f3d390eae8d | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-02-01T00:00:00Z | 1.1.0        | stable  |
+      | dde54ea8-731d-4375-9d57-186ef01f3fcb | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-04-01T00:00:00Z | 1.3.0        | stable  |
+      | a7fad100-04eb-418f-8af9-e5eac497ad5a | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-05-01T00:00:00Z | 2.0.0-beta.1 | beta    |
     And the current account has the following "artifact" rows:
       | release_id                           | filename                  | filetype | platform |
       | e314ba5d-c760-4e54-81c4-fa01af68ff66 | Test-App-1.0.0.dmg        | dmg      | macos    |
       | e26e9fef-d1ce-43d3-a15c-c8fc94429709 | Test-App-1.2.0.dmg        | dmg      | macos    |
       | ff04d1c4-cc04-4d19-985a-cb113827b821 | Test-App-1.0.1.zip        | zip      | macos    |
       | c8b55f91-e66f-4093-ae4d-7f3d390eae8d | Test-App-1.1.0.zip        | zip      | macos    |
-      | dde54ea8-731d-4375-9d57-186ef01f3fcb | Test-App-1.3.0.zip        | zip      | macos    |
+      | dde54ea8-731d-4375-9d57-186ef01f3fcb | Test-App-1.3.0.dmg        | dmg      | macos    |
       | a7fad100-04eb-418f-8af9-e5eac497ad5a | Test-App-2.0.0-beta.1.zip | zip      | macos    |
     And the current account has 1 "policy" for the first "product"
     And the first "policy" has the following attributes:
@@ -575,12 +665,12 @@ Feature: Release upgrade actions
     And the current account has 1 "license" for the first "policy"
     And the first "license" has the following attributes:
       """
-      { "expiry": "$time.6.months.ago" }
+      { "expiry": "2024-03-01T00:00:00Z" }
       """
     And I am a license of account "test1"
     And I authenticate with my key
     And I use API version "1.0"
-    When I send a GET request to "/accounts/test1/releases/$2/actions/upgrade"
+    When I send a GET request to "/accounts/test1/releases/e314ba5d-c760-4e54-81c4-fa01af68ff66/actions/upgrade"
     Then the response status should be "403"
     And the first error should have the following properties:
       """
@@ -986,7 +1076,7 @@ Feature: Release upgrade actions
     And I use an authentication token
     And I use API version "1.0"
     When I send a GET request to "/accounts/test1/releases/$0/actions/upgrade"
-    Then the response status should be "204"
+    Then the response status should be "404"
 
   Scenario: User retrieves an upgrade for a release of their product (suspended)
     Given the current account is "test1"

--- a/features/api/v1/releases/index.feature
+++ b/features/api/v1/releases/index.feature
@@ -1375,3 +1375,278 @@ Feature: List releases
     When I send a GET request to "/accounts/test1/releases"
     Then the response status should be "200"
     And the response body should be an array with 3 "releases"
+
+  Scenario: License retrieves their releases with an expired license (REVOKE_ACCESS)
+    Given the current account is "test1"
+    And the current account has 1 "product"
+    And the current account has 3 "releases" for the last "product"
+    And the first "release" has the following attributes:
+      """
+      { "createdAt": "2024-04-01T00:00:00Z" }
+      """
+    And the second "release" has the following attributes:
+      """
+      { "createdAt": "2024-04-02T00:00:00Z" }
+      """
+    And the third "release" has the following attributes:
+      """
+      { "createdAt": "2024-04-03T00:00:00Z" }
+      """
+    And the current account has 1 "policy" for the last "product"
+    And the last "policy" has the following attributes:
+      """
+      { "expirationStrategy": "REVOKE_ACCESS", "authenticationStrategy": "LICENSE" }
+      """
+    And the current account has 1 "license" for the last "policy"
+    And the last "license" has the following attributes:
+      """
+      { "expiry": "2024-04-02T00:00:00Z" }
+      """
+    And I am the last license of account "test1"
+    And I authenticate with my key
+    When I send a GET request to "/accounts/test1/releases"
+    Then the response status should be "403"
+
+  Scenario: License retrieves their releases with an expired license (RESTRICT_ACCESS)
+    Given the current account is "test1"
+    And the current account has 1 "product"
+    And the current account has 3 "releases" for the last "product"
+    And the first "release" has the following attributes:
+      """
+      { "createdAt": "2024-04-01T00:00:00Z" }
+      """
+    And the second "release" has the following attributes:
+      """
+      { "createdAt": "2024-04-02T00:00:00Z" }
+      """
+    And the third "release" has the following attributes:
+      """
+      { "createdAt": "2024-04-03T00:00:00Z" }
+      """
+    And the current account has 1 "policy" for the last "product"
+    And the last "policy" has the following attributes:
+      """
+      { "expirationStrategy": "RESTRICT_ACCESS", "authenticationStrategy": "LICENSE" }
+      """
+    And the current account has 1 "license" for the last "policy"
+    And the last "license" has the following attributes:
+      """
+      { "expiry": "2024-04-02T00:00:00Z" }
+      """
+    And I am the last license of account "test1"
+    And I authenticate with my key
+    When I send a GET request to "/accounts/test1/releases"
+    Then the response status should be "200"
+    And the response body should be an array with 2 "releases"
+
+  Scenario: License retrieves their releases with an expired license (MAINTAIN_ACCESS)
+    Given the current account is "test1"
+    And the current account has 1 "product"
+    And the current account has 3 "releases" for the last "product"
+    And the first "release" has the following attributes:
+      """
+      { "createdAt": "2024-04-01T00:00:00Z" }
+      """
+    And the second "release" has the following attributes:
+      """
+      { "createdAt": "2024-04-02T00:00:00Z" }
+      """
+    And the third "release" has the following attributes:
+      """
+      { "createdAt": "2024-04-03T00:00:00Z" }
+      """
+    And the current account has 1 "policy" for the last "product"
+    And the last "policy" has the following attributes:
+      """
+      { "expirationStrategy": "MAINTAIN_ACCESS", "authenticationStrategy": "LICENSE" }
+      """
+    And the current account has 1 "license" for the last "policy"
+    And the last "license" has the following attributes:
+      """
+      { "expiry": "2024-04-02T00:00:00Z" }
+      """
+    And I am the last license of account "test1"
+    And I authenticate with my key
+    When I send a GET request to "/accounts/test1/releases"
+    Then the response status should be "200"
+    And the response body should be an array with 2 "releases"
+
+  Scenario: License retrieves their releases with an expired license (ALLOW_ACCESS)
+    Given the current account is "test1"
+    And the current account has 1 "product"
+    And the current account has 3 "releases" for the last "product"
+    And the first "release" has the following attributes:
+      """
+      { "createdAt": "2024-04-01T00:00:00Z" }
+      """
+    And the second "release" has the following attributes:
+      """
+      { "createdAt": "2024-04-02T00:00:00Z" }
+      """
+    And the third "release" has the following attributes:
+      """
+      { "createdAt": "2024-04-03T00:00:00Z" }
+      """
+    And the current account has 1 "policy" for the last "product"
+    And the last "policy" has the following attributes:
+      """
+      { "expirationStrategy": "ALLOW_ACCESS", "authenticationStrategy": "LICENSE" }
+      """
+    And the current account has 1 "license" for the last "policy"
+    And the last "license" has the following attributes:
+      """
+      { "expiry": "2024-04-02T00:00:00Z" }
+      """
+    And I am the last license of account "test1"
+    And I authenticate with my key
+    When I send a GET request to "/accounts/test1/releases"
+    Then the response status should be "200"
+    And the response body should be an array with 3 "releases"
+
+  Scenario: User retrieves their releases with an expired license (REVOKE_ACCESS)
+    Given the current account is "test1"
+    And the current account has 1 "user"
+    And the current account has 2 "products"
+    And the current account has 3 "releases" for the first "product"
+    And the current account has 5 "releases" for the second "product"
+    And the first "release" has the following attributes:
+      """
+      { "createdAt": "2024-04-01T00:00:00Z" }
+      """
+    And the second "release" has the following attributes:
+      """
+      { "createdAt": "2024-04-02T00:00:00Z" }
+      """
+    And the third "release" has the following attributes:
+      """
+      { "createdAt": "2024-04-03T00:00:00Z" }
+      """
+    And the current account has 1 "policy" for the first "product"
+    And the current account has 1 "policy" for the second "product"
+    And the first "policy" has the following attributes:
+      """
+      { "expirationStrategy": "REVOKE_ACCESS", "authenticationStrategy": "LICENSE" }
+      """
+    And the current account has 1 "license" for the first "policy"
+    And the current account has 1 "license" for the second "policy" and the last "user" as "owner"
+    And the first "license" has the following attributes:
+      """
+      { "expiry": "2024-04-02T00:00:00Z" }
+      """
+    And the current account has 1 "license-user" for the first "license" and the last "user"
+    And I am the last user of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/releases"
+    Then the response status should be "200"
+    And the response body should be an array with 5 "releases"
+
+  Scenario: User retrieves their releases with an expired license (RESTRICT_ACCESS)
+    Given the current account is "test1"
+    And the current account has 1 "user"
+    And the current account has 2 "products"
+    And the current account has 3 "releases" for the first "product"
+    And the current account has 5 "releases" for the second "product"
+    And the first "release" has the following attributes:
+      """
+      { "createdAt": "2024-04-01T00:00:00Z" }
+      """
+    And the second "release" has the following attributes:
+      """
+      { "createdAt": "2024-04-02T00:00:00Z" }
+      """
+    And the third "release" has the following attributes:
+      """
+      { "createdAt": "2024-04-03T00:00:00Z" }
+      """
+    And the current account has 1 "policy" for the first "product"
+    And the current account has 1 "policy" for the second "product"
+    And the first "policy" has the following attributes:
+      """
+      { "expirationStrategy": "RESTRICT_ACCESS", "authenticationStrategy": "LICENSE" }
+      """
+    And the current account has 1 "license" for the first "policy"
+    And the current account has 1 "license" for the second "policy" and the last "user" as "owner"
+    And the first "license" has the following attributes:
+      """
+      { "expiry": "2024-04-02T00:00:00Z" }
+      """
+    And the current account has 1 "license-user" for the first "license" and the last "user"
+    And I am the last user of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/releases"
+    Then the response status should be "200"
+    And the response body should be an array with 7 "releases"
+
+  Scenario: User retrieves their releases with an expired license (MAINTAIN_ACCESS)
+    Given the current account is "test1"
+    And the current account has 1 "user"
+    And the current account has 2 "products"
+    And the current account has 3 "releases" for the first "product"
+    And the current account has 5 "releases" for the second "product"
+    And the first "release" has the following attributes:
+      """
+      { "createdAt": "2024-04-01T00:00:00Z" }
+      """
+    And the second "release" has the following attributes:
+      """
+      { "createdAt": "2024-04-02T00:00:00Z" }
+      """
+    And the third "release" has the following attributes:
+      """
+      { "createdAt": "2024-04-03T00:00:00Z" }
+      """
+    And the current account has 1 "policy" for the first "product"
+    And the current account has 1 "policy" for the second "product"
+    And the first "policy" has the following attributes:
+      """
+      { "expirationStrategy": "MAINTAIN_ACCESS", "authenticationStrategy": "LICENSE" }
+      """
+    And the current account has 1 "license" for the first "policy"
+    And the current account has 1 "license" for the second "policy" and the last "user" as "owner"
+    And the first "license" has the following attributes:
+      """
+      { "expiry": "2024-04-02T00:00:00Z" }
+      """
+    And the current account has 1 "license-user" for the first "license" and the last "user"
+    And I am the last user of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/releases"
+    Then the response status should be "200"
+    And the response body should be an array with 7 "releases"
+
+  Scenario: User retrieves their releases with an expired license (ALLOW_ACCESS)
+    Given the current account is "test1"
+    And the current account has 1 "user"
+    And the current account has 2 "products"
+    And the current account has 3 "releases" for the first "product"
+    And the current account has 5 "releases" for the second "product"
+    And the first "release" has the following attributes:
+      """
+      { "createdAt": "2024-04-01T00:00:00Z" }
+      """
+    And the second "release" has the following attributes:
+      """
+      { "createdAt": "2024-04-02T00:00:00Z" }
+      """
+    And the third "release" has the following attributes:
+      """
+      { "createdAt": "2024-04-03T00:00:00Z" }
+      """
+    And the current account has 1 "policy" for the first "product"
+    And the current account has 1 "policy" for the second "product"
+    And the first "policy" has the following attributes:
+      """
+      { "expirationStrategy": "ALLOW_ACCESS", "authenticationStrategy": "LICENSE" }
+      """
+    And the current account has 1 "license" for the first "policy"
+    And the current account has 1 "license" for the second "policy" and the last "user" as "owner"
+    And the first "license" has the following attributes:
+      """
+      { "expiry": "2024-04-02T00:00:00Z" }
+      """
+    And the current account has 1 "license-user" for the first "license" and the last "user"
+    And I am the last user of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/releases"
+    Then the response status should be "200"
+    And the response body should be an array with 8 "releases"

--- a/features/api/v1/releases/relationships/artifacts.feature
+++ b/features/api/v1/releases/relationships/artifacts.feature
@@ -334,7 +334,7 @@ Feature: Release artifacts relationship
     And I am a license of account "test1"
     And I use an authentication token
     When I send a GET request to "/accounts/test1/releases/$0/artifacts/$0"
-    Then the response status should be "403"
+    Then the response status should be "404"
 
   Scenario: License retrieves the artifact for a release of their product (expired after release, restrict access)
     Given the current account is "test1"
@@ -383,7 +383,7 @@ Feature: Release artifacts relationship
     And I am a license of account "test1"
     And I use an authentication token
     When I send a GET request to "/accounts/test1/releases/$0/artifacts/$0"
-    Then the response status should be "403"
+    Then the response status should be "404"
 
   Scenario: License retrieves the artifact for a release of their product (expired after release, maintain access)
     Given the current account is "test1"
@@ -453,7 +453,7 @@ Feature: Release artifacts relationship
     And I am a license of account "test1"
     And I use an authentication token
     When I send a GET request to "/accounts/test1/releases/$0/artifacts/$0"
-    Then the response status should be "403"
+    Then the response status should be "404"
 
   Scenario: License retrieves the artifact for a release of their product (expired before release, maintain access)
     Given the current account is "test1"
@@ -473,7 +473,7 @@ Feature: Release artifacts relationship
     And I am a license of account "test1"
     And I use an authentication token
     When I send a GET request to "/accounts/test1/releases/$0/artifacts/$0"
-    Then the response status should be "403"
+    Then the response status should be "404"
 
   Scenario: License retrieves the artifact for a release of their product (expired before release, allow access)
     Given the current account is "test1"
@@ -533,7 +533,7 @@ Feature: Release artifacts relationship
     And I am a license of account "test1"
     And I authenticate with my license key
     When I send a GET request to "/accounts/test1/releases/$0/artifacts/$0"
-    Then the response status should be "403"
+    Then the response status should be "404"
 
   Scenario: License retrieves the artifact for a release of their product (key auth, expired after release, restrict access)
     Given the current account is "test1"
@@ -861,7 +861,7 @@ Feature: Release artifacts relationship
     And I am a user of account "test1"
     And I use an authentication token
     When I send a GET request to "/accounts/test1/releases/$0/artifacts/$0"
-    Then the response status should be "403"
+    Then the response status should be "404"
 
   Scenario: User retrieves a release artifact with a license for it (expired after release)
     Given the current account is "test1"

--- a/features/api/v1/releases/relationships/upgrade.feature
+++ b/features/api/v1/releases/relationships/upgrade.feature
@@ -263,47 +263,19 @@ Feature: Upgrade release
       }
       """
 
-  Scenario: License retrieves an upgrade for a release of their product (expired, but access restricted)
-    Given the current account is "test1"
-    And the current account has the following "product" rows:
-      | id                                   | name     |
-      | 6198261a-48b5-4445-a045-9fed4afc7735 | Test App |
-    And the current account has the following "release" rows:
-      | id                                   | product_id                           | version      | channel |
-      | e314ba5d-c760-4e54-81c4-fa01af68ff66 | 6198261a-48b5-4445-a045-9fed4afc7735 | 1.0.0        | stable  |
-      | e26e9fef-d1ce-43d3-a15c-c8fc94429709 | 6198261a-48b5-4445-a045-9fed4afc7735 | 1.2.0        | stable  |
-      | ff04d1c4-cc04-4d19-985a-cb113827b821 | 6198261a-48b5-4445-a045-9fed4afc7735 | 1.0.1        | stable  |
-      | c8b55f91-e66f-4093-ae4d-7f3d390eae8d | 6198261a-48b5-4445-a045-9fed4afc7735 | 1.1.0        | stable  |
-      | dde54ea8-731d-4375-9d57-186ef01f3fcb | 6198261a-48b5-4445-a045-9fed4afc7735 | 1.3.0        | stable  |
-      | a7fad100-04eb-418f-8af9-e5eac497ad5a | 6198261a-48b5-4445-a045-9fed4afc7735 | 2.0.0-beta.1 | beta    |
-    And the current account has 1 "policy" for the first "product"
-    And the first "policy" has the following attributes:
-      """
-      { "expirationStrategy": "RESTRICT_ACCESS" }
-      """
-    And the current account has 1 "license" for the first "policy"
-    And the first "license" has the following attributes:
-      """
-      { "expiry": "$time.2.months.ago" }
-      """
-    And I am a license of account "test1"
-    And I use an authentication token
-    When I send a GET request to "/accounts/test1/releases/$2/upgrade"
-    Then the response status should be "403"
-
   Scenario: License retrieves an upgrade for a release of their product (expired, but access revoked)
     Given the current account is "test1"
     And the current account has the following "product" rows:
       | id                                   | name     |
       | 6198261a-48b5-4445-a045-9fed4afc7735 | Test App |
     And the current account has the following "release" rows:
-      | id                                   | product_id                           | version      | channel |
-      | e314ba5d-c760-4e54-81c4-fa01af68ff66 | 6198261a-48b5-4445-a045-9fed4afc7735 | 1.0.0        | stable  |
-      | e26e9fef-d1ce-43d3-a15c-c8fc94429709 | 6198261a-48b5-4445-a045-9fed4afc7735 | 1.2.0        | stable  |
-      | ff04d1c4-cc04-4d19-985a-cb113827b821 | 6198261a-48b5-4445-a045-9fed4afc7735 | 1.0.1        | stable  |
-      | c8b55f91-e66f-4093-ae4d-7f3d390eae8d | 6198261a-48b5-4445-a045-9fed4afc7735 | 1.1.0        | stable  |
-      | dde54ea8-731d-4375-9d57-186ef01f3fcb | 6198261a-48b5-4445-a045-9fed4afc7735 | 1.3.0        | stable  |
-      | a7fad100-04eb-418f-8af9-e5eac497ad5a | 6198261a-48b5-4445-a045-9fed4afc7735 | 2.0.0-beta.1 | beta    |
+      | id                                   | product_id                           | created_at           | version      | channel |
+      | e314ba5d-c760-4e54-81c4-fa01af68ff66 | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-01-01T00:00:00Z | 1.0.0        | stable  |
+      | e26e9fef-d1ce-43d3-a15c-c8fc94429709 | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-03-01T00:00:00Z | 1.2.0        | stable  |
+      | ff04d1c4-cc04-4d19-985a-cb113827b821 | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-01-02T00:00:00Z | 1.0.1        | stable  |
+      | c8b55f91-e66f-4093-ae4d-7f3d390eae8d | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-02-01T00:00:00Z | 1.1.0        | stable  |
+      | dde54ea8-731d-4375-9d57-186ef01f3fcb | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-04-01T00:00:00Z | 1.3.0        | stable  |
+      | a7fad100-04eb-418f-8af9-e5eac497ad5a | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-05-01T00:00:00Z | 2.0.0-beta.1 | beta    |
     And the current account has 1 "policy" for the first "product"
     And the first "policy" has the following attributes:
       """
@@ -312,12 +284,142 @@ Feature: Upgrade release
     And the current account has 1 "license" for the first "policy"
     And the first "license" has the following attributes:
       """
-      { "expiry": "$time.6.months.ago" }
+      { "expiry": "2024-03-02T00:00:00Z" }
       """
     And I am a license of account "test1"
     And I use an authentication token
-    When I send a GET request to "/accounts/test1/releases/$2/upgrade"
-    Then the response status should be "403"
+    When I send a GET request to "/accounts/test1/releases/1.0.0/upgrade"
+    Then the response status should be "404"
+
+  Scenario: License retrieves an upgrade for a release of their product (expired, out of date, but access restricted)
+    Given the current account is "test1"
+    And the current account has the following "product" rows:
+      | id                                   | name     |
+      | 6198261a-48b5-4445-a045-9fed4afc7735 | Test App |
+    And the current account has the following "release" rows:
+      | id                                   | product_id                           | created_at           | version      | channel |
+      | e314ba5d-c760-4e54-81c4-fa01af68ff66 | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-01-01T00:00:00Z | 1.0.0        | stable  |
+      | e26e9fef-d1ce-43d3-a15c-c8fc94429709 | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-03-01T00:00:00Z | 1.2.0        | stable  |
+      | ff04d1c4-cc04-4d19-985a-cb113827b821 | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-01-02T00:00:00Z | 1.0.1        | stable  |
+      | c8b55f91-e66f-4093-ae4d-7f3d390eae8d | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-02-01T00:00:00Z | 1.1.0        | stable  |
+      | dde54ea8-731d-4375-9d57-186ef01f3fcb | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-04-01T00:00:00Z | 1.3.0        | stable  |
+      | a7fad100-04eb-418f-8af9-e5eac497ad5a | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-05-01T00:00:00Z | 2.0.0-beta.1 | beta    |
+    And the current account has 1 "policy" for the first "product"
+    And the first "policy" has the following attributes:
+      """
+      { "expirationStrategy": "RESTRICT_ACCESS" }
+      """
+    And the current account has 1 "license" for the first "policy"
+    And the first "license" has the following attributes:
+      """
+      { "expiry": "2024-03-02T00:00:00Z" }
+      """
+    And I am a license of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/releases/1.1.0/upgrade"
+    Then the response status should be "200"
+    And the response body should be a "release" with the following attributes:
+      """
+      { "version": "1.2.0" }
+      """
+    And the response body should contain meta which includes the following:
+      """
+      {
+        "current": "1.1.0",
+        "next": "1.2.0"
+      }
+      """
+
+  Scenario: License retrieves an upgrade for a release of their product (expired, up to date, but access restricted)
+    Given the current account is "test1"
+    And the current account has the following "product" rows:
+      | id                                   | name     |
+      | 6198261a-48b5-4445-a045-9fed4afc7735 | Test App |
+    And the current account has the following "release" rows:
+      | id                                   | product_id                           | created_at           | version      | channel |
+      | e314ba5d-c760-4e54-81c4-fa01af68ff66 | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-01-01T00:00:00Z | 1.0.0        | stable  |
+      | e26e9fef-d1ce-43d3-a15c-c8fc94429709 | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-03-01T00:00:00Z | 1.2.0        | stable  |
+      | ff04d1c4-cc04-4d19-985a-cb113827b821 | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-01-02T00:00:00Z | 1.0.1        | stable  |
+      | c8b55f91-e66f-4093-ae4d-7f3d390eae8d | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-02-01T00:00:00Z | 1.1.0        | stable  |
+      | dde54ea8-731d-4375-9d57-186ef01f3fcb | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-04-01T00:00:00Z | 1.3.0        | stable  |
+      | a7fad100-04eb-418f-8af9-e5eac497ad5a | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-05-01T00:00:00Z | 2.0.0-beta.1 | beta    |
+    And the current account has 1 "policy" for the first "product"
+    And the first "policy" has the following attributes:
+      """
+      { "expirationStrategy": "RESTRICT_ACCESS" }
+      """
+    And the current account has 1 "license" for the first "policy"
+    And the first "license" has the following attributes:
+      """
+      { "expiry": "2024-03-02T00:00:00Z" }
+      """
+    And I am a license of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/releases/1.2.0/upgrade"
+    Then the response status should be "404"
+
+  Scenario: License retrieves an upgrade for a release of their product (expired, out of date, but access maintained)
+    Given the current account is "test1"
+    And the current account has the following "product" rows:
+      | id                                   | name     |
+      | 6198261a-48b5-4445-a045-9fed4afc7735 | Test App |
+    And the current account has the following "release" rows:
+      | id                                   | product_id                           | created_at           | version      | channel |
+      | e314ba5d-c760-4e54-81c4-fa01af68ff66 | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-01-01T00:00:00Z | 1.0.0        | stable  |
+      | e26e9fef-d1ce-43d3-a15c-c8fc94429709 | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-03-01T00:00:00Z | 1.2.0        | stable  |
+      | ff04d1c4-cc04-4d19-985a-cb113827b821 | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-01-02T00:00:00Z | 1.0.1        | stable  |
+      | c8b55f91-e66f-4093-ae4d-7f3d390eae8d | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-02-01T00:00:00Z | 1.1.0        | stable  |
+      | dde54ea8-731d-4375-9d57-186ef01f3fcb | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-04-01T00:00:00Z | 1.3.0        | stable  |
+      | a7fad100-04eb-418f-8af9-e5eac497ad5a | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-05-01T00:00:00Z | 2.0.0-beta.1 | beta    |
+    And the current account has 1 "policy" for the first "product"
+    And the first "policy" has the following attributes:
+      """
+      { "expirationStrategy": "MAINTAIN_ACCESS" }
+      """
+    And the current account has 1 "license" for the first "policy"
+    And the first "license" has the following attributes:
+      """
+      { "expiry": "2024-03-01T00:00:00Z" }
+      """
+    And I am a license of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/releases/1.0.1/upgrade"
+    Then the response status should be "200"
+    And the response body should contain meta which includes the following:
+      """
+      {
+        "current": "1.0.1",
+        "next": "1.2.0"
+      }
+      """
+
+  Scenario: License retrieves an upgrade for a release of their product (expired, up to date, but access maintained)
+    Given the current account is "test1"
+    And the current account has the following "product" rows:
+      | id                                   | name     |
+      | 6198261a-48b5-4445-a045-9fed4afc7735 | Test App |
+    And the current account has the following "release" rows:
+      | id                                   | product_id                           | created_at           | version      | channel |
+      | e314ba5d-c760-4e54-81c4-fa01af68ff66 | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-01-01T00:00:00Z | 1.0.0        | stable  |
+      | e26e9fef-d1ce-43d3-a15c-c8fc94429709 | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-03-01T00:00:00Z | 1.2.0        | stable  |
+      | ff04d1c4-cc04-4d19-985a-cb113827b821 | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-01-02T00:00:00Z | 1.0.1        | stable  |
+      | c8b55f91-e66f-4093-ae4d-7f3d390eae8d | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-02-01T00:00:00Z | 1.1.0        | stable  |
+      | dde54ea8-731d-4375-9d57-186ef01f3fcb | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-04-01T00:00:00Z | 1.3.0        | stable  |
+      | a7fad100-04eb-418f-8af9-e5eac497ad5a | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-05-01T00:00:00Z | 2.0.0-beta.1 | beta    |
+    And the current account has 1 "policy" for the first "product"
+    And the first "policy" has the following attributes:
+      """
+      { "expirationStrategy": "MAINTAIN_ACCESS" }
+      """
+    And the current account has 1 "license" for the first "policy"
+    And the first "license" has the following attributes:
+      """
+      { "expiry": "2024-03-01T00:00:00Z" }
+      """
+    And I am a license of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/releases/1.2.0/upgrade"
+    Then the response status should be "404"
 
   Scenario: License retrieves an upgrade for a release of their product (valid, but access maintained)
     Given the current account is "test1"
@@ -325,22 +427,26 @@ Feature: Upgrade release
       | id                                   | name     |
       | 6198261a-48b5-4445-a045-9fed4afc7735 | Test App |
     And the current account has the following "release" rows:
-      | id                                   | product_id                           | version      | channel |
-      | e314ba5d-c760-4e54-81c4-fa01af68ff66 | 6198261a-48b5-4445-a045-9fed4afc7735 | 1.0.0        | stable  |
-      | e26e9fef-d1ce-43d3-a15c-c8fc94429709 | 6198261a-48b5-4445-a045-9fed4afc7735 | 1.2.0        | stable  |
-      | ff04d1c4-cc04-4d19-985a-cb113827b821 | 6198261a-48b5-4445-a045-9fed4afc7735 | 1.0.1        | stable  |
-      | c8b55f91-e66f-4093-ae4d-7f3d390eae8d | 6198261a-48b5-4445-a045-9fed4afc7735 | 1.1.0        | stable  |
-      | dde54ea8-731d-4375-9d57-186ef01f3fcb | 6198261a-48b5-4445-a045-9fed4afc7735 | 1.3.0        | stable  |
-      | a7fad100-04eb-418f-8af9-e5eac497ad5a | 6198261a-48b5-4445-a045-9fed4afc7735 | 2.0.0-beta.1 | beta    |
+      | id                                   | product_id                           | created_at           | version      | channel |
+      | e314ba5d-c760-4e54-81c4-fa01af68ff66 | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-01-01T00:00:00Z | 1.0.0        | stable  |
+      | e26e9fef-d1ce-43d3-a15c-c8fc94429709 | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-03-01T00:00:00Z | 1.2.0        | stable  |
+      | ff04d1c4-cc04-4d19-985a-cb113827b821 | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-01-02T00:00:00Z | 1.0.1        | stable  |
+      | c8b55f91-e66f-4093-ae4d-7f3d390eae8d | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-02-01T00:00:00Z | 1.1.0        | stable  |
+      | dde54ea8-731d-4375-9d57-186ef01f3fcb | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-04-01T00:00:00Z | 1.3.0        | stable  |
+      | a7fad100-04eb-418f-8af9-e5eac497ad5a | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-05-01T00:00:00Z | 2.0.0-beta.1 | beta    |
     And the current account has 1 "policy" for the first "product"
     And the first "policy" has the following attributes:
       """
       { "expirationStrategy": "MAINTAIN_ACCESS" }
       """
     And the current account has 1 "license" for the first "policy"
+    And the first "license" has the following attributes:
+      """
+      { "expiry": "2025-01-01T00:00:00Z" }
+      """
     And I am a license of account "test1"
     And I use an authentication token
-    When I send a GET request to "/accounts/test1/releases/$2/upgrade"
+    When I send a GET request to "/accounts/test1/releases/1.0.1/upgrade"
     Then the response status should be "200"
     And the response body should contain meta which includes the following:
       """
@@ -350,47 +456,19 @@ Feature: Upgrade release
       }
       """
 
-  Scenario: License retrieves an upgrade for a release of their product (expired, but access maintained)
-    Given the current account is "test1"
-    And the current account has the following "product" rows:
-      | id                                   | name     |
-      | 6198261a-48b5-4445-a045-9fed4afc7735 | Test App |
-    And the current account has the following "release" rows:
-      | id                                   | product_id                           | version      | channel |
-      | e314ba5d-c760-4e54-81c4-fa01af68ff66 | 6198261a-48b5-4445-a045-9fed4afc7735 | 1.0.0        | stable  |
-      | e26e9fef-d1ce-43d3-a15c-c8fc94429709 | 6198261a-48b5-4445-a045-9fed4afc7735 | 1.2.0        | stable  |
-      | ff04d1c4-cc04-4d19-985a-cb113827b821 | 6198261a-48b5-4445-a045-9fed4afc7735 | 1.0.1        | stable  |
-      | c8b55f91-e66f-4093-ae4d-7f3d390eae8d | 6198261a-48b5-4445-a045-9fed4afc7735 | 1.1.0        | stable  |
-      | dde54ea8-731d-4375-9d57-186ef01f3fcb | 6198261a-48b5-4445-a045-9fed4afc7735 | 1.3.0        | stable  |
-      | a7fad100-04eb-418f-8af9-e5eac497ad5a | 6198261a-48b5-4445-a045-9fed4afc7735 | 2.0.0-beta.1 | beta    |
-    And the current account has 1 "policy" for the first "product"
-    And the first "policy" has the following attributes:
-      """
-      { "expirationStrategy": "MAINTAIN_ACCESS" }
-      """
-    And the current account has 1 "license" for the first "policy"
-    And the first "license" has the following attributes:
-      """
-      { "expiry": "$time.6.months.ago" }
-      """
-    And I am a license of account "test1"
-    And I use an authentication token
-    When I send a GET request to "/accounts/test1/releases/$2/upgrade"
-    Then the response status should be "403"
-
   Scenario: License retrieves an upgrade for a release of their product (expired, access allowed)
     Given the current account is "test1"
     And the current account has the following "product" rows:
       | id                                   | name     |
       | 6198261a-48b5-4445-a045-9fed4afc7735 | Test App |
     And the current account has the following "release" rows:
-      | id                                   | product_id                           | version      | channel |
-      | e314ba5d-c760-4e54-81c4-fa01af68ff66 | 6198261a-48b5-4445-a045-9fed4afc7735 | 1.0.0        | stable  |
-      | e26e9fef-d1ce-43d3-a15c-c8fc94429709 | 6198261a-48b5-4445-a045-9fed4afc7735 | 1.2.0        | stable  |
-      | ff04d1c4-cc04-4d19-985a-cb113827b821 | 6198261a-48b5-4445-a045-9fed4afc7735 | 1.0.1        | stable  |
-      | c8b55f91-e66f-4093-ae4d-7f3d390eae8d | 6198261a-48b5-4445-a045-9fed4afc7735 | 1.1.0        | stable  |
-      | dde54ea8-731d-4375-9d57-186ef01f3fcb | 6198261a-48b5-4445-a045-9fed4afc7735 | 1.3.0        | stable  |
-      | a7fad100-04eb-418f-8af9-e5eac497ad5a | 6198261a-48b5-4445-a045-9fed4afc7735 | 2.0.0-beta.1 | beta    |
+      | id                                   | product_id                           | created_at           | version      | channel |
+      | e314ba5d-c760-4e54-81c4-fa01af68ff66 | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-01-01T00:00:00Z | 1.0.0        | stable  |
+      | e26e9fef-d1ce-43d3-a15c-c8fc94429709 | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-03-01T00:00:00Z | 1.2.0        | stable  |
+      | ff04d1c4-cc04-4d19-985a-cb113827b821 | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-01-02T00:00:00Z | 1.0.1        | stable  |
+      | c8b55f91-e66f-4093-ae4d-7f3d390eae8d | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-02-01T00:00:00Z | 1.1.0        | stable  |
+      | dde54ea8-731d-4375-9d57-186ef01f3fcb | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-04-01T00:00:00Z | 1.3.0        | stable  |
+      | a7fad100-04eb-418f-8af9-e5eac497ad5a | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-05-01T00:00:00Z | 2.0.0-beta.1 | beta    |
     And the current account has 1 "policy" for the first "product"
     And the first "policy" has the following attributes:
       """
@@ -399,11 +477,11 @@ Feature: Upgrade release
     And the current account has 1 "license" for the first "policy"
     And the first "license" has the following attributes:
       """
-      { "expiry": "$time.2.months.ago" }
+      { "expiry": "2024-01-01T00:00:00Z" }
       """
     And I am a license of account "test1"
     And I use an authentication token
-    When I send a GET request to "/accounts/test1/releases/$2/upgrade"
+    When I send a GET request to "/accounts/test1/releases/1.0.1/upgrade"
     Then the response status should be "200"
     And the response body should contain meta which includes the following:
       """
@@ -443,13 +521,13 @@ Feature: Upgrade release
       | id                                   | name     |
       | 6198261a-48b5-4445-a045-9fed4afc7735 | Test App |
     And the current account has the following "release" rows:
-      | id                                   | product_id                           | version      | channel |
-      | e314ba5d-c760-4e54-81c4-fa01af68ff66 | 6198261a-48b5-4445-a045-9fed4afc7735 | 1.0.0        | stable  |
-      | e26e9fef-d1ce-43d3-a15c-c8fc94429709 | 6198261a-48b5-4445-a045-9fed4afc7735 | 1.2.0        | stable  |
-      | ff04d1c4-cc04-4d19-985a-cb113827b821 | 6198261a-48b5-4445-a045-9fed4afc7735 | 1.0.1        | stable  |
-      | c8b55f91-e66f-4093-ae4d-7f3d390eae8d | 6198261a-48b5-4445-a045-9fed4afc7735 | 1.1.0        | stable  |
-      | dde54ea8-731d-4375-9d57-186ef01f3fcb | 6198261a-48b5-4445-a045-9fed4afc7735 | 1.3.0        | stable  |
-      | a7fad100-04eb-418f-8af9-e5eac497ad5a | 6198261a-48b5-4445-a045-9fed4afc7735 | 2.0.0-beta.1 | beta    |
+      | id                                   | product_id                           | created_at           | version      | channel |
+      | e314ba5d-c760-4e54-81c4-fa01af68ff66 | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-01-01T00:00:00Z | 1.0.0        | stable  |
+      | e26e9fef-d1ce-43d3-a15c-c8fc94429709 | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-03-01T00:00:00Z | 1.2.0        | stable  |
+      | ff04d1c4-cc04-4d19-985a-cb113827b821 | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-01-02T00:00:00Z | 1.0.1        | stable  |
+      | c8b55f91-e66f-4093-ae4d-7f3d390eae8d | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-02-01T00:00:00Z | 1.1.0        | stable  |
+      | dde54ea8-731d-4375-9d57-186ef01f3fcb | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-04-01T00:00:00Z | 1.3.0        | stable  |
+      | a7fad100-04eb-418f-8af9-e5eac497ad5a | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-05-01T00:00:00Z | 2.0.0-beta.1 | beta    |
     And the current account has 1 "policy" for the first "product"
     And the first "policy" has the following attributes:
       """
@@ -461,12 +539,19 @@ Feature: Upgrade release
     And the current account has 1 "license" for the first "policy"
     And the first "license" has the following attributes:
       """
-      { "expiry": "$time.2.months.ago" }
+      { "expiry": "2024-02-01T00:00:00Z" }
       """
     And I am a license of account "test1"
     And I authenticate with my key
-    When I send a GET request to "/accounts/test1/releases/$2/upgrade"
-    Then the response status should be "403"
+    When I send a GET request to "/accounts/test1/releases/1.0.1/upgrade"
+    Then the response status should be "200"
+    And the response body should contain meta which includes the following:
+      """
+      {
+        "current": "1.0.1",
+        "next": "1.1.0"
+      }
+      """
 
   Scenario: License retrieves an upgrade for a release of their product (key auth, expired, but access allowed)
     Given the current account is "test1"
@@ -474,13 +559,13 @@ Feature: Upgrade release
       | id                                   | name     |
       | 6198261a-48b5-4445-a045-9fed4afc7735 | Test App |
     And the current account has the following "release" rows:
-      | id                                   | product_id                           | version      | channel |
-      | e314ba5d-c760-4e54-81c4-fa01af68ff66 | 6198261a-48b5-4445-a045-9fed4afc7735 | 1.0.0        | stable  |
-      | e26e9fef-d1ce-43d3-a15c-c8fc94429709 | 6198261a-48b5-4445-a045-9fed4afc7735 | 1.2.0        | stable  |
-      | ff04d1c4-cc04-4d19-985a-cb113827b821 | 6198261a-48b5-4445-a045-9fed4afc7735 | 1.0.1        | stable  |
-      | c8b55f91-e66f-4093-ae4d-7f3d390eae8d | 6198261a-48b5-4445-a045-9fed4afc7735 | 1.1.0        | stable  |
-      | dde54ea8-731d-4375-9d57-186ef01f3fcb | 6198261a-48b5-4445-a045-9fed4afc7735 | 1.3.0        | stable  |
-      | a7fad100-04eb-418f-8af9-e5eac497ad5a | 6198261a-48b5-4445-a045-9fed4afc7735 | 2.0.0-beta.1 | beta    |
+      | id                                   | product_id                           | created_at           | version      | channel |
+      | e314ba5d-c760-4e54-81c4-fa01af68ff66 | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-01-01T00:00:00Z | 1.0.0        | stable  |
+      | e26e9fef-d1ce-43d3-a15c-c8fc94429709 | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-03-01T00:00:00Z | 1.2.0        | stable  |
+      | ff04d1c4-cc04-4d19-985a-cb113827b821 | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-01-02T00:00:00Z | 1.0.1        | stable  |
+      | c8b55f91-e66f-4093-ae4d-7f3d390eae8d | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-02-01T00:00:00Z | 1.1.0        | stable  |
+      | dde54ea8-731d-4375-9d57-186ef01f3fcb | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-04-01T00:00:00Z | 1.3.0        | stable  |
+      | a7fad100-04eb-418f-8af9-e5eac497ad5a | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-05-01T00:00:00Z | 2.0.0-beta.1 | beta    |
     And the current account has 1 "policy" for the first "product"
     And the first "policy" has the following attributes:
       """
@@ -492,16 +577,16 @@ Feature: Upgrade release
     And the current account has 1 "license" for the first "policy"
     And the first "license" has the following attributes:
       """
-      { "expiry": "$time.2.months.ago" }
+      { "expiry": "2024-02-01T00:00:00Z" }
       """
     And I am a license of account "test1"
     And I authenticate with my key
-    When I send a GET request to "/accounts/test1/releases/$2/upgrade"
+    When I send a GET request to "/accounts/test1/releases/1.2.0/upgrade"
     Then the response status should be "200"
     And the response body should contain meta which includes the following:
       """
       {
-        "current": "1.0.1",
+        "current": "1.2.0",
         "next": "1.3.0"
       }
       """
@@ -512,13 +597,13 @@ Feature: Upgrade release
       | id                                   | name     |
       | 6198261a-48b5-4445-a045-9fed4afc7735 | Test App |
     And the current account has the following "release" rows:
-      | id                                   | product_id                           | version      | channel |
-      | e314ba5d-c760-4e54-81c4-fa01af68ff66 | 6198261a-48b5-4445-a045-9fed4afc7735 | 1.0.0        | stable  |
-      | e26e9fef-d1ce-43d3-a15c-c8fc94429709 | 6198261a-48b5-4445-a045-9fed4afc7735 | 1.2.0        | stable  |
-      | ff04d1c4-cc04-4d19-985a-cb113827b821 | 6198261a-48b5-4445-a045-9fed4afc7735 | 1.0.1        | stable  |
-      | c8b55f91-e66f-4093-ae4d-7f3d390eae8d | 6198261a-48b5-4445-a045-9fed4afc7735 | 1.1.0        | stable  |
-      | dde54ea8-731d-4375-9d57-186ef01f3fcb | 6198261a-48b5-4445-a045-9fed4afc7735 | 1.3.0        | stable  |
-      | a7fad100-04eb-418f-8af9-e5eac497ad5a | 6198261a-48b5-4445-a045-9fed4afc7735 | 2.0.0-beta.1 | beta    |
+      | id                                   | product_id                           | created_at           | version      | channel |
+      | e314ba5d-c760-4e54-81c4-fa01af68ff66 | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-01-01T00:00:00Z | 1.0.0        | stable  |
+      | e26e9fef-d1ce-43d3-a15c-c8fc94429709 | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-03-01T00:00:00Z | 1.2.0        | stable  |
+      | ff04d1c4-cc04-4d19-985a-cb113827b821 | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-01-02T00:00:00Z | 1.0.1        | stable  |
+      | c8b55f91-e66f-4093-ae4d-7f3d390eae8d | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-02-01T00:00:00Z | 1.1.0        | stable  |
+      | dde54ea8-731d-4375-9d57-186ef01f3fcb | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-04-01T00:00:00Z | 1.3.0        | stable  |
+      | a7fad100-04eb-418f-8af9-e5eac497ad5a | 6198261a-48b5-4445-a045-9fed4afc7735 | 2024-05-01T00:00:00Z | 2.0.0-beta.1 | beta    |
     And the current account has 1 "policy" for the first "product"
     And the first "policy" has the following attributes:
       """
@@ -530,7 +615,7 @@ Feature: Upgrade release
     And the current account has 1 "license" for the first "policy"
     And the first "license" has the following attributes:
       """
-      { "expiry": "$time.6.months.ago" }
+      { "expiry": "2024-02-01T00:00:00Z" }
       """
     And I am a license of account "test1"
     And I authenticate with my key
@@ -757,7 +842,7 @@ Feature: Upgrade release
     And I am a license of account "test1"
     And I use an authentication token
     When I send a GET request to "/accounts/test1/releases/$0/upgrade"
-    Then the response status should be "403"
+    Then the response status should be "404"
 
   Scenario: License retrieves an upgrade for a release of their product (missing all entitlements)
     Given the current account is "test1"
@@ -1281,7 +1366,7 @@ Feature: Upgrade release
     And I am a user of account "test1"
     And I use an authentication token
     When I send a GET request to "/accounts/test1/releases/$0/upgrade"
-    Then the response status should be "403"
+    Then the response status should be "404"
 
   Scenario: User retrieves an upgrade for a release of their product (suspended)
     Given the current account is "test1"
@@ -1494,7 +1579,7 @@ Feature: Upgrade release
     And I am a user of account "test1"
     And I use an authentication token
     When I send a GET request to "/accounts/test1/releases/$0/upgrade"
-    Then the response status should be "403"
+    Then the response status should be "404"
 
   Scenario: User retrieves an upgrade for a release of their product (missing all entitlements)
     Given the current account is "test1"
@@ -1570,7 +1655,7 @@ Feature: Upgrade release
     And I am a license of account "test1"
     And I use an authentication token
     When I send a GET request to "/accounts/test1/releases/$0/upgrade"
-    Then the response status should be "403"
+    Then the response status should be "404"
 
   Scenario: License retrieves an upgrade for a product release (OPEN distribution strategy, has entitlement)
     Given the current account is "test1"

--- a/features/api/v1/releases/relationships/v1x0/artifact.feature
+++ b/features/api/v1/releases/relationships/v1x0/artifact.feature
@@ -271,35 +271,9 @@ Feature: Release artifact relationship
     And I use an authentication token
     And I use API version "1.0"
     When I send a GET request to "/accounts/test1/releases/$0/artifact"
-    Then the response status should be "403"
+    Then the response status should be "404"
 
-  Scenario: License retrieves the artifact for a release of their product (expired after release, restrict access)
-    Given the current account is "test1"
-    And the current account has 1 "product"
-    And the current account has 1 "policy" for an existing "product"
-    And the first "policy" has the following attributes:
-      """
-      { "expirationStrategy": "RESTRICT_ACCESS" }
-      """
-    And the current account has 1 "license" for an existing "policy"
-    And the first "license" has the following attributes:
-      """
-      { "expiry": "$time.2.months.ago" }
-      """
-    And the current account has 3 "releases" for the first "product"
-    And the first "release" has the following attributes:
-      """
-      { "createdAt": "$time.3.months.ago" }
-      """
-    And the current account has 1 "artifact" for the first "release"
-    And I am a license of account "test1"
-    And I use an authentication token
-    And I use API version "1.0"
-    When I send a GET request to "/accounts/test1/releases/$0/artifact"
-    Then the response status should be "303"
-    And the response body should be an "artifact"
-
-  Scenario: License retrieves the artifact for a release of their product (expired after release, revoke access)
+  Scenario: License retrieves the artifact for a release of their product (expired before release, revoke access)
     Given the current account is "test1"
     And the current account has 1 "product"
     And the current account has 1 "policy" for an existing "product"
@@ -310,19 +284,95 @@ Feature: Release artifact relationship
     And the current account has 1 "license" for an existing "policy"
     And the first "license" has the following attributes:
       """
-      { "expiry": "$time.2.months.ago" }
+      { "expiry": "$time.3.months.ago" }
       """
     And the current account has 3 "releases" for the first "product"
     And the first "release" has the following attributes:
       """
-      { "createdAt": "$time.3.months.ago" }
+      { "createdAt": "$time.2.months.ago" }
       """
     And the current account has 1 "artifact" for the first "release"
     And I am a license of account "test1"
     And I use an authentication token
     And I use API version "1.0"
     When I send a GET request to "/accounts/test1/releases/$0/artifact"
-    Then the response status should be "403"
+    Then the response status should be "404"
+
+  Scenario: License retrieves the artifact for a release of their product (expired before release, restrict access)
+    Given the current account is "test1"
+    And the current account has 1 "product"
+    And the current account has 1 "policy" for an existing "product"
+    And the first "policy" has the following attributes:
+      """
+      { "expirationStrategy": "RESTRICT_ACCESS" }
+      """
+    And the current account has 1 "license" for an existing "policy"
+    And the first "license" has the following attributes:
+      """
+      { "expiry": "$time.3.months.ago" }
+      """
+    And the current account has 3 "releases" for the first "product"
+    And the first "release" has the following attributes:
+      """
+      { "createdAt": "$time.2.months.ago" }
+      """
+    And the current account has 1 "artifact" for the first "release"
+    And I am a license of account "test1"
+    And I use an authentication token
+    And I use API version "1.0"
+    When I send a GET request to "/accounts/test1/releases/$0/artifact"
+    Then the response status should be "404"
+
+  Scenario: License retrieves the artifact for a release of their product (expired before release, maintain access)
+    Given the current account is "test1"
+    And the current account has 1 "product"
+    And the current account has 1 "policy" for an existing "product"
+    And the first "policy" has the following attributes:
+      """
+      { "expirationStrategy": "MAINTAIN_ACCESS" }
+      """
+    And the current account has 1 "license" for an existing "policy"
+    And the first "license" has the following attributes:
+      """
+      { "expiry": "$time.3.months.ago" }
+      """
+    And the current account has 3 "releases" for the first "product"
+    And the first "release" has the following attributes:
+      """
+      { "createdAt": "$time.2.months.ago" }
+      """
+    And the current account has 1 "artifact" for the first "release"
+    And I am a license of account "test1"
+    And I use an authentication token
+    And I use API version "1.0"
+    When I send a GET request to "/accounts/test1/releases/$0/artifact"
+    Then the response status should be "404"
+
+  Scenario: License retrieves the artifact for a release of their product (expired before release, allow access)
+    Given the current account is "test1"
+    And the current account has 1 "product"
+    And the current account has 1 "policy" for an existing "product"
+    And the first "policy" has the following attributes:
+      """
+      { "expirationStrategy": "ALLOW_ACCESS" }
+      """
+    And the current account has 1 "license" for an existing "policy"
+    And the first "license" has the following attributes:
+      """
+      { "expiry": "$time.3.months.ago" }
+      """
+    And the current account has 3 "releases" for the first "product"
+    And the first "release" has the following attributes:
+      """
+      { "createdAt": "$time.2.months.ago" }
+      """
+    And the current account has 1 "artifact" for the first "release"
+    And I am a license of account "test1"
+    And I use an authentication token
+    And I use API version "1.0"
+    When I send a GET request to "/accounts/test1/releases/$0/artifact"
+    Then the response status should be "303"
+    And the response body should be an "artifact"
 
   Scenario: License retrieves the artifact for a release of their product (suspended)
     Given the current account is "test1"
@@ -363,6 +413,34 @@ Feature: Release artifact relationship
     And I authenticate with my license key
     And I use API version "1.0"
     When I send a GET request to "/accounts/test1/releases/$0/artifact"
+    Then the response status should be "404"
+
+  Scenario: License retrieves the artifact for a release of their product (key auth, expired after release, revoke access)
+    Given the current account is "test1"
+    And the current account has 1 "product"
+    And the current account has 1 "policy" for an existing "product"
+    And the first "policy" has the following attributes:
+      """
+      {
+        "expirationStrategy": "REVOKE_ACCESS",
+        "authenticationStrategy": "LICENSE"
+      }
+      """
+    And the current account has 1 "license" for an existing "policy"
+    And the first "license" has the following attributes:
+      """
+      { "expiry": "$time.2.months.ago" }
+      """
+    And the current account has 3 "releases" for the first "product"
+    And the first "release" has the following attributes:
+      """
+      { "createdAt": "$time.3.months.ago" }
+      """
+    And the current account has 1 "artifact" for the first "release"
+    And I am a license of account "test1"
+    And I authenticate with my license key
+    And I use API version "1.0"
+    When I send a GET request to "/accounts/test1/releases/$0/artifact"
     Then the response status should be "403"
 
   Scenario: License retrieves the artifact for a release of their product (key auth, expired after release, restrict access)
@@ -394,14 +472,14 @@ Feature: Release artifact relationship
     Then the response status should be "303"
     And the response body should be an "artifact"
 
-  Scenario: License retrieves the artifact for a release of their product (key auth, expired after release, revoke access)
+  Scenario: License retrieves the artifact for a release of their product (key auth, expired after release, maintain access)
     Given the current account is "test1"
     And the current account has 1 "product"
     And the current account has 1 "policy" for an existing "product"
     And the first "policy" has the following attributes:
       """
       {
-        "expirationStrategy": "REVOKE_ACCESS",
+        "expirationStrategy": "MAINTAIN_ACCESS",
         "authenticationStrategy": "LICENSE"
       }
       """
@@ -420,7 +498,37 @@ Feature: Release artifact relationship
     And I authenticate with my license key
     And I use API version "1.0"
     When I send a GET request to "/accounts/test1/releases/$0/artifact"
-    Then the response status should be "403"
+    Then the response status should be "303"
+    And the response body should be an "artifact"
+
+  Scenario: License retrieves the artifact for a release of their product (key auth, expired after release, allow access)
+    Given the current account is "test1"
+    And the current account has 1 "product"
+    And the current account has 1 "policy" for an existing "product"
+    And the first "policy" has the following attributes:
+      """
+      {
+        "expirationStrategy": "ALLOW_ACCESS",
+        "authenticationStrategy": "LICENSE"
+      }
+      """
+    And the current account has 1 "license" for an existing "policy"
+    And the first "license" has the following attributes:
+      """
+      { "expiry": "$time.2.months.ago" }
+      """
+    And the current account has 3 "releases" for the first "product"
+    And the first "release" has the following attributes:
+      """
+      { "createdAt": "$time.3.months.ago" }
+      """
+    And the current account has 1 "artifact" for the first "release"
+    And I am a license of account "test1"
+    And I authenticate with my license key
+    And I use API version "1.0"
+    When I send a GET request to "/accounts/test1/releases/$0/artifact"
+    Then the response status should be "303"
+    And the response body should be an "artifact"
 
   Scenario: License retrieves the artifact for a release of their product (key auth, suspended)
     Given the current account is "test1"
@@ -647,7 +755,7 @@ Feature: Release artifact relationship
     And I use an authentication token
     And I use API version "1.0"
     When I send a GET request to "/accounts/test1/releases/$0/artifact"
-    Then the response status should be "403"
+    Then the response status should be "404"
 
   Scenario: User retrieves a release artifact with a license for it (expired after release)
     Given the current account is "test1"

--- a/features/api/v1/releases/show.feature
+++ b/features/api/v1/releases/show.feature
@@ -474,7 +474,7 @@ Feature: Show release
     And I am a license of account "test1"
     And I use an authentication token
     When I send a GET request to "/accounts/test1/releases/$0"
-    Then the response status should be "403"
+    Then the response status should be "404"
 
   Scenario: User retrieves a LICENSED release without a license for it
     Given the current account is "test1"

--- a/features/step_definitions/before_after_steps.rb
+++ b/features/step_definitions/before_after_steps.rb
@@ -62,13 +62,12 @@ After do |scenario|
     Cucumber.wants_to_quit = true
 
     puts scenario.exception
-    puts
 
-    unless ENV.key?('NO_DUMP')
-      req_headers = last_request.env
-        .select { |k, v| k.start_with?('HTTP_') }
-        .transform_keys { |k| k.sub(/^HTTP_/, '').split('_').map(&:capitalize).join('-') } rescue {}
+    if ENV.key?('DEBUG')
+      req_headers = last_request.env.select { |k, v| k.start_with?('HTTP_') }
+                                    .transform_keys { |k| k.sub(/^HTTP_/, '').split('_').map(&:capitalize).join('-') } rescue {}
 
+      puts
       puts "dump:"
       puts
       pp(

--- a/spec/models/release_spec.rb
+++ b/spec/models/release_spec.rb
@@ -4,8 +4,9 @@ require 'rails_helper'
 require 'spec_helper'
 
 describe Release, type: :model do
-  let(:account) { create(:account) }
-  let(:product) { create(:product, account:) }
+  let(:account)  { create(:account) }
+  let(:product)  { create(:product, account:) }
+  let(:accessor) { create(:admin, account:) }
 
   it_behaves_like :environmental
   it_behaves_like :accountable
@@ -301,7 +302,7 @@ describe Release, type: :model do
       subject { create(:release, :published, product:, account:) }
 
       it 'should not upgrade' do
-        expect { subject.upgrade! }.to raise_error Keygen::Error::NotFoundError
+        expect { subject.upgrade!(accessor:) }.to raise_error Keygen::Error::NotFoundError
       end
     end
 
@@ -340,7 +341,7 @@ describe Release, type: :model do
       end
 
       it 'should not upgrade' do
-        expect { subject.upgrade! }.to raise_error Keygen::Error::NotFoundError
+        expect { subject.upgrade!(accessor:) }.to raise_error Keygen::Error::NotFoundError
       end
     end
 
@@ -352,7 +353,7 @@ describe Release, type: :model do
       end
 
       it 'should not upgrade' do
-        expect { subject.upgrade! }.to raise_error Keygen::Error::NotFoundError
+        expect { subject.upgrade!(accessor:) }.to raise_error Keygen::Error::NotFoundError
       end
     end
 
@@ -364,7 +365,7 @@ describe Release, type: :model do
       end
 
       it 'should not upgrade' do
-        expect { subject.upgrade! }.to raise_error Keygen::Error::NotFoundError
+        expect { subject.upgrade!(accessor:) }.to raise_error Keygen::Error::NotFoundError
       end
     end
 
@@ -409,7 +410,7 @@ describe Release, type: :model do
           before { create(:release, :published, version: '3.1.0', product:, account:) }
 
           it 'should upgrade to the latest version' do
-            upgrade = subject.upgrade!
+            upgrade = subject.upgrade!(accessor:)
             assert upgrade
 
             expect(upgrade.version).to eq '3.1.0'
@@ -420,14 +421,14 @@ describe Release, type: :model do
           before { create(:release, :published, version: '3.1.0-rc.1', product:, account:) }
 
           it 'should not upgrade to the rc release' do
-            upgrade = subject.upgrade!
+            upgrade = subject.upgrade!(accessor:)
             assert upgrade
 
             expect(upgrade.version).to eq '3.0.2'
           end
 
           it 'should upgrade with explicit rc channel' do
-            upgrade = subject.upgrade!(channel: 'rc')
+            upgrade = subject.upgrade!(accessor:, channel: 'rc')
             assert upgrade
 
             expect(upgrade.version).to eq '3.1.0-rc.1'
@@ -438,14 +439,14 @@ describe Release, type: :model do
           before { create(:release, :published, version: '3.1.0-beta.1', product:, account:) }
 
           it 'should not upgrade to the beta release' do
-            upgrade = subject.upgrade!
+            upgrade = subject.upgrade!(accessor:)
             assert upgrade
 
             expect(upgrade.version).to eq '3.0.2'
           end
 
           it 'should upgrade with explicit beta channel' do
-            upgrade = subject.upgrade!(channel: 'beta')
+            upgrade = subject.upgrade!(accessor:, channel: 'beta')
             assert upgrade
 
             expect(upgrade.version).to eq '3.1.0-beta.1'
@@ -456,14 +457,14 @@ describe Release, type: :model do
           before { create(:release, :published, version: '3.1.0-alpha.1', product:, account:) }
 
           it 'should not upgrade to the alpha release' do
-            upgrade = subject.upgrade!
+            upgrade = subject.upgrade!(accessor:)
             assert upgrade
 
             expect(upgrade.version).to eq '3.0.2'
           end
 
           it 'should upgrade with explicit alpha channel' do
-            upgrade = subject.upgrade!(channel: 'alpha')
+            upgrade = subject.upgrade!(accessor:, channel: 'alpha')
             assert upgrade
 
             expect(upgrade.version).to eq '3.1.0-alpha.1'
@@ -474,14 +475,14 @@ describe Release, type: :model do
           before { create(:release, :published, version: '3.1.0-dev.1', product:, account:) }
 
           it 'should not upgrade to the dev release' do
-            upgrade = subject.upgrade!
+            upgrade = subject.upgrade!(accessor:)
             assert upgrade
 
             expect(upgrade.version).to eq '3.0.2'
           end
 
           it 'should upgrade with explicit dev channel' do
-            upgrade = subject.upgrade!(channel: 'dev')
+            upgrade = subject.upgrade!(accessor:, channel: 'dev')
             assert upgrade
 
             expect(upgrade.version).to eq '3.1.0-dev.1'
@@ -496,7 +497,7 @@ describe Release, type: :model do
           before { create(:release, :published, version: '3.1.0', product:, account:) }
 
           it 'should upgrade to the latest version' do
-            upgrade = subject.upgrade!
+            upgrade = subject.upgrade!(accessor:)
             assert upgrade
 
             expect(upgrade.version).to eq '3.1.0'
@@ -507,7 +508,7 @@ describe Release, type: :model do
           before { create(:release, :published, version: '3.1.0-rc.1', product:, account:) }
 
           it 'should upgrade to the rc release' do
-            upgrade = subject.upgrade!
+            upgrade = subject.upgrade!(accessor:)
             assert upgrade
 
             expect(upgrade.version).to eq '3.1.0-rc.1'
@@ -518,7 +519,7 @@ describe Release, type: :model do
           before { create(:release, :published, version: '3.1.0-beta.1', product:, account:) }
 
           it 'should not upgrade to the beta release' do
-            upgrade = subject.upgrade!
+            upgrade = subject.upgrade!(accessor:)
             assert upgrade
 
             expect(upgrade.version).to eq '3.0.2'
@@ -529,7 +530,7 @@ describe Release, type: :model do
           before { create(:release, :published, version: '3.1.0-alpha.1', product:, account:) }
 
           it 'should not upgrade to the alpha release' do
-            upgrade = subject.upgrade!
+            upgrade = subject.upgrade!(accessor:)
             assert upgrade
 
             expect(upgrade.version).to eq '3.0.2'
@@ -540,7 +541,7 @@ describe Release, type: :model do
           before { create(:release, :published, version: '3.1.0-dev.1', product:, account:) }
 
           it 'should not upgrade to the dev release' do
-            upgrade = subject.upgrade!
+            upgrade = subject.upgrade!(accessor:)
             assert upgrade
 
             expect(upgrade.version).to eq '3.0.2'
@@ -555,7 +556,7 @@ describe Release, type: :model do
           before { create(:release, :published, version: '3.1.0', product:, account:) }
 
           it 'should upgrade to the latest version' do
-            upgrade = subject.upgrade!
+            upgrade = subject.upgrade!(accessor:)
             assert upgrade
 
             expect(upgrade.version).to eq '3.1.0'
@@ -566,7 +567,7 @@ describe Release, type: :model do
           before { create(:release, :published, version: '3.1.0-rc.1', product:, account:) }
 
           it 'should upgrade to the rc release' do
-            upgrade = subject.upgrade!
+            upgrade = subject.upgrade!(accessor:)
             assert upgrade
 
             expect(upgrade.version).to eq '3.1.0-rc.1'
@@ -577,7 +578,7 @@ describe Release, type: :model do
           before { create(:release, :published, version: '3.1.0-beta.1', product:, account:) }
 
           it 'should upgrade to the beta release' do
-            upgrade = subject.upgrade!
+            upgrade = subject.upgrade!(accessor:)
             assert upgrade
 
             expect(upgrade.version).to eq '3.1.0-beta.1'
@@ -588,7 +589,7 @@ describe Release, type: :model do
           before { create(:release, :published, version: '3.1.0-alpha.1', product:, account:) }
 
           it 'should not upgrade to the alpha release' do
-            upgrade = subject.upgrade!
+            upgrade = subject.upgrade!(accessor:)
             assert upgrade
 
             expect(upgrade.version).to eq '3.0.2'
@@ -599,7 +600,7 @@ describe Release, type: :model do
           before { create(:release, :published, version: '3.1.0-dev.1', product:, account:) }
 
           it 'should not upgrade to the dev release' do
-            upgrade = subject.upgrade!
+            upgrade = subject.upgrade!(accessor:)
             assert upgrade
 
             expect(upgrade.version).to eq '3.0.2'
@@ -614,7 +615,7 @@ describe Release, type: :model do
           before { create(:release, :published, version: '3.0.3', product:, account:) }
 
           it 'should upgrade to the latest version' do
-            upgrade = subject.upgrade!
+            upgrade = subject.upgrade!(accessor:)
             assert upgrade
 
             expect(upgrade.version).to eq '3.0.3'
@@ -625,7 +626,7 @@ describe Release, type: :model do
           before { create(:release, :published, version: '3.1.0-rc.1', product:, account:) }
 
           it 'should upgrade to the rc release' do
-            upgrade = subject.upgrade!
+            upgrade = subject.upgrade!(accessor:)
             assert upgrade
 
             expect(upgrade.version).to eq '3.1.0-rc.1'
@@ -636,7 +637,7 @@ describe Release, type: :model do
           before { create(:release, :published, version: '3.1.0-beta.1', product:, account:) }
 
           it 'should upgrade to the beta release' do
-            upgrade = subject.upgrade!
+            upgrade = subject.upgrade!(accessor:)
             assert upgrade
 
             expect(upgrade.version).to eq '3.1.0-beta.1'
@@ -647,7 +648,7 @@ describe Release, type: :model do
           before { create(:release, :published, version: '3.1.0-alpha.1', product:, account:) }
 
           it 'should upgrade to the alpha release' do
-            upgrade = subject.upgrade!
+            upgrade = subject.upgrade!(accessor:)
             assert upgrade
 
             expect(upgrade.version).to eq '3.1.0-alpha.1'
@@ -661,7 +662,7 @@ describe Release, type: :model do
           end
 
           it 'should not upgrade to the dev release' do
-            upgrade = subject.upgrade!
+            upgrade = subject.upgrade!(accessor:)
             assert upgrade
 
             expect(upgrade.version).to eq '3.0.3'
@@ -676,7 +677,7 @@ describe Release, type: :model do
           before { create(:release, :published, version: '3.1.0', product:, account:) }
 
           it 'should not upgrade to the latest version' do
-            expect { subject.upgrade! }.to raise_error Keygen::Error::NotFoundError
+            expect { subject.upgrade!(accessor:) }.to raise_error Keygen::Error::NotFoundError
           end
         end
 
@@ -684,7 +685,7 @@ describe Release, type: :model do
           before { create(:release, :published, version: '3.1.0-rc.1', product:, account:) }
 
           it 'should not upgrade to the rc release' do
-            expect { subject.upgrade! }.to raise_error Keygen::Error::NotFoundError
+            expect { subject.upgrade!(accessor:) }.to raise_error Keygen::Error::NotFoundError
           end
         end
 
@@ -692,7 +693,7 @@ describe Release, type: :model do
           before { create(:release, :published, version: '3.1.0-beta.1', product:, account:) }
 
           it 'should not upgrade to the beta release' do
-            expect { subject.upgrade! }.to raise_error Keygen::Error::NotFoundError
+            expect { subject.upgrade!(accessor:) }.to raise_error Keygen::Error::NotFoundError
           end
         end
 
@@ -700,7 +701,7 @@ describe Release, type: :model do
           before { create(:release, :published, version: '3.1.0-alpha.1', product:, account:) }
 
           it 'should not upgrade to the alpha release' do
-            expect { subject.upgrade! }.to raise_error Keygen::Error::NotFoundError
+            expect { subject.upgrade!(accessor:) }.to raise_error Keygen::Error::NotFoundError
           end
         end
 
@@ -708,7 +709,7 @@ describe Release, type: :model do
           before { create(:release, :published, version: '3.1.0-dev.1', product:, account:) }
 
           it 'should upgrade to the dev release' do
-            upgrade = subject.upgrade!
+            upgrade = subject.upgrade!(accessor:)
             assert upgrade
 
             expect(upgrade.version).to eq '3.1.0-dev.1'
@@ -720,25 +721,25 @@ describe Release, type: :model do
         subject { create(:release, :published, version: '2.0.0', product:, account:) }
 
         it 'should raise for an invalid constraint' do
-          expect { subject.upgrade!(constraint: 'invalid') }.to raise_error Semverse::InvalidConstraintFormat
+          expect { subject.upgrade!(accessor:, constraint: 'invalid') }.to raise_error Semverse::InvalidConstraintFormat
         end
 
         it 'should upgrade to the latest v2 version' do
-          upgrade = subject.upgrade!(constraint: '2')
+          upgrade = subject.upgrade!(accessor:, constraint: '2')
           assert upgrade
 
           expect(upgrade.version).to eq '2.9.0'
         end
 
         it 'should upgrade to the latest v2.x version' do
-          upgrade = subject.upgrade!(constraint: '2.0')
+          upgrade = subject.upgrade!(accessor:, constraint: '2.0')
           assert upgrade
 
           expect(upgrade.version).to eq '2.9.0'
         end
 
         it 'should upgrade to the latest v2.0.x version' do
-          upgrade = subject.upgrade!(constraint: '2.1.0')
+          upgrade = subject.upgrade!(accessor:, constraint: '2.1.0')
           assert upgrade
 
           expect(upgrade.version).to eq '2.1.9'
@@ -754,7 +755,59 @@ describe Release, type: :model do
       end
 
       it 'should not upgrade to the same version' do
-        expect { subject.upgrade! }.to raise_error Keygen::Error::NotFoundError
+        expect { subject.upgrade!(accessor:) }.to raise_error Keygen::Error::NotFoundError
+      end
+    end
+
+    context 'when :accessor is a user with an expired license' do
+      subject { create(:release, :published, created_at: 1.year.ago, version: '1.0.0', product:, account:) }
+
+      let(:policy) { create(:policy, product:, account:) }
+      let(:user)   { create(:user, account:) }
+
+      before do
+        create(:release, :published, created_at: 9.months.ago, version: '2.0.0', product:, account:)
+        create(:release, :published, created_at: 1.month.ago, version: '3.0.0', product:, account:)
+        create(:release, :published, created_at: 1.week.ago, version: '3.0.1', product:, account:)
+        create(:release, :published, created_at: 4.days.ago, version: '3.0.2', product:, account:)
+        create(:release, :published, created_at: 4.days.ago, version: '3.1.0', product:, account:)
+        create(:release, :yanked, created_at: 4.days.ago, version: '3.1.1', product:, account:)
+        create(:release, :published, created_at: 1.day.ago, version: '3.1.2', product:, account:)
+        create(:release, :draft, created_at: 1.hour.ago, version: '3.1.3', product:, account:)
+
+        create(:license, expiry: 3.days.ago, owner: user, policy:, account:)
+      end
+
+      it 'should scope to accessible releases' do
+        upgrade = subject.upgrade!(accessor: user)
+        assert upgrade
+
+        expect(upgrade.version).to eq '3.1.0'
+      end
+    end
+
+    context 'when :accessor is an expired license' do
+      subject { create(:release, :published, created_at: 1.year.ago, version: '1.0.0', product:, account:) }
+
+      let(:policy)  { create(:policy, product:, account:) }
+      let(:license) { create(:license, expiry: 3.days.ago, policy:, account:) }
+
+      before do
+        create(:release, :published, created_at: 9.months.ago, version: '2.0.0', product:, account:)
+        create(:release, :published, created_at: 1.month.ago, version: '3.0.0', product:, account:)
+        create(:release, :published, created_at: 1.week.ago, version: '3.0.1', product:, account:)
+        create(:release, :published, created_at: 4.days.ago, version: '3.0.2', product:, account:)
+        create(:release, :published, created_at: 4.days.ago, version: '3.1.0', product:, account:)
+        create(:release, :yanked, created_at: 4.days.ago, version: '3.1.1', product:, account:)
+        create(:release, :published, created_at: 1.day.ago, version: '3.1.2', product:, account:)
+        create(:release, :draft, created_at: 1.hour.ago, version: '3.1.3', product:, account:)
+      end
+
+      it 'should scope to accessible releases' do
+        upgrade = subject.upgrade!(accessor: license)
+        assert upgrade
+
+        expect(upgrade.version).to eq '3.1.0'
       end
     end
   end
@@ -795,7 +848,7 @@ describe Release, type: :model do
       end
 
       it 'should not upgrade' do
-        upgrade = subject.upgrade
+        upgrade = subject.upgrade(accessor:)
 
         expect(upgrade).to be_nil
       end
@@ -838,7 +891,7 @@ describe Release, type: :model do
       end
 
       it 'should upgrade' do
-        upgrade = subject.upgrade
+        upgrade = subject.upgrade(accessor:)
         assert upgrade
 
         expect(upgrade.version).to eq '3.0.2'

--- a/spec/services/v1x0/release_upgrade_service_spec.rb
+++ b/spec/services/v1x0/release_upgrade_service_spec.rb
@@ -4,8 +4,9 @@ require 'rails_helper'
 require 'spec_helper'
 
 describe V1x0::ReleaseUpgradeService do
-  let(:account) { create(:account) }
-  let(:product) { create(:product, account: account) }
+  let(:account)  { create(:account) }
+  let(:product)  { create(:product, account: account) }
+  let(:accessor) { create(:admin, account:) }
 
   context 'when invalid parameters are supplied to the service' do
     it 'should raise an error when account is nil' do
@@ -16,6 +17,7 @@ describe V1x0::ReleaseUpgradeService do
           platform: 'win32',
           filetype: 'exe',
           version: '1.0.0',
+          accessor:,
         )
       }
 
@@ -30,6 +32,7 @@ describe V1x0::ReleaseUpgradeService do
           platform: 'win32',
           filetype: 'exe',
           version: '1.0.0',
+          accessor:,
         )
       }
 
@@ -44,6 +47,7 @@ describe V1x0::ReleaseUpgradeService do
           platform: 'win32',
           filetype: 'exe',
           version: '1.0.0',
+          accessor:,
         )
       }
 
@@ -58,6 +62,7 @@ describe V1x0::ReleaseUpgradeService do
           platform: nil,
           filetype: 'exe',
           version: '1.0.0',
+          accessor:,
         )
       }
 
@@ -72,6 +77,7 @@ describe V1x0::ReleaseUpgradeService do
           platform: 'win32',
           filetype: nil,
           version: '1.0.0',
+          accessor:,
         )
       }
 
@@ -86,6 +92,7 @@ describe V1x0::ReleaseUpgradeService do
           platform: 'win32',
           filetype: 'exe',
           version: nil,
+          accessor:,
         )
       }
 
@@ -101,6 +108,7 @@ describe V1x0::ReleaseUpgradeService do
           filetype: 'exe',
           version: '1.0.0',
           channel: nil,
+          accessor:,
         )
       }
 
@@ -115,7 +123,8 @@ describe V1x0::ReleaseUpgradeService do
           platform: 'win32',
           filetype: 'exe',
           version: '1.0.0',
-          constraint: 'v8.0.2.1'
+          constraint: 'v8.0.2.1',
+          accessor:,
         )
       }
 
@@ -131,6 +140,7 @@ describe V1x0::ReleaseUpgradeService do
         platform: 'win32',
         filetype: 'exe',
         version: '1.0.0',
+        accessor:,
       )
 
       expect(upgrade.current_version).to eq '1.0.0'
@@ -148,6 +158,7 @@ describe V1x0::ReleaseUpgradeService do
         platform: 'macos',
         filetype: 'dmg',
         version: '0.1.0',
+        accessor:,
       )
 
       expect(upgrade.current_version).to eq '0.1.0'
@@ -201,6 +212,7 @@ describe V1x0::ReleaseUpgradeService do
         platform: platform,
         filetype: filetype,
         version: '1.0.0',
+        accessor:,
       )
 
       expect(upgrade.current_version).to eq '1.0.0'
@@ -255,6 +267,7 @@ describe V1x0::ReleaseUpgradeService do
         filetype: 'dmg',
         version: '1.0.0',
         channel: channel,
+        accessor:,
       )
 
       expect(upgrade.current_version).to eq current_release.version
@@ -270,6 +283,7 @@ describe V1x0::ReleaseUpgradeService do
         platform: platform,
         filetype: filetype,
         version: '0.1.0',
+        accessor:,
       )
 
       expect(upgrade.current_version).to eq '0.1.0'
@@ -285,6 +299,7 @@ describe V1x0::ReleaseUpgradeService do
         platform: platform,
         filetype: filetype,
         version: '1.0.1',
+        accessor:,
       )
 
       expect(upgrade.current_version).to eq '1.0.1'
@@ -344,6 +359,7 @@ describe V1x0::ReleaseUpgradeService do
         filetype: filetype,
         version: '1.0.0',
         channel: 'stable',
+        accessor:,
       )
 
       expect(upgrade.current_version).to eq '1.0.0'
@@ -360,6 +376,7 @@ describe V1x0::ReleaseUpgradeService do
         filetype: filetype,
         version: '1.0.0',
         channel: 'rc',
+        accessor:,
       )
 
       expect(upgrade.current_version).to eq '1.0.0'
@@ -376,6 +393,7 @@ describe V1x0::ReleaseUpgradeService do
         filetype: filetype,
         version: '1.0.0',
         channel: 'beta',
+        accessor:,
       )
 
       expect(upgrade.current_version).to eq '1.0.0'
@@ -392,6 +410,7 @@ describe V1x0::ReleaseUpgradeService do
         filetype: filetype,
         version: '1.0.0',
         channel: 'alpha',
+        accessor:,
       )
 
       expect(upgrade.current_version).to eq '1.0.0'
@@ -408,6 +427,7 @@ describe V1x0::ReleaseUpgradeService do
         filetype: filetype,
         version: '1.0.0',
         channel: 'dev',
+        accessor:,
       )
 
       expect(upgrade.current_version).to eq '1.0.0'
@@ -467,6 +487,7 @@ describe V1x0::ReleaseUpgradeService do
         filetype: filetype,
         version: '2.1.9',
         channel: stable_channel,
+        accessor:,
       )
 
       expect(upgrade.current_version).to eq '2.1.9'
@@ -483,6 +504,7 @@ describe V1x0::ReleaseUpgradeService do
         filetype: filetype,
         version: '2.1.9',
         channel: rc_channel,
+        accessor:,
       )
 
       expect(upgrade.current_version).to eq '2.1.9'
@@ -499,6 +521,7 @@ describe V1x0::ReleaseUpgradeService do
         filetype: filetype,
         version: '2.1.9',
         channel: beta_channel,
+        accessor:,
       )
 
       expect(upgrade.current_version).to eq '2.1.9'
@@ -515,6 +538,7 @@ describe V1x0::ReleaseUpgradeService do
         filetype: filetype,
         version: '2.1.9',
         channel: alpha_channel,
+        accessor:,
       )
 
       expect(upgrade.current_version).to eq '2.1.9'
@@ -531,6 +555,7 @@ describe V1x0::ReleaseUpgradeService do
         filetype: filetype,
         version: '2.1.9',
         channel: dev_channel,
+        accessor:,
       )
 
       expect(upgrade.current_version).to eq '2.1.9'
@@ -590,6 +615,7 @@ describe V1x0::ReleaseUpgradeService do
         filetype: filetype,
         version: '2.13.37',
         channel: stable_channel,
+        accessor:,
       )
 
       expect(upgrade.current_version).to eq '2.13.37'
@@ -606,6 +632,7 @@ describe V1x0::ReleaseUpgradeService do
         filetype: filetype,
         version: '2.13.37',
         channel: rc_channel,
+        accessor:,
       )
 
       expect(upgrade.current_version).to eq '2.13.37'
@@ -622,6 +649,7 @@ describe V1x0::ReleaseUpgradeService do
         filetype: filetype,
         version: '2.13.37',
         channel: beta_channel,
+        accessor:,
       )
 
       expect(upgrade.current_version).to eq '2.13.37'
@@ -638,6 +666,7 @@ describe V1x0::ReleaseUpgradeService do
         filetype: filetype,
         version: '2.13.37',
         channel: alpha_channel,
+        accessor:,
       )
 
       expect(upgrade.current_version).to eq '2.13.37'
@@ -654,6 +683,7 @@ describe V1x0::ReleaseUpgradeService do
         filetype: filetype,
         version: '2.13.37',
         channel: dev_channel,
+        accessor:,
       )
 
       expect(upgrade.current_version).to eq '2.13.37'
@@ -713,6 +743,7 @@ describe V1x0::ReleaseUpgradeService do
         filetype: filetype.id,
         version: '1.0.0',
         channel: stable_channel.id,
+        accessor:,
       )
 
       expect(upgrade.current_version).to eq '1.0.0'
@@ -729,6 +760,7 @@ describe V1x0::ReleaseUpgradeService do
         filetype: filetype.id,
         version: '1.0.0',
         channel: rc_channel.id,
+        accessor:,
       )
 
       expect(upgrade.current_version).to eq '1.0.0'
@@ -745,6 +777,7 @@ describe V1x0::ReleaseUpgradeService do
         filetype: filetype.id,
         version: '1.0.0',
         channel: beta_channel.id,
+        accessor:,
       )
 
       expect(upgrade.current_version).to eq '1.0.0'
@@ -761,6 +794,7 @@ describe V1x0::ReleaseUpgradeService do
         filetype: filetype.id,
         version: '1.0.0',
         channel: alpha_channel.id,
+        accessor:,
       )
 
       expect(upgrade.current_version).to eq '1.0.0'
@@ -777,6 +811,7 @@ describe V1x0::ReleaseUpgradeService do
         filetype: filetype.id,
         version: '1.0.0',
         channel: dev_channel.id,
+        accessor:,
       )
 
       expect(upgrade.current_version).to eq '1.0.0'
@@ -830,6 +865,7 @@ describe V1x0::ReleaseUpgradeService do
         platform: 'linux',
         filetype: 'tar.gz',
         version: '1.0.0',
+        accessor:,
       )
 
       expect(upgrade.current_version).to eq '1.0.0'
@@ -883,6 +919,7 @@ describe V1x0::ReleaseUpgradeService do
         platform: 'win32',
         filetype: 'exe',
         version: '1.0.0',
+        accessor:,
       )
 
       expect(upgrade.current_version).to eq '1.0.0'
@@ -937,6 +974,7 @@ describe V1x0::ReleaseUpgradeService do
         filetype: 'dmg',
         version: '1.0.0',
         channel: channel,
+        accessor:,
       )
 
       expect(upgrade.current_version).to eq '1.0.0'
@@ -954,6 +992,7 @@ describe V1x0::ReleaseUpgradeService do
         filetype: 'dmg',
         version: '1.0.0+build.1624288707',
         channel: channel,
+        accessor:,
       )
 
       expect(upgrade.current_version).to eq current_release.version
@@ -1011,6 +1050,7 @@ describe V1x0::ReleaseUpgradeService do
         filetype: 'tar.gz',
         version: '1.0.0',
         channel: channel,
+        accessor:,
       )
 
       expect(upgrade.current_version).to eq current_release.version
@@ -1066,6 +1106,7 @@ describe V1x0::ReleaseUpgradeService do
         filetype: 'exe',
         version: '1.0.0',
         channel: channel,
+        accessor:,
       )
 
       expect(upgrade.current_version).to eq current_release.version
@@ -1153,6 +1194,7 @@ describe V1x0::ReleaseUpgradeService do
         version: '1.0.0',
         channel: channel,
         constraint: '1.0.0',
+        accessor:,
       )
 
       expect(upgrade.current_version).to eq current_release.version
@@ -1170,6 +1212,7 @@ describe V1x0::ReleaseUpgradeService do
         version: '1.0.0',
         channel: channel,
         constraint: '1.0',
+        accessor:,
       )
 
       expect(upgrade.current_version).to eq current_release.version
@@ -1187,6 +1230,7 @@ describe V1x0::ReleaseUpgradeService do
         version: '1.0.0',
         channel: channel,
         constraint: '2.0',
+        accessor:,
       )
 
       expect(upgrade.current_version).to eq current_release.version


### PR DESCRIPTION
In cases where a license is expired, or a user has an expired license, releases and artifacts would allow inaccessible releases and artifacts in the underlying scope, which would later fail with an 403 authorization response. Although this was correct behavior i.r.t. authz, this was problematic i.r.t. UX, because it severely complicated and even forbade listing a license's or user's _available_ releases and artifacts, and also completely broke upgrades after expiration, since both cases would return inaccessible resources.

This PR resolves those problems by making the scopes aware of each license's expiration and applies it during scoping, according to each license's expiration strategy.