### PR TITLE
Add configurable statement_timeout to prune and vacuum workers

### DIFF
--- a/app/workers/prune_metrics_worker.rb
+++ b/app/workers/prune_metrics_worker.rb
@@ -1,8 +1,9 @@
 class PruneMetricsWorker < BaseWorker
-  BACKLOG_DAYS = ENV.fetch('KEYGEN_PRUNE_METRIC_BACKLOG_DAYS') { 30 }.to_i
-  TARGET_DAYS  = ENV.fetch('KEYGEN_PRUNE_METRIC_TARGET_DAYS')  { 1 }.to_i
-  BATCH_SIZE   = ENV.fetch('KEYGEN_PRUNE_BATCH_SIZE')          { 1_000 }.to_i
-  BATCH_WAIT   = ENV.fetch('KEYGEN_PRUNE_BATCH_WAIT')          { 1 }.to_f
+  BACKLOG_DAYS      = ENV.fetch('KEYGEN_PRUNE_METRIC_BACKLOG_DAYS') { 30 }.to_i
+  TARGET_DAYS       = ENV.fetch('KEYGEN_PRUNE_METRIC_TARGET_DAYS')  { 1 }.to_i
+  STATEMENT_TIMEOUT = ENV.fetch('KEYGEN_PRUNE_STATEMENT_TIMEOUT')   { '1min' }
+  BATCH_SIZE        = ENV.fetch('KEYGEN_PRUNE_BATCH_SIZE')          { 1_000 }.to_i
+  BATCH_WAIT        = ENV.fetch('KEYGEN_PRUNE_BATCH_WAIT')          { 1 }.to_f
 
   sidekiq_options queue: :cron,
                   cronitor_disabled: false
@@ -42,8 +43,9 @@ class PruneMetricsWorker < BaseWorker
                                  .where('created_at < ?', end_date)
 
         batch += 1
-        count = metrics.limit(BATCH_SIZE)
-                       .delete_all
+        count = metrics.statement_timeout(STATEMENT_TIMEOUT) do
+          metrics.limit(BATCH_SIZE).delete_all
+        end
 
         Keygen.logger.info "[workers.prune-metrics] Pruned #{count} rows: account_id=#{account_id} batch=#{batch}"
 

--- a/app/workers/prune_release_download_links_worker.rb
+++ b/app/workers/prune_release_download_links_worker.rb
@@ -1,6 +1,7 @@
 class PruneReleaseDownloadLinksWorker < BaseWorker
-  BATCH_SIZE = ENV.fetch('KEYGEN_PRUNE_BATCH_SIZE') { 1_000 }.to_i
-  BATCH_WAIT = ENV.fetch('KEYGEN_PRUNE_BATCH_WAIT') { 1 }.to_f
+  STATEMENT_TIMEOUT = ENV.fetch('KEYGEN_PRUNE_STATEMENT_TIMEOUT') { '1min' }
+  BATCH_SIZE        = ENV.fetch('KEYGEN_PRUNE_BATCH_SIZE')        { 1_000 }.to_i
+  BATCH_WAIT        = ENV.fetch('KEYGEN_PRUNE_BATCH_WAIT')        { 1 }.to_f
 
   sidekiq_options queue: :cron,
                   cronitor_disabled: false
@@ -24,8 +25,9 @@ class PruneReleaseDownloadLinksWorker < BaseWorker
                            .where('created_at < ?', 90.days.ago.beginning_of_day)
 
         batch += 1
-        count = downloads.limit(BATCH_SIZE)
-                         .delete_all
+        count = downloads.statement_timeout(STATEMENT_TIMEOUT) do
+          downloads.limit(BATCH_SIZE).delete_all
+        end
 
         Keygen.logger.info "[workers.prune-release-download-links] Pruned #{count} rows: account_id=#{account_id} batch=#{batch}"
 

--- a/app/workers/vacuum_analyze_event_logs_worker.rb
+++ b/app/workers/vacuum_analyze_event_logs_worker.rb
@@ -1,10 +1,12 @@
 class VacuumAnalyzeEventLogsWorker < BaseWorker
+  STATEMENT_TIMEOUT = ENV.fetch('KEYGEN_VACUUM_STATEMENT_TIMEOUT') { '5min' }
+
   sidekiq_options queue: :cron,
                   cronitor_disabled: false
 
   def perform
-    conn = ActiveRecord::Base.connection
-
-    conn.execute 'VACUUM ANALYZE event_logs'
+    EventLog.statement_timeout(STATEMENT_TIMEOUT) do |conn|
+      conn.execute 'VACUUM ANALYZE event_logs'
+    end
   end
 end

--- a/app/workers/vacuum_analyze_metrics_worker.rb
+++ b/app/workers/vacuum_analyze_metrics_worker.rb
@@ -1,10 +1,12 @@
 class VacuumAnalyzeMetricsWorker < BaseWorker
+  STATEMENT_TIMEOUT = ENV.fetch('KEYGEN_VACUUM_STATEMENT_TIMEOUT') { '5min' }
+
   sidekiq_options queue: :cron,
                   cronitor_disabled: false
 
   def perform
-    conn = ActiveRecord::Base.connection
-
-    conn.execute 'VACUUM ANALYZE metrics'
+    Metric.statement_timeout(STATEMENT_TIMEOUT) do |conn|
+      conn.execute 'VACUUM ANALYZE metrics'
+    end
   end
 end

--- a/app/workers/vacuum_analyze_request_logs_worker.rb
+++ b/app/workers/vacuum_analyze_request_logs_worker.rb
@@ -1,10 +1,12 @@
 class VacuumAnalyzeRequestLogsWorker < BaseWorker
+  STATEMENT_TIMEOUT = ENV.fetch('KEYGEN_VACUUM_STATEMENT_TIMEOUT') { '5min' }
+
   sidekiq_options queue: :cron,
                   cronitor_disabled: false
 
   def perform
-    conn = ActiveRecord::Base.connection
-
-    conn.execute 'VACUUM ANALYZE request_logs'
+    RequestLog.statement_timeout(STATEMENT_TIMEOUT) do |conn|
+      conn.execute 'VACUUM ANALYZE request_logs'
+    end
   end
 end

--- a/app/workers/vacuum_analyze_webhook_events_worker.rb
+++ b/app/workers/vacuum_analyze_webhook_events_worker.rb
@@ -1,10 +1,12 @@
 class VacuumAnalyzeWebhookEventsWorker < BaseWorker
+  STATEMENT_TIMEOUT = ENV.fetch('KEYGEN_VACUUM_STATEMENT_TIMEOUT') { '5min' }
+
   sidekiq_options queue: :cron,
                   cronitor_disabled: false
 
   def perform
-    conn = ActiveRecord::Base.connection
-
-    conn.execute 'VACUUM ANALYZE webhook_events'
+    WebhookEvent.statement_timeout(STATEMENT_TIMEOUT) do |conn|
+      conn.execute 'VACUUM ANALYZE webhook_events'
+    end
   end
 end

--- a/config/initializers/statement_timeout.rb
+++ b/config/initializers/statement_timeout.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require_dependency Rails.root / 'lib' / 'statement_timeout'

--- a/lib/statement_timeout.rb
+++ b/lib/statement_timeout.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module StatementTimeout
+  module QueryMethodsExtension
+    def statement_timeout(timeout)
+      t = if timeout in ActiveSupport::Duration
+            timeout.in_milliseconds
+          else
+            timeout
+          end
+
+      spawn.transaction do
+        conn = respond_to?(:lease_connection) ? lease_connection : connection
+
+        conn.execute(
+          sanitize_sql(['SET LOCAL statement_timeout = :t', t:]),
+        )
+
+        yield conn
+      end
+    end
+  end
+
+  module QueryingExtension
+    delegate :statement_timeout, to: :all
+  end
+
+  ActiveSupport.on_load :active_record do
+    ActiveRecord::QueryMethods.prepend(QueryMethodsExtension)
+    ActiveRecord::Querying.prepend(QueryingExtension)
+  end
+end

--- a/spec/lib/statement_timeout_spec.rb
+++ b/spec/lib/statement_timeout_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'spec_helper'
+
+require_dependency Rails.root / 'lib' / 'statement_timeout'
+
+describe StatementTimeout do
+  context 'with a duration' do
+    it 'should set a local statement_timeout' do
+      expect { License.statement_timeout(1.minute) { License.unscoped.take } }.to(
+        match_queries(count: 2) do |queries|
+          expect(queries.first).to eq <<~SQL.squish
+            SET LOCAL statement_timeout = 60000
+          SQL
+
+          expect(queries.second).to eq <<~SQL.squish
+            SELECT "licenses".* FROM "licenses" LIMIT 1
+          SQL
+        end
+      )
+    end
+  end
+
+  context 'with an integer' do
+    it 'should set a local statement_timeout' do
+      expect { License.statement_timeout(1000) { License.unscoped.take } }.to(
+        match_queries(count: 2) do |queries|
+          expect(queries.first).to eq <<~SQL.squish
+            SET LOCAL statement_timeout = 1000
+          SQL
+
+          expect(queries.second).to eq <<~SQL.squish
+            SELECT "licenses".* FROM "licenses" LIMIT 1
+          SQL
+        end
+      )
+    end
+  end
+
+  context 'with a float' do
+    it 'should set a local statement_timeout' do
+      expect { License.statement_timeout(1000.5) { License.unscoped.take } }.to(
+        match_queries(count: 2) do |queries|
+          expect(queries.first).to eq <<~SQL.squish
+            SET LOCAL statement_timeout = 1000.5
+          SQL
+
+          expect(queries.second).to eq <<~SQL.squish
+            SELECT "licenses".* FROM "licenses" LIMIT 1
+          SQL
+        end
+      )
+    end
+  end
+
+  context 'with a string' do
+    it 'should set a local statement_timeout' do
+      expect { License.statement_timeout('1s') { License.unscoped.take } }.to(
+        match_queries(count: 2) do |queries|
+          expect(queries.first).to eq <<~SQL.squish
+            SET LOCAL statement_timeout = '1s'
+          SQL
+
+          expect(queries.second).to eq <<~SQL.squish
+            SELECT "licenses".* FROM "licenses" LIMIT 1
+          SQL
+        end
+      )
+    end
+  end
+end

--- a/spec/support/matchers/query_matcher.rb
+++ b/spec/support/matchers/query_matcher.rb
@@ -10,7 +10,7 @@ def match_queries(...) = QueryMatcher.new(...)
 def match_query(...)   = match_queries(...)
 
 class QueryMatcher
-  def initialize(count: 0, &block)
+  def initialize(count: nil, &block)
     @count = count
     @block = block
   end
@@ -21,7 +21,7 @@ class QueryMatcher
   def matches?(block)
     @queries = QueryLogger.log(&block)
 
-    @queries.size == @count && (
+    (@count.nil? || @queries.size == @count) && (
       @block.nil? || @block.call(@queries)
     )
   end


### PR DESCRIPTION
Some of these queries need a longer `statement_timeout` than our default. This makes the timeouts configurable.