### PR TITLE
Update statement_timeout to not use a transaction

### DIFF
--- a/app/workers/prune_event_logs_worker.rb
+++ b/app/workers/prune_event_logs_worker.rb
@@ -53,8 +53,8 @@ class PruneEventLogsWorker < BaseWorker
           "event_logs"
         WHERE
           "event_logs"."account_id"  = "accounts"."id" AND
-          "event_logs"."created_at" >= :start_date     AND
-          "event_logs"."created_at" <  :end_date
+          "event_logs"."created_date" >= :start_date     AND
+          "event_logs"."created_date" <  :end_date
         LIMIT
           1
       )
@@ -75,8 +75,8 @@ class PruneEventLogsWorker < BaseWorker
       loop do
         # FIXME(ezekg) Update this to use created_date after we've backfilled old logs
         event_logs = account.event_logs.where(event_type_id: event_type_ids)
-                                       .where('created_at >= ?', start_date)
-                                       .where('created_at < ?', end_date)
+                                       .where('created_date >= ?', start_date)
+                                       .where('created_date < ?', end_date)
 
         # Keep the latest log per-resource for each day and event type (i.e. discard duplicates)
         kept_logs = event_logs.distinct_on(:resource_id, :resource_type, :event_type_id, :created_date)

--- a/app/workers/prune_metrics_worker.rb
+++ b/app/workers/prune_metrics_worker.rb
@@ -23,8 +23,8 @@ class PruneMetricsWorker < BaseWorker
           "metrics"
         WHERE
           "metrics"."account_id"  = "accounts"."id" AND
-          "metrics"."created_at" >= :start_date     AND
-          "metrics"."created_at" <  :end_date
+          "metrics"."created_date" >= :start_date     AND
+          "metrics"."created_date" <  :end_date
         LIMIT
           1
       )
@@ -39,8 +39,8 @@ class PruneMetricsWorker < BaseWorker
       Keygen.logger.info "[workers.prune-metrics] Pruning rows: account_id=#{account_id}"
 
       loop do
-        metrics = account.metrics.where('created_at >= ?', start_date)
-                                 .where('created_at < ?', end_date)
+        metrics = account.metrics.where('created_date >= ?', start_date)
+                                 .where('created_date < ?', end_date)
 
         batch += 1
         count = metrics.statement_timeout(STATEMENT_TIMEOUT) do

--- a/app/workers/prune_request_logs_worker.rb
+++ b/app/workers/prune_request_logs_worker.rb
@@ -23,8 +23,8 @@ class PruneRequestLogsWorker < BaseWorker
           "request_logs"
         WHERE
           "request_logs"."account_id"  = "accounts"."id" AND
-          "request_logs"."created_at" >= :start_date     AND
-          "request_logs"."created_at" <  :end_date
+          "request_logs"."created_date" >= :start_date     AND
+          "request_logs"."created_date" <  :end_date
         LIMIT
           1
       )
@@ -39,8 +39,8 @@ class PruneRequestLogsWorker < BaseWorker
       Keygen.logger.info "[workers.prune-request-logs] Pruning rows: account_id=#{account_id}"
 
       loop do
-        logs = account.request_logs.where('created_at >= ?', start_date)
-                                   .where('created_at < ?', end_date)
+        logs = account.request_logs.where('created_date >= ?', start_date)
+                                   .where('created_date < ?', end_date)
 
         batch += 1
         count = logs.statement_timeout(STATEMENT_TIMEOUT) do

--- a/lib/statement_timeout.rb
+++ b/lib/statement_timeout.rb
@@ -1,22 +1,41 @@
 # frozen_string_literal: true
 
 module StatementTimeout
+  module AbstractAdapterExtension
+    def supports_statement_timeout? = false
+    def statement_timeout           = raise NotImplementedError
+    def statement_timeout=(timeout)
+      raise NotImplementedError
+    end
+  end
+
+  module PostgreSQLAdapterExtension
+    def supports_statement_timeout? = true
+    def statement_timeout           = @statement_timeout ||= query_value("SHOW statement_timeout")
+    def statement_timeout=(timeout)
+      @statement_timeout = nil
+
+      internal_exec_query("SET statement_timeout = #{quote(timeout)}")
+    end
+  end
+
   module QueryMethodsExtension
     def statement_timeout(timeout)
-      t = if timeout in ActiveSupport::Duration
-            timeout.in_milliseconds
-          else
-            timeout
-          end
+      timeout = if timeout in ActiveSupport::Duration
+                  timeout.in_milliseconds
+                else
+                  timeout
+                end
 
-      spawn.transaction do
-        conn = respond_to?(:lease_connection) ? lease_connection : connection
+      connection_pool.with_connection do |connection|
+        raise ActiveRecord::AdapterError, "statement_timeout is not supported for the #{connection.class.inspect} adapter" unless
+          connection.supports_statement_timeout?
 
-        conn.execute(
-          sanitize_sql(['SET LOCAL statement_timeout = :t', t:]),
-        )
+        statement_timeout_was, connection.statement_timeout = connection.statement_timeout, timeout
 
-        yield conn
+        yield connection
+      ensure
+        connection.statement_timeout = statement_timeout_was
       end
     end
   end
@@ -26,6 +45,8 @@ module StatementTimeout
   end
 
   ActiveSupport.on_load :active_record do
+    ActiveRecord::ConnectionAdapters::AbstractAdapter.prepend(AbstractAdapterExtension)
+    ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.prepend(PostgreSQLAdapterExtension)
     ActiveRecord::QueryMethods.prepend(QueryMethodsExtension)
     ActiveRecord::Querying.prepend(QueryingExtension)
   end

--- a/spec/lib/statement_timeout_spec.rb
+++ b/spec/lib/statement_timeout_spec.rb
@@ -6,67 +6,158 @@ require 'spec_helper'
 require_dependency Rails.root / 'lib' / 'statement_timeout'
 
 describe StatementTimeout do
+  before(:all) { DatabaseCleaner.strategy = nil } # vacuum doesn't support transactions
+  after(:all)  { DatabaseCleaner.strategy = :transaction }
+
+  subject { License }
+
+  let(:connection) { subject.respond_to?(:lease_connection) ? subject.lease_connection : subject.connection }
+  let(:table_name) { subject.table_name }
+
   context 'with a duration' do
-    it 'should set a local statement_timeout' do
-      expect { License.statement_timeout(1.minute) { License.unscoped.take } }.to(
-        match_queries(count: 2) do |queries|
+    it 'should set a temporary statement_timeout for valid duration' do
+      statement_timeout_was = connection.statement_timeout
+
+      expect { subject.statement_timeout(1.minute) { subject.unscoped.take } }.to(
+        match_queries(count: 3) do |queries|
           expect(queries.first).to eq <<~SQL.squish
-            SET LOCAL statement_timeout = 60000
+            SET statement_timeout = 60000
           SQL
 
           expect(queries.second).to eq <<~SQL.squish
-            SELECT "licenses".* FROM "licenses" LIMIT 1
+            SELECT "#{table_name}".* FROM "#{table_name}" LIMIT 1
+          SQL
+
+          expect(queries.third).to eq <<~SQL.squish
+            SET statement_timeout = '#{statement_timeout_was}'
           SQL
         end
       )
+
+      expect(connection.statement_timeout).to eq statement_timeout_was
     end
   end
 
   context 'with an integer' do
-    it 'should set a local statement_timeout' do
-      expect { License.statement_timeout(1000) { License.unscoped.take } }.to(
-        match_queries(count: 2) do |queries|
+    it 'should set a temporary statement_timeout for valid integer' do
+      statement_timeout_was = connection.statement_timeout
+
+      expect { subject.statement_timeout(1000) { subject.unscoped.take } }.to(
+        match_queries(count: 3) do |queries|
           expect(queries.first).to eq <<~SQL.squish
-            SET LOCAL statement_timeout = 1000
+            SET statement_timeout = 1000
           SQL
 
           expect(queries.second).to eq <<~SQL.squish
-            SELECT "licenses".* FROM "licenses" LIMIT 1
+            SELECT "#{table_name}".* FROM "#{table_name}" LIMIT 1
+          SQL
+
+          expect(queries.third).to eq <<~SQL.squish
+            SET statement_timeout = '#{statement_timeout_was}'
           SQL
         end
       )
+
+      expect(connection.statement_timeout).to eq statement_timeout_was
     end
   end
 
   context 'with a float' do
-    it 'should set a local statement_timeout' do
-      expect { License.statement_timeout(1000.5) { License.unscoped.take } }.to(
-        match_queries(count: 2) do |queries|
+    it 'should set a temporary statement_timeout for valid float' do
+      statement_timeout_was = connection.statement_timeout
+
+      expect { subject.statement_timeout(1000.5) { subject.unscoped.take } }.to(
+        match_queries(count: 3) do |queries|
           expect(queries.first).to eq <<~SQL.squish
-            SET LOCAL statement_timeout = 1000.5
+            SET statement_timeout = 1000.5
           SQL
 
           expect(queries.second).to eq <<~SQL.squish
-            SELECT "licenses".* FROM "licenses" LIMIT 1
+            SELECT "#{table_name}".* FROM "#{table_name}" LIMIT 1
+          SQL
+
+          expect(queries.third).to eq <<~SQL.squish
+            SET statement_timeout = '#{statement_timeout_was}'
           SQL
         end
       )
+
+      expect(connection.statement_timeout).to eq statement_timeout_was
     end
   end
 
   context 'with a string' do
-    it 'should set a local statement_timeout' do
-      expect { License.statement_timeout('1s') { License.unscoped.take } }.to(
-        match_queries(count: 2) do |queries|
+    it 'should set a temporary statement_timeout for valid value' do
+      statement_timeout_was = connection.statement_timeout
+
+      expect { subject.statement_timeout('1s') { subject.unscoped.take } }.to(
+        match_queries(count: 3) do |queries|
           expect(queries.first).to eq <<~SQL.squish
-            SET LOCAL statement_timeout = '1s'
+            SET statement_timeout = '1s'
           SQL
 
           expect(queries.second).to eq <<~SQL.squish
-            SELECT "licenses".* FROM "licenses" LIMIT 1
+            SELECT "#{table_name}".* FROM "#{table_name}" LIMIT 1
+          SQL
+
+          expect(queries.third).to eq <<~SQL.squish
+            SET statement_timeout = '#{statement_timeout_was}'
           SQL
         end
       )
+
+      expect(connection.statement_timeout).to eq statement_timeout_was
     end
+
+    it 'should raise for invalid value' do
+      statement_timeout_was = connection.statement_timeout
+
+      expect { subject.statement_timeout('foo') { subject.unscoped.take } }
+        .to raise_error ActiveRecord::StatementInvalid
+
+      expect(connection.statement_timeout).to eq statement_timeout_was
+    end
+  end
+
+  it 'should not timeout' do
+    expect { subject.statement_timeout('2s') { connection.execute('select pg_sleep(1)') } }
+      .to_not raise_error
+  end
+
+  it 'should timeout' do
+    expect { subject.statement_timeout('1s') { connection.execute('select pg_sleep(2)') } }
+      .to raise_error ActiveRecord::StatementInvalid
+  end
+
+  it 'should return a relation' do
+    expect(subject.statement_timeout('1s') { subject.all }).to be_an ActiveRecord::Relation
+  end
+
+  it 'should return a record' do
+    expect(subject.statement_timeout('1s') { subject.new }).to be_a subject
+  end
+
+  it 'should return a value' do
+    expect(subject.statement_timeout('1s') { connection.execute('select 1 as value')[0]['value'] }).to eq 1
+  end
+
+  it 'should support transaction' do
+    expect { subject.statement_timeout('1s') { subject.transaction { subject.unscoped.take } } }
+      .to_not raise_error
+  end
+
+  # NOTE(ezekg) We're explicitly testing VACUUM because it doesn't support
+  #             transactions, and this asserts our implementation is
+  #             compatible with such queries.
+  it 'should support vacuum' do
+    expect { subject.statement_timeout('1s') { connection.execute("VACUUM ANALYZE #{table_name}") } }
+      .to_not raise_error
+  end
+
+  it 'should raise error' do
+    expect { subject.statement_timeout('1s') { subject.transaction { connection.execute("VACUUM ANALYZE #{table_name}") } } }
+      .to raise_error { |err|
+        expect(err.message).to match /vacuum cannot run inside a transaction block/i
+      }
   end
 end


### PR DESCRIPTION
Resolves [an issue where `VACUUM` would fail](https://github.com/keygen-sh/keygen-api/pull/853#issuecomment-2138593242) because it can't run inside a transaction.