### PR TITLE
Remove sidekiq-unique-jobs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,7 +59,6 @@ gem 'rails-pattern_matching'
 
 # Background jobs
 gem 'sidekiq', '~> 7.2.4'
-gem 'sidekiq-unique-jobs', '~> 8.0.10'
 gem 'sidekiq-cron', '~> 1.12.0'
 gem 'sidekiq-cronitor', '~> 3.6.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -464,10 +464,6 @@ GEM
     sidekiq-cronitor (3.6.0)
       cronitor (~> 5.0)
       sidekiq (< 8)
-    sidekiq-unique-jobs (8.0.10)
-      concurrent-ruby (~> 1.0, >= 1.0.5)
-      sidekiq (>= 7.0.0, < 8.0.0)
-      thor (>= 1.0, < 3.0)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -571,7 +567,6 @@ DEPENDENCIES
   sidekiq (~> 7.2.4)
   sidekiq-cron (~> 1.12.0)
   sidekiq-cronitor (~> 3.6.0)
-  sidekiq-unique-jobs (~> 8.0.10)
   sprockets (~> 3.0)
   stackprof
   stripe (~> 5.43)

--- a/app/workers/create_webhook_events_worker.rb
+++ b/app/workers/create_webhook_events_worker.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 class CreateWebhookEventsWorker < BaseWorker
-  sidekiq_options queue: :webhooks,
-                  lock: :until_executed
+  sidekiq_options queue: :webhooks
 
   def perform(event, account_id, payload, environment_id = nil)
     account = Rails.cache.fetch(Account.cache_key(account_id), skip_nil: true, expires_in: 15.minutes) do

--- a/app/workers/cull_dead_machines_worker.rb
+++ b/app/workers/cull_dead_machines_worker.rb
@@ -2,7 +2,6 @@
 
 class CullDeadMachinesWorker < BaseWorker
   sidekiq_options queue: :cron,
-                  lock: :until_executed, lock_ttl: 10.minutes, on_conflict: :raise,
                   cronitor_disabled: false
 
   def perform

--- a/app/workers/cull_dead_processes_worker.rb
+++ b/app/workers/cull_dead_processes_worker.rb
@@ -2,7 +2,6 @@
 
 class CullDeadProcessesWorker < BaseWorker
   sidekiq_options queue: :cron,
-                  lock: :until_executed, lock_ttl: 10.minutes, on_conflict: :raise,
                   cronitor_disabled: false
 
   def perform

--- a/app/workers/event_log_worker.rb
+++ b/app/workers/event_log_worker.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 class EventLogWorker < BaseWorker
-  sidekiq_options lock: :until_executed,
-                  queue: :logs
+  sidekiq_options queue: :logs
 
   def perform(
     event,

--- a/app/workers/event_notification_worker.rb
+++ b/app/workers/event_notification_worker.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 class EventNotificationWorker < BaseWorker
-  sidekiq_options lock: :until_executed,
-                  queue: :logs
+  sidekiq_options queue: :logs
 
   def perform(
     event,

--- a/app/workers/license_expirations_worker.rb
+++ b/app/workers/license_expirations_worker.rb
@@ -2,7 +2,6 @@
 
 class LicenseExpirationsWorker < BaseWorker
   sidekiq_options queue: :critical,
-                  lock: :until_executed, lock_ttl: 30.minutes, on_conflict: :raise,
                   cronitor_disabled: false
 
   def perform

--- a/app/workers/license_overdue_check_ins_worker.rb
+++ b/app/workers/license_overdue_check_ins_worker.rb
@@ -2,7 +2,6 @@
 
 class LicenseOverdueCheckInsWorker < BaseWorker
   sidekiq_options queue: :critical,
-                  lock: :until_executed, lock_ttl: 30.minutes, on_conflict: :raise,
                   cronitor_disabled: false
 
   def perform

--- a/app/workers/machine_heartbeat_worker.rb
+++ b/app/workers/machine_heartbeat_worker.rb
@@ -2,12 +2,7 @@
 
 class MachineHeartbeatWorker < BaseWorker
   sidekiq_options queue: :critical,
-    retry: 1_000_000, # retry forever
-    lock: :until_executing,
-    on_conflict: {
-      client: :replace,
-      server: :raise,
-    }
+                  retry: 1_000_000 # retry forever
 
   sidekiq_retry_in { |count|
     if count in 0..60

--- a/app/workers/process_heartbeat_worker.rb
+++ b/app/workers/process_heartbeat_worker.rb
@@ -2,12 +2,7 @@
 
 class ProcessHeartbeatWorker < BaseWorker
   sidekiq_options queue: :critical,
-    retry: 1_000_000, # retry forever
-    lock: :until_executing,
-    on_conflict: {
-      client: :replace,
-      server: :raise,
-    }
+                  retry: 1_000_000 # retry forever
 
   sidekiq_retry_in { |count|
     if count in 0..60

--- a/app/workers/prune_event_logs_worker.rb
+++ b/app/workers/prune_event_logs_worker.rb
@@ -31,7 +31,6 @@ class PruneEventLogsWorker < BaseWorker
   ].freeze
 
   sidekiq_options queue: :cron,
-                  lock: :until_executed,
                   cronitor_disabled: false
 
   def perform

--- a/app/workers/prune_expired_tokens_worker.rb
+++ b/app/workers/prune_expired_tokens_worker.rb
@@ -3,7 +3,6 @@ class PruneExpiredTokensWorker < BaseWorker
   BATCH_WAIT = ENV.fetch('KEYGEN_PRUNE_BATCH_WAIT') { 1 }.to_f
 
   sidekiq_options queue: :cron,
-                  lock: :until_executed,
                   cronitor_disabled: false
 
   def perform

--- a/app/workers/prune_metrics_worker.rb
+++ b/app/workers/prune_metrics_worker.rb
@@ -5,7 +5,6 @@ class PruneMetricsWorker < BaseWorker
   BATCH_WAIT   = ENV.fetch('KEYGEN_PRUNE_BATCH_WAIT')          { 1 }.to_f
 
   sidekiq_options queue: :cron,
-                  lock: :until_executed,
                   cronitor_disabled: false
 
   def perform

--- a/app/workers/prune_release_download_links_worker.rb
+++ b/app/workers/prune_release_download_links_worker.rb
@@ -3,7 +3,6 @@ class PruneReleaseDownloadLinksWorker < BaseWorker
   BATCH_WAIT = ENV.fetch('KEYGEN_PRUNE_BATCH_WAIT') { 1 }.to_f
 
   sidekiq_options queue: :cron,
-                  lock: :until_executed,
                   cronitor_disabled: false
 
   def perform

--- a/app/workers/prune_release_upgrade_links_worker.rb
+++ b/app/workers/prune_release_upgrade_links_worker.rb
@@ -3,7 +3,6 @@ class PruneReleaseUpgradeLinksWorker < BaseWorker
   BATCH_WAIT = ENV.fetch('KEYGEN_PRUNE_BATCH_WAIT') { 1 }.to_f
 
   sidekiq_options queue: :cron,
-                  lock: :until_executed,
                   cronitor_disabled: false
 
   def perform

--- a/app/workers/prune_request_logs_worker.rb
+++ b/app/workers/prune_request_logs_worker.rb
@@ -5,7 +5,6 @@ class PruneRequestLogsWorker < BaseWorker
   BATCH_WAIT   = ENV.fetch('KEYGEN_PRUNE_BATCH_WAIT')           { 1 }.to_f
 
   sidekiq_options queue: :cron,
-                  lock: :until_executed,
                   cronitor_disabled: false
 
   def perform

--- a/app/workers/prune_webhook_events_worker.rb
+++ b/app/workers/prune_webhook_events_worker.rb
@@ -5,7 +5,6 @@ class PruneWebhookEventsWorker < BaseWorker
   SLEEP_DURATION = ENV.fetch('PRUNE_SLEEP_DURATION')              { 1 }.to_f
 
   sidekiq_options queue: :cron,
-                  lock: :until_executed,
                   cronitor_disabled: false
 
   def perform

--- a/app/workers/request_limits_report_worker.rb
+++ b/app/workers/request_limits_report_worker.rb
@@ -2,7 +2,6 @@
 
 class RequestLimitsReportWorker < BaseWorker
   sidekiq_options queue: :cron,
-                  lock: :until_executed,
                   cronitor_disabled: false
 
   def perform

--- a/app/workers/touch_license_worker.rb
+++ b/app/workers/touch_license_worker.rb
@@ -1,12 +1,7 @@
 # frozen_string_literal: true
 
 class TouchLicenseWorker < BaseWorker
-  sidekiq_options retry: false,
-    lock: :until_executing,
-    on_conflict: {
-      client: :replace,
-      server: :raise,
-    }
+  sidekiq_options retry: false
 
   def perform(license_id, touches)
     license = License.find(license_id)

--- a/app/workers/vacuum_analyze_event_logs_worker.rb
+++ b/app/workers/vacuum_analyze_event_logs_worker.rb
@@ -1,6 +1,5 @@
 class VacuumAnalyzeEventLogsWorker < BaseWorker
   sidekiq_options queue: :cron,
-                  lock: :until_executed,
                   cronitor_disabled: false
 
   def perform

--- a/app/workers/vacuum_analyze_metrics_worker.rb
+++ b/app/workers/vacuum_analyze_metrics_worker.rb
@@ -1,6 +1,5 @@
 class VacuumAnalyzeMetricsWorker < BaseWorker
   sidekiq_options queue: :cron,
-                  lock: :until_executed,
                   cronitor_disabled: false
 
   def perform

--- a/app/workers/vacuum_analyze_request_logs_worker.rb
+++ b/app/workers/vacuum_analyze_request_logs_worker.rb
@@ -1,6 +1,5 @@
 class VacuumAnalyzeRequestLogsWorker < BaseWorker
   sidekiq_options queue: :cron,
-                  lock: :until_executed,
                   cronitor_disabled: false
 
   def perform

--- a/app/workers/vacuum_analyze_webhook_events_worker.rb
+++ b/app/workers/vacuum_analyze_webhook_events_worker.rb
@@ -1,6 +1,5 @@
 class VacuumAnalyzeWebhookEventsWorker < BaseWorker
   sidekiq_options queue: :cron,
-                  lock: :until_executed,
                   cronitor_disabled: false
 
   def perform

--- a/app/workers/webhook_worker.rb
+++ b/app/workers/webhook_worker.rb
@@ -10,7 +10,6 @@ class WebhookWorker < BaseWorker
 
   sidekiq_options queue: :webhooks,
                   retry: 15,
-                  lock: :until_executed,
                   dead: false
 
   sidekiq_retry_in do |count|

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'sidekiq/web'
-require 'sidekiq_unique_jobs/web'
 
 Rails.application.routes.draw do
   domain_constraints = {

--- a/spec/workers/cull_dead_machines_worker_spec.rb
+++ b/spec/workers/cull_dead_machines_worker_spec.rb
@@ -7,14 +7,8 @@ describe CullDeadMachinesWorker do
   let(:worker)  { CullDeadMachinesWorker }
   let(:account) { create(:account) }
 
-  # See: https://github.com/mhenrixon/sidekiq-unique-jobs#testing
-  before do
-    Sidekiq::Testing.inline!
-  end
-
-  after do
-    Sidekiq::Worker.clear_all
-  end
+  before { Sidekiq::Testing.inline! }
+  after  { Sidekiq::Testing.fake! }
 
   context 'without a monitor' do
     let(:heartbeat_jid) { nil }

--- a/spec/workers/cull_dead_processes_worker_spec.rb
+++ b/spec/workers/cull_dead_processes_worker_spec.rb
@@ -7,14 +7,8 @@ describe CullDeadProcessesWorker do
   let(:worker)  { CullDeadProcessesWorker }
   let(:account) { create(:account) }
 
-  # See: https://github.com/mhenrixon/sidekiq-unique-jobs#testing
-  before do
-    Sidekiq::Testing.inline!
-  end
-
-  after do
-    Sidekiq::Worker.clear_all
-  end
+  before { Sidekiq::Testing.inline! }
+  after  { Sidekiq::Testing.fake! }
 
   context 'without a monitor' do
     let(:heartbeat_jid) { nil }

--- a/spec/workers/license_expirations_worker_spec.rb
+++ b/spec/workers/license_expirations_worker_spec.rb
@@ -7,14 +7,6 @@ describe LicenseExpirationsWorker do
   let(:worker) { LicenseExpirationsWorker }
   let(:account) { create(:account) }
 
-  it 'should enqueue and run the worker' do
-    worker.perform_async
-    expect(worker.jobs.size).to eq 1
-
-    worker.drain
-    expect(worker.jobs.size).to eq 0
-  end
-
   context 'when there is a license that has recently expired' do
     let(:event) { 'license.expired' }
 

--- a/spec/workers/license_overdue_check_ins_worker_spec.rb
+++ b/spec/workers/license_overdue_check_ins_worker_spec.rb
@@ -7,14 +7,6 @@ describe LicenseOverdueCheckInsWorker do
   let(:worker) { LicenseOverdueCheckInsWorker }
   let(:account) { create(:account) }
 
-  it 'should enqueue and run the worker' do
-    worker.perform_async
-    expect(worker.jobs.size).to eq 1
-
-    worker.drain
-    expect(worker.jobs.size).to eq 0
-  end
-
   context 'when there is a license that has recently become overdue' do
     let(:event) { 'license.check-in-overdue' }
 

--- a/spec/workers/machine_heartbeat_worker_spec.rb
+++ b/spec/workers/machine_heartbeat_worker_spec.rb
@@ -7,37 +7,6 @@ describe MachineHeartbeatWorker do
   let(:worker) { MachineHeartbeatWorker }
   let(:account) { create(:account) }
 
-  # See: https://github.com/mhenrixon/sidekiq-unique-jobs#testing
-  before do
-    SidekiqUniqueJobs.configure { _1.enabled = true }
-  end
-
-  after do
-    SidekiqUniqueJobs.configure { _1.enabled = false }
-  end
-
-  it 'should enqueue and run the worker' do
-    machine = create :machine, last_heartbeat_at: nil, account: account
-
-    worker.perform_async machine.id
-    expect(worker.jobs.size).to eq 1
-
-    worker.drain
-    expect(worker.jobs.size).to eq 0
-  end
-
-  it 'should replace the worker on conflict' do
-    machine = create :machine, last_heartbeat_at: nil, account: account
-
-    worker.perform_async machine.id
-    worker.perform_async machine.id
-    worker.perform_async machine.id
-    expect(worker.jobs.size).to eq 1
-
-    worker.drain
-    expect(worker.jobs.size).to eq 0
-  end
-
   context 'when there is a machine that does not require heartbeats' do
     let(:machine) { create(:machine, last_heartbeat_at: heartbeat_at, account: account) }
     let(:event) { 'machine.heartbeat.pong' }

--- a/spec/workers/process_heartbeat_worker_spec.rb
+++ b/spec/workers/process_heartbeat_worker_spec.rb
@@ -7,37 +7,6 @@ describe ProcessHeartbeatWorker do
   let(:worker) { ProcessHeartbeatWorker }
   let(:account) { create(:account) }
 
-  # See: https://github.com/mhenrixon/sidekiq-unique-jobs#testing
-  before do
-    SidekiqUniqueJobs.configure { _1.enabled = true }
-  end
-
-  after do
-    SidekiqUniqueJobs.configure { _1.enabled = false }
-  end
-
-  it 'should enqueue and run the worker' do
-    process = create(:machine_process, account:)
-
-    worker.perform_async process.id
-    expect(worker.jobs.size).to eq 1
-
-    worker.drain
-    expect(worker.jobs.size).to eq 0
-  end
-
-  it 'should replace the worker on conflict' do
-    process = create(:machine_process, account:)
-
-    worker.perform_async process.id
-    worker.perform_async process.id
-    worker.perform_async process.id
-    expect(worker.jobs.size).to eq 1
-
-    worker.drain
-    expect(worker.jobs.size).to eq 0
-  end
-
   context 'when heartbeat is alive' do
     let(:process) { create(:machine_process, last_heartbeat_at:, account:) }
     let(:event) { 'process.heartbeat.pong' }

--- a/spec/workers/prune_event_logs_worker_spec.rb
+++ b/spec/workers/prune_event_logs_worker_spec.rb
@@ -7,14 +7,8 @@ describe PruneEventLogsWorker do
   let(:worker)  { PruneEventLogsWorker }
   let(:account) { create(:account) }
 
-  # See: https://github.com/mhenrixon/sidekiq-unique-jobs#testing
-  before do
-    Sidekiq::Testing.inline!
-  end
-
-  after do
-    Sidekiq::Worker.clear_all
-  end
+  before { Sidekiq::Testing.inline! }
+  after  { Sidekiq::Testing.fake! }
 
   it 'should prune backlog of high-volume event logs' do
     license = create(:license, account:)

--- a/spec/workers/prune_request_logs_worker_spec.rb
+++ b/spec/workers/prune_request_logs_worker_spec.rb
@@ -7,14 +7,8 @@ describe PruneRequestLogsWorker do
   let(:worker)  { PruneRequestLogsWorker }
   let(:account) { create(:account) }
 
-  # See: https://github.com/mhenrixon/sidekiq-unique-jobs#testing
-  before do
-    Sidekiq::Testing.inline!
-  end
-
-  after do
-    Sidekiq::Worker.clear_all
-  end
+  before { Sidekiq::Testing.inline! }
+  after  { Sidekiq::Testing.fake! }
 
   it 'should prune backlog of request logs' do
     create_list(:request_log, 50, account:, created_at: (worker::BACKLOG_DAYS + 1).days.ago)

--- a/spec/workers/prune_webhook_events_worker_spec.rb
+++ b/spec/workers/prune_webhook_events_worker_spec.rb
@@ -7,14 +7,8 @@ describe PruneWebhookEventsWorker do
   let(:worker)  { PruneWebhookEventsWorker }
   let(:account) { create(:account) }
 
-  # See: https://github.com/mhenrixon/sidekiq-unique-jobs#testing
-  before do
-    Sidekiq::Testing.inline!
-  end
-
-  after do
-    Sidekiq::Worker.clear_all
-  end
+  before { Sidekiq::Testing.inline! }
+  after  { Sidekiq::Testing.fake! }
 
   it 'should prune backlog of webhook events' do
     create_list(:webhook_event, 50, account:, created_at: (worker::BACKLOG_DAYS + 1).days.ago)


### PR DESCRIPTION
Related to #798. This gem has been causing outages lately as we scale. Right now, I'm still seeing slow Lua scripts when deleting items from large sets, e.g. when a spike of requests come in and jobs are queued up for each request, or when a lot of scheduled jobs are pushed to the queue. I tried to fix this upstream, but there's more issues and I don't have time to debug.

Follow up to fc1b739dab603c45d6fe00fe99e77138a69c30d6 (i.e. the fix for [the big outage](https://keygen.sh/blog/that-one-time-keygen-went-down-for-5-hours-twice/)), which removed all mission-critical use of the gem. If and when we need job uniqueness, we can reach for Sidekiq Ent, which has timing guarantees.