### PR TITLE
Add SAML/SSO

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,9 @@ gem 'jwt'
 # 2FA/TOTP
 gem 'rotp', '~> 6.2'
 
+# SSO
+gem 'workos'
+
 # Scopes and pagination
 gem 'has_scope'
 gem 'kaminari', '~> 1.2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -500,6 +500,7 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    workos (5.2.1)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.6.15)
@@ -579,6 +580,7 @@ DEPENDENCIES
   typed_params (~> 1.2.5)
   uri (>= 0.12.2)
   webmock (~> 3.14.0)
+  workos
 
 RUBY VERSION
    ruby 3.3.4p94

--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ Keygen Enterprise Edition:
 - **Environments**: manage separate environments within a Keygen account, from
   test environments, to a sandbox, to QA, to production.
 - **Permissions**: enterprise-grade roles and permissions.
-- **SSO/SAML**: support for SSO/SAML coming soon.
+- **Import/export**: migrate from Keygen Cloud to Keygen EE.
+- **SSO/SAML**: support for SSO/SAML/OAuth.
 
 Keygen uses Keygen EE in production to run Keygen Cloud, which is used to
 license Keygen EE. It's ~~turtles~~ Keygens all the way down (we love

--- a/app/controllers/api/v1/accounts/actions/subscription_controller.rb
+++ b/app/controllers/api/v1/accounts/actions/subscription_controller.rb
@@ -3,7 +3,7 @@
 module Api::V1::Accounts::Actions
   class SubscriptionController < Api::V1::BaseController
     before_action :scope_to_current_account!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
 
     def manage
       authorize! with: Accounts::SubscriptionPolicy

--- a/app/controllers/api/v1/accounts/relationships/billings_controller.rb
+++ b/app/controllers/api/v1/accounts/relationships/billings_controller.rb
@@ -3,7 +3,7 @@
 module Api::V1::Accounts::Relationships
   class BillingsController < Api::V1::BaseController
     before_action :scope_to_current_account!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
     before_action :set_billing
 
     def show

--- a/app/controllers/api/v1/accounts/relationships/plans_controller.rb
+++ b/app/controllers/api/v1/accounts/relationships/plans_controller.rb
@@ -3,7 +3,7 @@
 module Api::V1::Accounts::Relationships
   class PlansController < Api::V1::BaseController
     before_action :scope_to_current_account!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
 
     def show
       plan = current_account.plan

--- a/app/controllers/api/v1/accounts_controller.rb
+++ b/app/controllers/api/v1/accounts_controller.rb
@@ -3,7 +3,7 @@
 module Api::V1
   class AccountsController < Api::V1::BaseController
     before_action :scope_to_current_account!, only: %i[show update destroy]
-    before_action :authenticate_with_token!, only: %i[show update destroy]
+    before_action :authenticate!, only: %i[show update destroy]
     before_action :set_account, only: %i[show update destroy]
 
     def show

--- a/app/controllers/api/v1/analytics/actions/counts_controller.rb
+++ b/app/controllers/api/v1/analytics/actions/counts_controller.rb
@@ -4,7 +4,7 @@ module Api::V1::Analytics::Actions
   class CountsController < Api::V1::BaseController
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
 
     def count
       authorize! to: :show?, with: Accounts::AnalyticsPolicy

--- a/app/controllers/api/v1/entitlements_controller.rb
+++ b/app/controllers/api/v1/entitlements_controller.rb
@@ -4,7 +4,7 @@ module Api::V1
   class EntitlementsController < Api::V1::BaseController
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
     before_action :set_entitlement, only: %i[show update destroy]
 
     def index

--- a/app/controllers/api/v1/environments/relationships/tokens_controller.rb
+++ b/app/controllers/api/v1/environments/relationships/tokens_controller.rb
@@ -5,7 +5,7 @@ module Api::V1::Environments::Relationships
     before_action :require_ee!
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
     before_action :set_environment
 
     def index

--- a/app/controllers/api/v1/environments_controller.rb
+++ b/app/controllers/api/v1/environments_controller.rb
@@ -5,7 +5,7 @@ module Api::V1
     before_action :require_ee!
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
     before_action :set_environment, only: %i[show update destroy]
 
     def index

--- a/app/controllers/api/v1/event_logs_controller.rb
+++ b/app/controllers/api/v1/event_logs_controller.rb
@@ -12,7 +12,7 @@ module Api::V1
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
     before_action :require_ent_subscription!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
     before_action :set_event_log, only: %i[show]
 
     def index

--- a/app/controllers/api/v1/groups/relationships/group_owners_controller.rb
+++ b/app/controllers/api/v1/groups/relationships/group_owners_controller.rb
@@ -4,7 +4,7 @@ module Api::V1::Groups::Relationships
   class GroupOwnersController < Api::V1::BaseController
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
     before_action :set_group
 
     authorize :group

--- a/app/controllers/api/v1/groups/relationships/licenses_controller.rb
+++ b/app/controllers/api/v1/groups/relationships/licenses_controller.rb
@@ -4,7 +4,7 @@ module Api::V1::Groups::Relationships
   class LicensesController < Api::V1::BaseController
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
     before_action :set_group
 
     authorize :group

--- a/app/controllers/api/v1/groups/relationships/machines_controller.rb
+++ b/app/controllers/api/v1/groups/relationships/machines_controller.rb
@@ -4,7 +4,7 @@ module Api::V1::Groups::Relationships
   class MachinesController < Api::V1::BaseController
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
     before_action :set_group
 
     authorize :group

--- a/app/controllers/api/v1/groups/relationships/users_controller.rb
+++ b/app/controllers/api/v1/groups/relationships/users_controller.rb
@@ -4,7 +4,7 @@ module Api::V1::Groups::Relationships
   class UsersController < Api::V1::BaseController
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
     before_action :set_group
 
     authorize :group

--- a/app/controllers/api/v1/groups_controller.rb
+++ b/app/controllers/api/v1/groups_controller.rb
@@ -4,7 +4,7 @@ module Api::V1
   class GroupsController < Api::V1::BaseController
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
     before_action :set_group, only: %i[show update destroy]
 
     def index

--- a/app/controllers/api/v1/keys/relationships/policies_controller.rb
+++ b/app/controllers/api/v1/keys/relationships/policies_controller.rb
@@ -4,7 +4,7 @@ module Api::V1::Keys::Relationships
   class PoliciesController < Api::V1::BaseController
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
     before_action :set_key
 
     authorize :key

--- a/app/controllers/api/v1/keys/relationships/products_controller.rb
+++ b/app/controllers/api/v1/keys/relationships/products_controller.rb
@@ -4,7 +4,7 @@ module Api::V1::Keys::Relationships
   class ProductsController < Api::V1::BaseController
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
     before_action :set_key
 
     authorize :key

--- a/app/controllers/api/v1/keys_controller.rb
+++ b/app/controllers/api/v1/keys_controller.rb
@@ -7,7 +7,7 @@ module Api::V1
 
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
     before_action :set_key, only: %i[show update destroy]
 
     def index

--- a/app/controllers/api/v1/licenses/actions/checkouts_controller.rb
+++ b/app/controllers/api/v1/licenses/actions/checkouts_controller.rb
@@ -4,7 +4,7 @@ module Api::V1::Licenses::Actions
   class CheckoutsController < Api::V1::BaseController
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
     before_action :set_license
 
     authorize :license

--- a/app/controllers/api/v1/licenses/actions/permits_controller.rb
+++ b/app/controllers/api/v1/licenses/actions/permits_controller.rb
@@ -4,7 +4,7 @@ module Api::V1::Licenses::Actions
   class PermitsController < Api::V1::BaseController
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
     before_action :set_license
 
     def check_in

--- a/app/controllers/api/v1/licenses/actions/uses_controller.rb
+++ b/app/controllers/api/v1/licenses/actions/uses_controller.rb
@@ -4,7 +4,7 @@ module Api::V1::Licenses::Actions
   class UsesController < Api::V1::BaseController
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
     before_action :set_license
 
     authorize :license

--- a/app/controllers/api/v1/licenses/actions/validations_controller.rb
+++ b/app/controllers/api/v1/licenses/actions/validations_controller.rb
@@ -4,8 +4,8 @@ module Api::V1::Licenses::Actions
   class ValidationsController < Api::V1::BaseController
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!, except: %i[validate_by_key]
-    before_action :authenticate_with_token, only: %i[validate_by_key]
+    before_action :authenticate!, except: %i[validate_by_key]
+    before_action :authenticate, only: %i[validate_by_key]
     before_action :set_license, only: %i[quick_validate_by_id validate_by_id]
 
     def quick_validate_by_id

--- a/app/controllers/api/v1/licenses/relationships/entitlements_controller.rb
+++ b/app/controllers/api/v1/licenses/relationships/entitlements_controller.rb
@@ -4,7 +4,7 @@ module Api::V1::Licenses::Relationships
   class EntitlementsController < Api::V1::BaseController
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
     before_action :set_license
 
     authorize :license

--- a/app/controllers/api/v1/licenses/relationships/groups_controller.rb
+++ b/app/controllers/api/v1/licenses/relationships/groups_controller.rb
@@ -4,7 +4,7 @@ module Api::V1::Licenses::Relationships
   class GroupsController < Api::V1::BaseController
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
     before_action :set_license
 
     authorize :license

--- a/app/controllers/api/v1/licenses/relationships/machines_controller.rb
+++ b/app/controllers/api/v1/licenses/relationships/machines_controller.rb
@@ -8,7 +8,7 @@ module Api::V1::Licenses::Relationships
 
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
     before_action :set_license
 
     authorize :license

--- a/app/controllers/api/v1/licenses/relationships/owners_controller.rb
+++ b/app/controllers/api/v1/licenses/relationships/owners_controller.rb
@@ -4,7 +4,7 @@ module Api::V1::Licenses::Relationships
   class OwnersController < Api::V1::BaseController
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
     before_action :set_license
 
     authorize :license

--- a/app/controllers/api/v1/licenses/relationships/policies_controller.rb
+++ b/app/controllers/api/v1/licenses/relationships/policies_controller.rb
@@ -4,7 +4,7 @@ module Api::V1::Licenses::Relationships
   class PoliciesController < Api::V1::BaseController
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
     before_action :set_license
 
     authorize :license

--- a/app/controllers/api/v1/licenses/relationships/products_controller.rb
+++ b/app/controllers/api/v1/licenses/relationships/products_controller.rb
@@ -4,7 +4,7 @@ module Api::V1::Licenses::Relationships
   class ProductsController < Api::V1::BaseController
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
     before_action :set_license
 
     authorize :license

--- a/app/controllers/api/v1/licenses/relationships/tokens_controller.rb
+++ b/app/controllers/api/v1/licenses/relationships/tokens_controller.rb
@@ -4,7 +4,7 @@ module Api::V1::Licenses::Relationships
   class TokensController < Api::V1::BaseController
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
     before_action :set_license
 
     authorize :license

--- a/app/controllers/api/v1/licenses/relationships/users_controller.rb
+++ b/app/controllers/api/v1/licenses/relationships/users_controller.rb
@@ -4,7 +4,7 @@ module Api::V1::Licenses::Relationships
   class UsersController < Api::V1::BaseController
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
     before_action :set_license
 
     authorize :license

--- a/app/controllers/api/v1/licenses/relationships/v1x5/users_controller.rb
+++ b/app/controllers/api/v1/licenses/relationships/v1x5/users_controller.rb
@@ -4,7 +4,7 @@ module Api::V1::Licenses::Relationships::V1x5
   class UsersController < Api::V1::BaseController
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
     before_action :set_license
 
     authorize :license

--- a/app/controllers/api/v1/licenses_controller.rb
+++ b/app/controllers/api/v1/licenses_controller.rb
@@ -25,7 +25,7 @@ module Api::V1
 
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
     before_action :set_license, only: %i[show update destroy]
 
     def index

--- a/app/controllers/api/v1/machine_components/relationships/licenses_controller.rb
+++ b/app/controllers/api/v1/machine_components/relationships/licenses_controller.rb
@@ -4,7 +4,7 @@ module Api::V1::MachineComponents::Relationships
   class LicensesController < Api::V1::BaseController
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
     before_action :set_machine_component
 
     authorize :machine_component

--- a/app/controllers/api/v1/machine_components/relationships/machines_controller.rb
+++ b/app/controllers/api/v1/machine_components/relationships/machines_controller.rb
@@ -4,7 +4,7 @@ module Api::V1::MachineComponents::Relationships
   class MachinesController < Api::V1::BaseController
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
     before_action :set_machine_component
 
     authorize :machine_component

--- a/app/controllers/api/v1/machine_components/relationships/products_controller.rb
+++ b/app/controllers/api/v1/machine_components/relationships/products_controller.rb
@@ -4,7 +4,7 @@ module Api::V1::MachineComponents::Relationships
   class ProductsController < Api::V1::BaseController
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
     before_action :set_machine_component
 
     authorize :machine_component

--- a/app/controllers/api/v1/machine_components_controller.rb
+++ b/app/controllers/api/v1/machine_components_controller.rb
@@ -10,7 +10,7 @@ module Api::V1
 
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
     before_action :set_machine_component, only: %i[show update destroy]
 
     def index

--- a/app/controllers/api/v1/machine_processes/actions/heartbeats_controller.rb
+++ b/app/controllers/api/v1/machine_processes/actions/heartbeats_controller.rb
@@ -4,7 +4,7 @@ module Api::V1::MachineProcesses::Actions
   class HeartbeatsController < Api::V1::BaseController
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
     before_action :set_machine_process
 
     authorize :machine_process

--- a/app/controllers/api/v1/machine_processes/relationships/licenses_controller.rb
+++ b/app/controllers/api/v1/machine_processes/relationships/licenses_controller.rb
@@ -4,7 +4,7 @@ module Api::V1::MachineProcesses::Relationships
   class LicensesController < Api::V1::BaseController
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
     before_action :set_machine_process
 
     authorize :machine_process

--- a/app/controllers/api/v1/machine_processes/relationships/machines_controller.rb
+++ b/app/controllers/api/v1/machine_processes/relationships/machines_controller.rb
@@ -4,7 +4,7 @@ module Api::V1::MachineProcesses::Relationships
   class MachinesController < Api::V1::BaseController
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
     before_action :set_machine_process
 
     authorize :machine_process

--- a/app/controllers/api/v1/machine_processes/relationships/products_controller.rb
+++ b/app/controllers/api/v1/machine_processes/relationships/products_controller.rb
@@ -4,7 +4,7 @@ module Api::V1::MachineProcesses::Relationships
   class ProductsController < Api::V1::BaseController
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
     before_action :set_machine_process
 
     authorize :machine_process

--- a/app/controllers/api/v1/machine_processes_controller.rb
+++ b/app/controllers/api/v1/machine_processes_controller.rb
@@ -11,7 +11,7 @@ module Api::V1
 
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
     before_action :set_machine_process, only: %i[show update destroy]
 
     def index

--- a/app/controllers/api/v1/machines/actions/checkouts_controller.rb
+++ b/app/controllers/api/v1/machines/actions/checkouts_controller.rb
@@ -4,7 +4,7 @@ module Api::V1::Machines::Actions
   class CheckoutsController < Api::V1::BaseController
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
     before_action :set_machine
 
     authorize :machine

--- a/app/controllers/api/v1/machines/actions/heartbeats_controller.rb
+++ b/app/controllers/api/v1/machines/actions/heartbeats_controller.rb
@@ -4,7 +4,7 @@ module Api::V1::Machines::Actions
   class HeartbeatsController < Api::V1::BaseController
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
     before_action :set_machine
 
     authorize :machine

--- a/app/controllers/api/v1/machines/actions/v1x0/proofs_controller.rb
+++ b/app/controllers/api/v1/machines/actions/v1x0/proofs_controller.rb
@@ -4,7 +4,7 @@ module Api::V1::Machines::Actions::V1x0
   class ProofsController < Api::V1::BaseController
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
     before_action :set_machine
 
     authorize :machine

--- a/app/controllers/api/v1/machines/relationships/groups_controller.rb
+++ b/app/controllers/api/v1/machines/relationships/groups_controller.rb
@@ -4,7 +4,7 @@ module Api::V1::Machines::Relationships
   class GroupsController < Api::V1::BaseController
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
     before_action :set_machine
 
     authorize :machine

--- a/app/controllers/api/v1/machines/relationships/licenses_controller.rb
+++ b/app/controllers/api/v1/machines/relationships/licenses_controller.rb
@@ -4,7 +4,7 @@ module Api::V1::Machines::Relationships
   class LicensesController < Api::V1::BaseController
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
     before_action :set_machine
 
     authorize :machine

--- a/app/controllers/api/v1/machines/relationships/machine_components_controller.rb
+++ b/app/controllers/api/v1/machines/relationships/machine_components_controller.rb
@@ -6,7 +6,7 @@ module Api::V1::Machines::Relationships
 
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
     before_action :set_machine
 
     authorize :machine

--- a/app/controllers/api/v1/machines/relationships/machine_processes_controller.rb
+++ b/app/controllers/api/v1/machines/relationships/machine_processes_controller.rb
@@ -6,7 +6,7 @@ module Api::V1::Machines::Relationships
 
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
     before_action :set_machine
 
     authorize :machine

--- a/app/controllers/api/v1/machines/relationships/owners_controller.rb
+++ b/app/controllers/api/v1/machines/relationships/owners_controller.rb
@@ -4,7 +4,7 @@ module Api::V1::Machines::Relationships
   class OwnersController < Api::V1::BaseController
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
     before_action :set_machine
 
     authorize :machine

--- a/app/controllers/api/v1/machines/relationships/products_controller.rb
+++ b/app/controllers/api/v1/machines/relationships/products_controller.rb
@@ -4,7 +4,7 @@ module Api::V1::Machines::Relationships
   class ProductsController < Api::V1::BaseController
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
     before_action :set_machine
 
     authorize :machine

--- a/app/controllers/api/v1/machines/relationships/v1x5/users_controller.rb
+++ b/app/controllers/api/v1/machines/relationships/v1x5/users_controller.rb
@@ -4,7 +4,7 @@ module Api::V1::Machines::Relationships::V1x5
   class UsersController < Api::V1::BaseController
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
     before_action :set_machine
 
     authorize :machine

--- a/app/controllers/api/v1/machines_controller.rb
+++ b/app/controllers/api/v1/machines_controller.rb
@@ -17,7 +17,7 @@ module Api::V1
 
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
     before_action :set_machine, only: [:show, :update, :destroy]
 
     def index

--- a/app/controllers/api/v1/metrics/actions/counts_controller.rb
+++ b/app/controllers/api/v1/metrics/actions/counts_controller.rb
@@ -6,7 +6,7 @@ module Api::V1::Metrics::Actions
 
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
 
     def count
       authorize! with: MetricPolicy

--- a/app/controllers/api/v1/metrics_controller.rb
+++ b/app/controllers/api/v1/metrics_controller.rb
@@ -8,7 +8,7 @@ module Api::V1
 
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
     before_action :set_metric, only: %i[show]
 
     def index

--- a/app/controllers/api/v1/policies/relationships/entitlements_controller.rb
+++ b/app/controllers/api/v1/policies/relationships/entitlements_controller.rb
@@ -4,7 +4,7 @@ module Api::V1::Policies::Relationships
   class EntitlementsController < Api::V1::BaseController
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
     before_action :set_policy
 
     authorize :policy

--- a/app/controllers/api/v1/policies/relationships/licenses_controller.rb
+++ b/app/controllers/api/v1/policies/relationships/licenses_controller.rb
@@ -8,7 +8,7 @@ module Api::V1::Policies::Relationships
 
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
     before_action :set_policy
 
     authorize :policy

--- a/app/controllers/api/v1/policies/relationships/pool_controller.rb
+++ b/app/controllers/api/v1/policies/relationships/pool_controller.rb
@@ -4,7 +4,7 @@ module Api::V1::Policies::Relationships
   class PoolController < Api::V1::BaseController
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
     before_action :set_policy, only: %i[index show pop]
 
     authorize :policy

--- a/app/controllers/api/v1/policies/relationships/products_controller.rb
+++ b/app/controllers/api/v1/policies/relationships/products_controller.rb
@@ -4,7 +4,7 @@ module Api::V1::Policies::Relationships
   class ProductsController < Api::V1::BaseController
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
     before_action :set_policy
 
     authorize :policy

--- a/app/controllers/api/v1/policies_controller.rb
+++ b/app/controllers/api/v1/policies_controller.rb
@@ -6,7 +6,7 @@ module Api::V1
 
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
     before_action :set_policy, only: %i[show update destroy]
 
     def index

--- a/app/controllers/api/v1/products/relationships/licenses_controller.rb
+++ b/app/controllers/api/v1/products/relationships/licenses_controller.rb
@@ -8,7 +8,7 @@ module Api::V1::Products::Relationships
 
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
     before_action :set_product
 
     authorize :product

--- a/app/controllers/api/v1/products/relationships/machines_controller.rb
+++ b/app/controllers/api/v1/products/relationships/machines_controller.rb
@@ -8,7 +8,7 @@ module Api::V1::Products::Relationships
 
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
     before_action :set_product
 
     authorize :product

--- a/app/controllers/api/v1/products/relationships/policies_controller.rb
+++ b/app/controllers/api/v1/products/relationships/policies_controller.rb
@@ -4,7 +4,7 @@ module Api::V1::Products::Relationships
   class PoliciesController < Api::V1::BaseController
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
     before_action :set_product
 
     authorize :product

--- a/app/controllers/api/v1/products/relationships/release_arches_controller.rb
+++ b/app/controllers/api/v1/products/relationships/release_arches_controller.rb
@@ -4,7 +4,7 @@ module Api::V1::Products::Relationships
   class ReleaseArchesController < Api::V1::BaseController
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
     before_action :set_product
 
     authorize :product

--- a/app/controllers/api/v1/products/relationships/release_artifacts_controller.rb
+++ b/app/controllers/api/v1/products/relationships/release_artifacts_controller.rb
@@ -12,7 +12,7 @@ module Api::V1::Products::Relationships
 
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
     before_action :set_product, only: %i[index show]
     before_action :set_artifact, only: %i[show]
 

--- a/app/controllers/api/v1/products/relationships/release_channels_controller.rb
+++ b/app/controllers/api/v1/products/relationships/release_channels_controller.rb
@@ -4,7 +4,7 @@ module Api::V1::Products::Relationships
   class ReleaseChannelsController < Api::V1::BaseController
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
     before_action :set_product
 
     authorize :product

--- a/app/controllers/api/v1/products/relationships/release_engines_controller.rb
+++ b/app/controllers/api/v1/products/relationships/release_engines_controller.rb
@@ -4,7 +4,7 @@ module Api::V1::Products::Relationships
   class ReleaseEnginesController < Api::V1::BaseController
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
     before_action :set_product
 
     authorize :product

--- a/app/controllers/api/v1/products/relationships/release_packages_controller.rb
+++ b/app/controllers/api/v1/products/relationships/release_packages_controller.rb
@@ -6,7 +6,7 @@ module Api::V1::Products::Relationships
 
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
     before_action :set_product
 
     authorize :product

--- a/app/controllers/api/v1/products/relationships/release_platforms_controller.rb
+++ b/app/controllers/api/v1/products/relationships/release_platforms_controller.rb
@@ -4,7 +4,7 @@ module Api::V1::Products::Relationships
   class ReleasePlatformsController < Api::V1::BaseController
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
     before_action :set_product
 
     authorize :product

--- a/app/controllers/api/v1/products/relationships/releases_controller.rb
+++ b/app/controllers/api/v1/products/relationships/releases_controller.rb
@@ -16,7 +16,7 @@ module Api::V1::Products::Relationships
 
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
     before_action :set_product
 
     authorize :product

--- a/app/controllers/api/v1/products/relationships/tokens_controller.rb
+++ b/app/controllers/api/v1/products/relationships/tokens_controller.rb
@@ -4,7 +4,7 @@ module Api::V1::Products::Relationships
   class TokensController < Api::V1::BaseController
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
     before_action :set_product
 
     authorize :product

--- a/app/controllers/api/v1/products/relationships/users_controller.rb
+++ b/app/controllers/api/v1/products/relationships/users_controller.rb
@@ -6,7 +6,7 @@ module Api::V1::Products::Relationships
 
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
     before_action :set_product
 
     authorize :product

--- a/app/controllers/api/v1/products_controller.rb
+++ b/app/controllers/api/v1/products_controller.rb
@@ -4,7 +4,7 @@ module Api::V1
   class ProductsController < Api::V1::BaseController
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
     before_action :set_product, only: [:show, :update, :destroy]
 
     def index

--- a/app/controllers/api/v1/profiles_controller.rb
+++ b/app/controllers/api/v1/profiles_controller.rb
@@ -3,7 +3,7 @@
 module Api::V1
   class ProfilesController < Api::V1::BaseController
     before_action :scope_to_current_account!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
 
     def show
       authorize! current_bearer

--- a/app/controllers/api/v1/release_arches_controller.rb
+++ b/app/controllers/api/v1/release_arches_controller.rb
@@ -4,7 +4,7 @@ module Api::V1
   class ReleaseArchesController < Api::V1::BaseController
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token
+    before_action :authenticate
     before_action :set_arch, only: %i[show]
 
     def index

--- a/app/controllers/api/v1/release_artifacts_controller.rb
+++ b/app/controllers/api/v1/release_artifacts_controller.rb
@@ -14,8 +14,8 @@ module Api::V1
 
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!, except: %i[index show]
-    before_action :authenticate_with_token, only: %i[index show]
+    before_action :authenticate!, except: %i[index show]
+    before_action :authenticate, only: %i[index show]
     before_action :set_artifact, only: %i[show update destroy]
 
     def index

--- a/app/controllers/api/v1/release_channels_controller.rb
+++ b/app/controllers/api/v1/release_channels_controller.rb
@@ -4,7 +4,7 @@ module Api::V1
   class ReleaseChannelsController < Api::V1::BaseController
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token
+    before_action :authenticate
     before_action :set_channel, only: %i[show]
 
     def index

--- a/app/controllers/api/v1/release_engines/pypi/simple_controller.rb
+++ b/app/controllers/api/v1/release_engines/pypi/simple_controller.rb
@@ -6,7 +6,7 @@ module Api::V1::ReleaseEngines
 
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token
+    before_action :authenticate
     before_action :set_package, only: %i[show]
 
     def index

--- a/app/controllers/api/v1/release_engines/tauri/upgrades_controller.rb
+++ b/app/controllers/api/v1/release_engines/tauri/upgrades_controller.rb
@@ -4,7 +4,7 @@ module Api::V1::ReleaseEngines
   class Tauri::UpgradesController < Api::V1::BaseController
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token
+    before_action :authenticate
     before_action :set_package, only: %i[show]
 
     typed_query {

--- a/app/controllers/api/v1/release_engines_controller.rb
+++ b/app/controllers/api/v1/release_engines_controller.rb
@@ -4,7 +4,7 @@ module Api::V1
   class ReleaseEnginesController < Api::V1::BaseController
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token
+    before_action :authenticate
     before_action :set_engine, only: %i[show]
 
     def index

--- a/app/controllers/api/v1/release_packages_controller.rb
+++ b/app/controllers/api/v1/release_packages_controller.rb
@@ -7,8 +7,8 @@ module Api::V1
 
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!, except: %i[index show]
-    before_action :authenticate_with_token, only: %i[index show]
+    before_action :authenticate!, except: %i[index show]
+    before_action :authenticate, only: %i[index show]
     before_action :set_package, only: %i[show update destroy]
 
     def index

--- a/app/controllers/api/v1/release_platforms_controller.rb
+++ b/app/controllers/api/v1/release_platforms_controller.rb
@@ -4,7 +4,7 @@ module Api::V1
   class ReleasePlatformsController < Api::V1::BaseController
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token
+    before_action :authenticate
     before_action :set_platform, only: %i[show]
 
     def index

--- a/app/controllers/api/v1/releases/actions/publishings_controller.rb
+++ b/app/controllers/api/v1/releases/actions/publishings_controller.rb
@@ -2,7 +2,7 @@ module Api::V1::Releases::Actions
   class PublishingsController < Api::V1::BaseController
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
     before_action :set_release
 
     def publish

--- a/app/controllers/api/v1/releases/actions/v1x0/upgrades_controller.rb
+++ b/app/controllers/api/v1/releases/actions/v1x0/upgrades_controller.rb
@@ -4,7 +4,7 @@ module Api::V1::Releases::Actions::V1x0
   class UpgradesController < Api::V1::BaseController
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token
+    before_action :authenticate
     before_action :set_release, only: %i[check_for_upgrade_by_id]
 
     skip_verify_authorized only: %i[

--- a/app/controllers/api/v1/releases/relationships/entitlements_controller.rb
+++ b/app/controllers/api/v1/releases/relationships/entitlements_controller.rb
@@ -4,7 +4,7 @@ module Api::V1::Releases::Relationships
   class EntitlementsController < Api::V1::BaseController
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
     before_action :set_release
 
     authorize :release

--- a/app/controllers/api/v1/releases/relationships/products_controller.rb
+++ b/app/controllers/api/v1/releases/relationships/products_controller.rb
@@ -4,7 +4,7 @@ module Api::V1::Releases::Relationships
   class ProductsController < Api::V1::BaseController
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
     before_action :set_release
 
     authorize :release

--- a/app/controllers/api/v1/releases/relationships/release_artifacts_controller.rb
+++ b/app/controllers/api/v1/releases/relationships/release_artifacts_controller.rb
@@ -9,8 +9,8 @@ module Api::V1::Releases::Relationships
 
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!, except: %i[index show]
-    before_action :authenticate_with_token, only: %i[index show]
+    before_action :authenticate!, except: %i[index show]
+    before_action :authenticate, only: %i[index show]
     before_action :set_release, only: %i[index show]
     before_action :set_artifact, only: %i[show]
 

--- a/app/controllers/api/v1/releases/relationships/release_entitlement_constraints_controller.rb
+++ b/app/controllers/api/v1/releases/relationships/release_entitlement_constraints_controller.rb
@@ -4,7 +4,7 @@ module Api::V1::Releases::Relationships
   class ReleaseEntitlementConstraintsController < Api::V1::BaseController
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
     before_action :set_release
 
     authorize :release

--- a/app/controllers/api/v1/releases/relationships/release_packages_controller.rb
+++ b/app/controllers/api/v1/releases/relationships/release_packages_controller.rb
@@ -4,8 +4,8 @@ module Api::V1::Releases::Relationships
   class ReleasePackagesController < Api::V1::BaseController
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!, except: %i[show]
-    before_action :authenticate_with_token, only: %i[show]
+    before_action :authenticate!, except: %i[show]
+    before_action :authenticate, only: %i[show]
     before_action :set_release
 
     authorize :release

--- a/app/controllers/api/v1/releases/relationships/upgrades_controller.rb
+++ b/app/controllers/api/v1/releases/relationships/upgrades_controller.rb
@@ -7,7 +7,7 @@ module Api::V1::Releases::Relationships
 
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token
+    before_action :authenticate
     before_action :set_release
 
     typed_query {

--- a/app/controllers/api/v1/releases/relationships/v1x0/release_artifacts_controller.rb
+++ b/app/controllers/api/v1/releases/relationships/v1x0/release_artifacts_controller.rb
@@ -4,8 +4,8 @@ module Api::V1::Releases::Relationships::V1x0
   class ReleaseArtifactsController < Api::V1::BaseController
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!, except: %i[show]
-    before_action :authenticate_with_token, only: %i[show]
+    before_action :authenticate!, except: %i[show]
+    before_action :authenticate, only: %i[show]
     before_action :set_release
 
     typed_query {

--- a/app/controllers/api/v1/releases_controller.rb
+++ b/app/controllers/api/v1/releases_controller.rb
@@ -20,8 +20,8 @@ module Api::V1
 
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!, except: %i[index show]
-    before_action :authenticate_with_token, only: %i[index show]
+    before_action :authenticate!, except: %i[index show]
+    before_action :authenticate, only: %i[index show]
     before_action :set_release, only: %i[show update destroy]
 
     def index

--- a/app/controllers/api/v1/request_logs/actions/counts_controller.rb
+++ b/app/controllers/api/v1/request_logs/actions/counts_controller.rb
@@ -4,7 +4,7 @@ module Api::V1::RequestLogs::Actions
   class CountsController < Api::V1::BaseController
     before_action :require_ee!
     before_action :scope_to_current_account!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
 
     def count
       authorize! with: RequestLogPolicy

--- a/app/controllers/api/v1/request_logs_controller.rb
+++ b/app/controllers/api/v1/request_logs_controller.rb
@@ -15,7 +15,7 @@ module Api::V1
     before_action :require_ee!
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
     before_action :set_request_log, only: [:show]
 
     def index

--- a/app/controllers/api/v1/searches_controller.rb
+++ b/app/controllers/api/v1/searches_controller.rb
@@ -21,7 +21,7 @@ module Api::V1
 
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
 
     typed_params {
       format :jsonapi

--- a/app/controllers/api/v1/tokens_controller.rb
+++ b/app/controllers/api/v1/tokens_controller.rb
@@ -10,7 +10,7 @@ module Api::V1
     before_action :scope_to_current_account!
     before_action :require_active_subscription!, only: %i[index regenerate regenerate_current]
     before_action :authenticate_with_password_or_token!, only: %i[generate]
-    before_action :authenticate_with_token!, except: %i[generate]
+    before_action :authenticate!, except: %i[generate]
     before_action :set_token, only: %i[show regenerate revoke]
 
     def index
@@ -64,7 +64,8 @@ module Api::V1
         end
       end
       param :meta, type: :hash, optional: true do
-        param :otp, type: :string
+        param :provider, type: :string, optional: true, inclusion: { in: %w[AppleOAuth GitHubOAuth GoogleOAUth MicrosoftOAuth] }
+        param :otp, type: :string, optional: true
       end
     }
     def generate
@@ -93,8 +94,6 @@ module Api::V1
       else
         render_unprocessable_resource token
       end
-    rescue ArgumentError # Catch null bytes (Postgres throws an argument error)
-      render_bad_request
     end
 
     # FIXME(ezekg) Deprecate this route.

--- a/app/controllers/api/v1/users/actions/bans_controller.rb
+++ b/app/controllers/api/v1/users/actions/bans_controller.rb
@@ -3,7 +3,7 @@
 module Api::V1::Users::Actions
   class BansController < Api::V1::BaseController
     before_action :scope_to_current_account!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
     before_action :set_user
 
     def ban

--- a/app/controllers/api/v1/users/actions/password_controller.rb
+++ b/app/controllers/api/v1/users/actions/password_controller.rb
@@ -3,7 +3,7 @@
 module Api::V1::Users::Actions
   class PasswordController < Api::V1::BaseController
     before_action :scope_to_current_account!
-    before_action :authenticate_with_token!, only: %i[update]
+    before_action :authenticate!, only: %i[update]
     before_action :set_user, only: %i[update reset]
 
     authorize :user

--- a/app/controllers/api/v1/users/relationships/groups_controller.rb
+++ b/app/controllers/api/v1/users/relationships/groups_controller.rb
@@ -4,7 +4,7 @@ module Api::V1::Users::Relationships
   class GroupsController < Api::V1::BaseController
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
     before_action :set_user
 
     authorize :user

--- a/app/controllers/api/v1/users/relationships/licenses_controller.rb
+++ b/app/controllers/api/v1/users/relationships/licenses_controller.rb
@@ -8,7 +8,7 @@ module Api::V1::Users::Relationships
 
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
     before_action :set_user
 
     authorize :user

--- a/app/controllers/api/v1/users/relationships/machines_controller.rb
+++ b/app/controllers/api/v1/users/relationships/machines_controller.rb
@@ -8,7 +8,7 @@ module Api::V1::Users::Relationships
 
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
     before_action :set_user
 
     authorize :user

--- a/app/controllers/api/v1/users/relationships/products_controller.rb
+++ b/app/controllers/api/v1/users/relationships/products_controller.rb
@@ -4,7 +4,7 @@ module Api::V1::Users::Relationships
   class ProductsController < Api::V1::BaseController
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
     before_action :set_user
 
     authorize :user

--- a/app/controllers/api/v1/users/relationships/second_factors_controller.rb
+++ b/app/controllers/api/v1/users/relationships/second_factors_controller.rb
@@ -4,7 +4,7 @@ module Api::V1::Users::Relationships
   class SecondFactorsController < Api::V1::BaseController
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
     before_action :set_user
 
     authorize :user

--- a/app/controllers/api/v1/users/relationships/tokens_controller.rb
+++ b/app/controllers/api/v1/users/relationships/tokens_controller.rb
@@ -4,7 +4,7 @@ module Api::V1::Users::Relationships
   class TokensController < Api::V1::BaseController
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
     before_action :set_user
 
     authorize :user

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -15,8 +15,8 @@ module Api::V1
 
     before_action :scope_to_current_account!
     before_action :require_active_subscription!, only: %i[index create destroy]
-    before_action :authenticate_with_token!, only: %i[index show update destroy]
-    before_action :authenticate_with_token, only: %i[create]
+    before_action :authenticate!, only: %i[index show update destroy]
+    before_action :authenticate, only: %i[create]
     before_action :set_user, only: %i[show update destroy]
 
     def index

--- a/app/controllers/api/v1/webhook_endpoints_controller.rb
+++ b/app/controllers/api/v1/webhook_endpoints_controller.rb
@@ -4,7 +4,7 @@ module Api::V1
   class WebhookEndpointsController < Api::V1::BaseController
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
     before_action :set_endpoint, only: [:show, :update, :destroy]
 
     def index

--- a/app/controllers/api/v1/webhook_events/actions/retries_controller.rb
+++ b/app/controllers/api/v1/webhook_events/actions/retries_controller.rb
@@ -4,7 +4,7 @@ module Api::V1::WebhookEvents::Actions
   class RetriesController < Api::V1::BaseController
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
     before_action :set_event
 
     def retry

--- a/app/controllers/api/v1/webhook_events_controller.rb
+++ b/app/controllers/api/v1/webhook_events_controller.rb
@@ -6,7 +6,7 @@ module Api::V1
 
     before_action :scope_to_current_account!
     before_action :require_active_subscription!
-    before_action :authenticate_with_token!
+    before_action :authenticate!
     before_action :set_event, only: [:show, :destroy]
 
     def index

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -385,6 +385,11 @@ class ApplicationController < ActionController::API
       e.code.present?
 
     render_bad_request(**kwargs)
+  rescue Keygen::Error::InvalidSingleSignOnError => e
+    Keygen.logger.warn { "[sso] code=#{e.code.inspect} message=#{e.message.inspect}" }
+
+    # we want to redirect to Portal to display the SSO error message in a helpful way
+    redirect_to portal_url('/sso/error', query: { error: e.message, code: e.code })
   rescue Keygen::Error::UnauthorizedError => e
     kwargs = { code: e.code }
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -394,16 +394,19 @@ class ApplicationController < ActionController::API
     kwargs[:source] = e.source if
       e.source.present?
 
+    kwargs[:links] = e.links if
+      e.links.present?
+
     # Add additional properties based on code
     case e.code
     when 'LICENSE_NOT_ALLOWED',
          'LICENSE_INVALID'
-      kwargs[:links] = { about: 'https://keygen.sh/docs/api/authentication/#license-authentication' }
+      kwargs.deep_merge(links: { about: docs_url('/docs/api/authentication/#license-authentication') })
     when 'TOKEN_NOT_ALLOWED',
          'TOKEN_INVALID'
-      kwargs[:links] = { about: 'https://keygen.sh/docs/api/authentication/#token-authentication' }
+      kwargs.deep_merge(links: { about: docs_url('/docs/api/authentication/#token-authentication') })
     when 'TOKEN_MISSING'
-      kwargs[:links] = { about: 'https://keygen.sh/docs/api/authentication/' }
+      kwargs.deep_merge(links: { about: docs_url('/docs/api/authentication/') })
     end
 
     render_unauthorized(**kwargs)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -401,12 +401,12 @@ class ApplicationController < ActionController::API
     case e.code
     when 'LICENSE_NOT_ALLOWED',
          'LICENSE_INVALID'
-      kwargs.deep_merge(links: { about: docs_url('/docs/api/authentication/#license-authentication') })
+      kwargs.deep_merge(links: { about: docs_url(:authentication, anchor: 'license-authentication') })
     when 'TOKEN_NOT_ALLOWED',
          'TOKEN_INVALID'
-      kwargs.deep_merge(links: { about: docs_url('/docs/api/authentication/#token-authentication') })
+      kwargs.deep_merge(links: { about: docs_url(:authentication, anchor: 'token-authentication') })
     when 'TOKEN_MISSING'
-      kwargs.deep_merge(links: { about: docs_url('/docs/api/authentication/') })
+      kwargs.deep_merge(links: { about: docs_url(:authentication) })
     end
 
     render_unauthorized(**kwargs)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -386,10 +386,10 @@ class ApplicationController < ActionController::API
 
     render_bad_request(**kwargs)
   rescue Keygen::Error::InvalidSingleSignOnError => e
-    Keygen.logger.warn { "[sso] code=#{e.code.inspect} message=#{e.message.inspect}" }
+    Keygen.logger.warn { "[sso] error=#{e.class.inspect} code=#{e.code.inspect} message=#{e.message.inspect}" }
 
     # we want to redirect to Portal to display the SSO error message in a helpful way
-    redirect_to portal_url('/sso/error', query: { error: e.message, code: e.code })
+    redirect_to portal_url('/sso/error', query: { code: e.code }), status: :see_other, allow_other_host: true
   rescue Keygen::Error::UnauthorizedError => e
     kwargs = { code: e.code }
 

--- a/app/controllers/auth/sso_controller.rb
+++ b/app/controllers/auth/sso_controller.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Auth
+  KEYGEN_PORTAL_HOST = ENV.fetch('KEYGEN_PORTAL_HOST') { 'portal.keygen.sh' }
+
+  class SsoController < Api::V1::BaseController
+    include ActionController::Cookies
+
+    skip_verify_authorized
+
+    typed_query {
+      param :state, type: :string, optional: true, allow_blank: true
+      param :code, type: :string
+    }
+    def callback
+      code, state = sso_query.values_at(:code, :state)
+      profile     = WorkOS::SSO.profile_and_token(client_id: WORKOS_CLIENT_ID, code:)
+                               .profile
+
+      # TODO(ezekg) error handling e.g. code is invalid, error callback,
+      #             failure to find/create user, etc.
+
+      account = Account.find_by!(sso_organization_id: profile.organization_id)
+      user    = account.users.find_or_create_by!(email: profile.email) do |u|
+        u.sso_profile_id = profile.id
+        u.sso_idp_id     = profile.idp_id
+        u.first_name     = profile.first_name
+        u.last_name      = profile.last_name
+
+        # TODO(ezekg) eventually implement workos groups?
+        u.grant_role! :admin
+      end
+
+      # Generate a nonce to assert that only 1 SSO-based session can be
+      # active for a user at any given time.
+      user.update!(session_nonce: SecureRandom.random_number(2**32))
+
+      # We use encrypted session cookies for SSO authentication because we
+      # don't want to expose a token in the redirect URL, and we don't
+      # want the token used for an API integration.
+      session[:nonce]      = user.session_nonce
+      session[:account_id] = account.id
+      session[:user_id]    = user.id
+
+      redirect_to portal_url(account), status: :temporary_redirect,
+                                       allow_other_host: true
+    end
+  end
+end

--- a/app/controllers/auth/sso_controller.rb
+++ b/app/controllers/auth/sso_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 module Auth
-  KEYGEN_PORTAL_HOST = ENV.fetch('KEYGEN_PORTAL_HOST') { 'portal.keygen.sh' }
-
   class SsoController < Api::V1::BaseController
     include ActionController::Cookies
 

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -121,6 +121,10 @@ module Authentication
     return nil if
       current_account.nil? || session.nil?
 
+    @current_http_scheme = :session
+    @current_http_token  = nil
+    @current_token       = nil
+
     user = current_account.users.for_environment(current_environment, strict: current_environment.nil?)
                                 .find_by(id: session[:user_id])
 

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -152,6 +152,12 @@ module Authentication
   end
 
   def http_password_authenticator(username = nil, password = nil)
+    if current_account.sso? && current_account.sso_organization_domains.any? { username.ends_with?(_1) } # for JIT-user-provisioning
+      redirect = Keygen::SSO.authorization_url(account: current_account, email: username)
+
+      raise Keygen::Error::SingleSignOnRequiredError.new(links: { redirect: })
+    end
+
     user = current_account.users.for_environment(current_environment, strict: current_environment.nil?)
                                 .find_by(email: "#{username}".downcase)
 

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -124,6 +124,8 @@ module Authentication
     user = current_account.users.for_environment(current_environment, strict: current_environment.nil?)
                                 .find_by(id: session[:user_id])
 
+    # Currently we only allow 1 session per-user, meaning if the session
+    # nonce doesn't match then the current session is outdated.
     unless user.present? && user.account_id == session[:account_id] &&
                             user.session_nonce == session[:nonce]
       session.destroy # clear cookie

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -166,13 +166,7 @@ module Authentication
     end
 
     if user.single_sign_on_enabled?
-      provider = params.dig(:meta, :provider)
-      redirect = WorkOS::SSO.authorization_url(
-        redirect_uri: sso_callback_url,
-        client_id: WORKOS_CLIENT_ID,
-        organization: current_account.sso_organization_id,
-        provider:,
-      )
+      redirect = Keygen::SSO.authorization_url(account: current_account, email: user.email)
 
       raise Keygen::Error::SingleSignOnRequiredError.new(links: { redirect: })
     end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -290,6 +290,14 @@ class Account < ApplicationRecord
   end
 
   def sso? = sso_organization_id?
+  def sso_for?(email)
+    return false if email.blank?
+
+    _, domain = email.downcase.match(/([^@]+)@(.+)/)
+                              .captures
+
+    domain.in?(sso_organization_domains)
+  end
 
   def status
     billing&.state&.upcase

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -289,6 +289,8 @@ class Account < ApplicationRecord
     protected
   end
 
+  def sso? = sso_organization_id?
+
   def status
     billing&.state&.upcase
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -470,7 +470,7 @@ class User < ApplicationRecord
     end
   end
 
-  def single_sign_on_enabled? = account.sso?
+  def single_sign_on_enabled? = !role.user? && account.sso?
 
   def second_factor_enabled?
     second_factors.enabled.exists?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -470,6 +470,8 @@ class User < ApplicationRecord
     end
   end
 
+  def single_sign_on_enabled? = account.sso?
+
   def second_factor_enabled?
     second_factors.enabled.exists?
   end

--- a/app/services/resolve_account_service.rb
+++ b/app/services/resolve_account_service.rb
@@ -12,6 +12,7 @@ class ResolveAccountService < BaseService
     case
     when Keygen.singleplayer?
       account_id = request.params[:account_id] ||
+                   request.session[:account_id] ||
                    ENV['KEYGEN_ACCOUNT_ID']
       raise Keygen::Error::InvalidAccountIdError, 'account is required' unless
         account_id.present?
@@ -22,7 +23,7 @@ class ResolveAccountService < BaseService
 
       account
     when Keygen.multiplayer?
-      account_id   = request.params[:account_id]
+      account_id   = request.params[:account_id] || request.session[:account_id]
       account_host = request.host
 
       account = find_by_account_cname(account_host) ||

--- a/config/application.rb
+++ b/config/application.rb
@@ -34,6 +34,17 @@ module Keygen
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
 
+    # Use cookies for sessions
+    config.session_store :cookie_store, key: '_keygen_session',
+      domain: ENV.fetch('KEYGEN_PORTAL_HOST') { 'portal.keygen.sh' },
+      expire_after: 1.day,
+      httponly: true,
+      secure: true
+
+    # Re-add session middleware since we're an API-only app
+    config.middleware.use ActionDispatch::Cookies
+    config.middleware.use config.session_store, config.session_options
+
     # Remove unneeded Rack middleware
     config.middleware.delete Rack::ConditionalGet
     config.middleware.delete Rack::ETag
@@ -92,6 +103,9 @@ module Keygen
 
     # FIXME(ezekg) Use 7.0 cache format until we can roll over to 7.1.
     config.active_support.cache_format_version 7.0
+
+    # Use SHA256 for signed cookies
+    config.action_dispatch.signed_cookie_digest = 'SHA256'
 
     # We don't need this: https://guides.rubyonrails.org/security.html#unsafe-query-generation
     config.action_dispatch.perform_deep_munge = false

--- a/config/application.rb
+++ b/config/application.rb
@@ -36,7 +36,7 @@ module Keygen
 
     # Use cookies for sessions
     config.session_store :cookie_store, key: '_keygen_session',
-      domain: ENV.fetch('KEYGEN_PORTAL_HOST') { 'portal.keygen.sh' },
+      domain: Keygen::PORTAL_HOST,
       expire_after: 1.day,
       httponly: true,
       secure: true

--- a/config/initializers/workos.rb
+++ b/config/initializers/workos.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+WORKOS_CLIENT_ID = ENV['WORKOS_CLIENT_ID']
+WORKOS_API_KEY   = ENV['WORKOS_API_KEY']
+
+WorkOS.configure do |config|
+  config.key = WORKOS_API_KEY
+end

--- a/config/initializers/zietwork.rb
+++ b/config/initializers/zietwork.rb
@@ -3,8 +3,11 @@
 Rails.autoloaders.each do |autoloader|
   # FIXME(ezekg) Should we rename these to follow conventions?
   autoloader.inflector.inflect(
-    "digest_io" => "DigestIO",
-    "jsonapi" => "JSONAPI",
-    "ee" => "EE",
+    'digest_io' => 'DigestIO',
+    'jsonapi'   => 'JSONAPI',
+    'ee'        => 'EE',
+    'ldap'      => 'LDAP',
+    'saml'      => 'SAML',
+    'sso'       => 'SSO',
   )
 end

--- a/config/initializers/zietwork.rb
+++ b/config/initializers/zietwork.rb
@@ -9,5 +9,7 @@ Rails.autoloaders.each do |autoloader|
     'ldap'      => 'LDAP',
     'saml'      => 'SAML',
     'sso'       => 'SSO',
+    'idp'       => 'IdP',
+    'sp'        => 'SP',
   )
 end

--- a/config/initializers/zietwork.rb
+++ b/config/initializers/zietwork.rb
@@ -11,5 +11,7 @@ Rails.autoloaders.each do |autoloader|
     'sso'       => 'SSO',
     'idp'       => 'IdP',
     'sp'        => 'SP',
+    'uri'       => 'URI',
+    'url'       => 'URL',
   )
 end

--- a/config/initializers/zietwork.rb
+++ b/config/initializers/zietwork.rb
@@ -4,14 +4,8 @@ Rails.autoloaders.each do |autoloader|
   # FIXME(ezekg) Should we rename these to follow conventions?
   autoloader.inflector.inflect(
     'digest_io' => 'DigestIO',
-    'jsonapi'   => 'JSONAPI',
-    'ee'        => 'EE',
-    'ldap'      => 'LDAP',
-    'saml'      => 'SAML',
-    'sso'       => 'SSO',
-    'idp'       => 'IdP',
-    'sp'        => 'SP',
-    'uri'       => 'URI',
-    'url'       => 'URL',
+    'jsonapi' => 'JSONAPI',
+    'ee' => 'EE',
+    'sso' => 'SSO',
   )
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -552,12 +552,12 @@ Rails.application.routes.draw do
 
   # Route helper for redirecting to Portal
   direct :portal do |segment, options|
-    Keygen::URL.portal_url(segment, **options)
+    Keygen.portal_url(segment, **options)
   end
 
   # Route helpers for redirecting to docs
   direct :docs do |segment, options|
-    Keygen::URL.docs_url(segment, **options)
+    Keygen.docs_url(segment, **options)
   end
 
   %w[500 503].each do |code|

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -551,25 +551,13 @@ Rails.application.routes.draw do
   end
 
   # Route helper for redirecting to Portal
-  direct :portal do |segment|
-    case segment
-    in Account => account
-      "https://portal.keygen.sh/#{account.slug}"
-    in String => path
-      "https://portal.keygen.sh/#{path}"
-    else
-      "https://portal.keygen.sh"
-    end
+  direct :portal do |segment, options|
+    Keygen::URL.portal_url(segment, **options)
   end
 
   # Route helpers for redirecting to docs
-  direct :docs do |segment|
-    case segment
-    in String => path
-      "https://keygen.sh/#{path}"
-    else
-      "https://keygen.sh"
-    end
+  direct :docs do |segment, options|
+    Keygen::URL.docs_url(segment, **options)
   end
 
   %w[500 503].each do |code|

--- a/db/migrate/20240712202229_add_sso_organization_id_to_accounts.rb
+++ b/db/migrate/20240712202229_add_sso_organization_id_to_accounts.rb
@@ -1,0 +1,8 @@
+class AddSsoOrganizationIdToAccounts < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    add_column :accounts, :sso_organization_id, :string, null: true
+    add_index :accounts, :sso_organization_id, unique: true, algorithm: :concurrently
+  end
+end

--- a/db/migrate/20240715164737_add_sso_profile_id_to_users.rb
+++ b/db/migrate/20240715164737_add_sso_profile_id_to_users.rb
@@ -1,0 +1,8 @@
+class AddSsoProfileIdToUsers < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    add_column :users, :sso_profile_id, :string, null: true
+    add_index :users, %i[account_id sso_profile_id], unique: true, algorithm: :concurrently
+  end
+end

--- a/db/migrate/20240715174443_add_sso_idp_id_to_users.rb
+++ b/db/migrate/20240715174443_add_sso_idp_id_to_users.rb
@@ -1,0 +1,8 @@
+class AddSsoIdpIdToUsers < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    add_column :users, :sso_idp_id, :string, null: true
+    add_index :users, %i[account_id sso_idp_id], unique: true, algorithm: :concurrently
+  end
+end

--- a/db/migrate/20240715210732_add_session_nonce_to_users.rb
+++ b/db/migrate/20240715210732_add_session_nonce_to_users.rb
@@ -1,0 +1,5 @@
+class AddSessionNonceToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :session_nonce, :integer, limit: 8
+  end
+end

--- a/db/migrate/20240716153309_add_sso_connection_id_to_users.rb
+++ b/db/migrate/20240716153309_add_sso_connection_id_to_users.rb
@@ -1,0 +1,7 @@
+class AddSsoConnectionIdToUsers < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    add_column :users, :sso_connection_id, :string, null: true
+  end
+end

--- a/db/migrate/20240716174322_add_sso_organization_domain_to_accounts.rb
+++ b/db/migrate/20240716174322_add_sso_organization_domain_to_accounts.rb
@@ -1,0 +1,5 @@
+class AddSsoOrganizationDomainToAccounts < ActiveRecord::Migration[7.1]
+  def change
+    add_column :accounts, :sso_organization_domains, :string, array: true, default: []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -40,6 +40,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_24_204821) do
     t.string "cname"
     t.string "backend"
     t.string "sso_organization_id"
+    t.string "sso_organization_domains", default: [], array: true
     t.index ["cname"], name: "index_accounts_on_cname", unique: true
     t.index ["created_at"], name: "index_accounts_on_created_at", order: :desc
     t.index ["domain"], name: "index_accounts_on_domain", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -39,6 +39,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_24_204821) do
     t.string "api_version"
     t.string "cname"
     t.string "backend"
+    t.string "sso_organization_id"
     t.index ["cname"], name: "index_accounts_on_cname", unique: true
     t.index ["created_at"], name: "index_accounts_on_created_at", order: :desc
     t.index ["domain"], name: "index_accounts_on_domain", unique: true
@@ -46,6 +47,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_24_204821) do
     t.index ["plan_id", "created_at"], name: "index_accounts_on_plan_id_and_created_at"
     t.index ["slug", "created_at"], name: "index_accounts_on_slug_and_created_at", unique: true
     t.index ["slug"], name: "index_accounts_on_slug", unique: true
+    t.index ["sso_organization_id"], name: "index_accounts_on_sso_organization_id", unique: true
     t.index ["subdomain"], name: "index_accounts_on_subdomain", unique: true
   end
 
@@ -794,11 +796,16 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_24_204821) do
     t.datetime "banned_at", precision: nil
     t.uuid "group_id"
     t.uuid "environment_id"
+    t.string "sso_profile_id"
+    t.string "sso_idp_id"
+    t.bigint "session_nonce"
     t.index "to_tsvector('simple'::regconfig, COALESCE((first_name)::text, ''::text))", name: "users_tsv_first_name_idx", using: :gist
     t.index "to_tsvector('simple'::regconfig, COALESCE((id)::text, ''::text))", name: "users_tsv_id_idx", using: :gist
     t.index "to_tsvector('simple'::regconfig, COALESCE((last_name)::text, ''::text))", name: "users_tsv_last_name_idx", using: :gist
     t.index "to_tsvector('simple'::regconfig, COALESCE((metadata)::text, ''::text))", name: "users_tsv_metadata_idx", using: :gist
     t.index ["account_id", "created_at"], name: "index_users_on_account_id_and_created_at"
+    t.index ["account_id", "sso_idp_id"], name: "index_users_on_account_id_and_sso_idp_id", unique: true
+    t.index ["account_id", "sso_profile_id"], name: "index_users_on_account_id_and_sso_profile_id", unique: true
     t.index ["banned_at"], name: "index_users_on_banned_at"
     t.index ["created_at"], name: "index_users_on_created_at", order: :desc
     t.index ["email", "account_id"], name: "index_users_on_email_and_account_id", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -799,6 +799,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_24_204821) do
     t.string "sso_profile_id"
     t.string "sso_idp_id"
     t.bigint "session_nonce"
+    t.string "sso_connection_id"
     t.index "to_tsvector('simple'::regconfig, COALESCE((first_name)::text, ''::text))", name: "users_tsv_first_name_idx", using: :gist
     t.index "to_tsvector('simple'::regconfig, COALESCE((id)::text, ''::text))", name: "users_tsv_id_idx", using: :gist
     t.index "to_tsvector('simple'::regconfig, COALESCE((last_name)::text, ''::text))", name: "users_tsv_last_name_idx", using: :gist

--- a/lib/keygen.rb
+++ b/lib/keygen.rb
@@ -10,6 +10,7 @@ require_relative 'keygen/version'
 require_relative 'keygen/portable_class'
 require_relative 'keygen/exporter'
 require_relative 'keygen/importer'
+require_relative 'keygen/url'
 
 module Keygen
   PUBLIC_KEY = %(\xB8\xF3\xEBL\xD2`\x13_g\xA5\tn\x8D\xC1\xC9\xB9\xDC\xB8\x1E\xE9\xFEP\xD1,\xDC\xD9A\xF6`z\x901).freeze

--- a/lib/keygen.rb
+++ b/lib/keygen.rb
@@ -10,6 +10,7 @@ require_relative 'keygen/version'
 require_relative 'keygen/portable_class'
 require_relative 'keygen/exporter'
 require_relative 'keygen/importer'
+require_relative 'keygen/sso'
 require_relative 'keygen/url'
 
 module Keygen

--- a/lib/keygen.rb
+++ b/lib/keygen.rb
@@ -11,9 +11,11 @@ require_relative 'keygen/portable_class'
 require_relative 'keygen/exporter'
 require_relative 'keygen/importer'
 require_relative 'keygen/sso'
-require_relative 'keygen/url'
+require_relative 'keygen/url_for'
 
 module Keygen
+  include UrlFor
+
   PUBLIC_KEY = %(\xB8\xF3\xEBL\xD2`\x13_g\xA5\tn\x8D\xC1\xC9\xB9\xDC\xB8\x1E\xE9\xFEP\xD1,\xDC\xD9A\xF6`z\x901).freeze
 
   class << self

--- a/lib/keygen/error.rb
+++ b/lib/keygen/error.rb
@@ -23,27 +23,27 @@ module Keygen
     end
 
     class InvalidCredentialsError < UnauthorizedError
-      def initialize(*, **) = super(detail: 'email and password must be valid', code: 'CREDENTIALS_INVALID', **)
+      def initialize(*, **) = super(*, detail: 'email and password must be valid', code: 'CREDENTIALS_INVALID', **)
     end
 
     class SingleSignOnRequiredError < UnauthorizedError
-      def initialize(*, **) = super(detail: 'single sign on is required', code: 'SSO_REQUIRED', **)
+      def initialize(*, **) = super(*, detail: 'single sign on is required', code: 'SSO_REQUIRED', **)
     end
 
     class InvalidSingleSignOnError < UnauthorizedError
-      def initialize(*, **) = super(detail: 'single sign on is invalid', code: 'SSO_INVALID', **)
+      def initialize(*, **) = super(*, detail: 'single sign on is invalid', code: 'SSO_INVALID', **)
     end
 
     class SecondFactorRequiredError < UnauthorizedError
-      def initialize(*, **) = super(detail: 'second factor is required', code: 'OTP_REQUIRED', **)
+      def initialize(*, **) = super(*, detail: 'second factor is required', code: 'OTP_REQUIRED', **)
     end
 
     class InvalidSecondFactorError < UnauthorizedError
-      def initialize(*, **) = super(detail: 'second factor must be valid', code: 'OTP_INVALID', **)
+      def initialize(*, **) = super(*, detail: 'second factor must be valid', code: 'OTP_INVALID', **)
     end
 
     class InvalidSessionError < UnauthorizedError
-      def initialize(*, **) = super(detail: 'session is invalid', code: 'SESSION_INVALID', **)
+      def initialize(*, **) = super(*, detail: 'session is invalid', code: 'SESSION_INVALID', **)
     end
 
     class ForbiddenError < JSONAPIError

--- a/lib/keygen/error.rb
+++ b/lib/keygen/error.rb
@@ -30,6 +30,10 @@ module Keygen
       def initialize(*, **) = super(detail: 'single sign on is required', code: 'SSO_REQUIRED', **)
     end
 
+    class InvalidSingleSignOnError < UnauthorizedError
+      def initialize(*, **) = super(detail: 'single sign on is invalid', code: 'SSO_INVALID', **)
+    end
+
     class SecondFactorRequiredError < UnauthorizedError
       def initialize(*, **) = super(detail: 'second factor is required', code: 'OTP_REQUIRED', **)
     end

--- a/lib/keygen/error.rb
+++ b/lib/keygen/error.rb
@@ -5,12 +5,14 @@ module Keygen
     class JSONAPIError < StandardError
       attr_reader :code,
                   :detail,
-                  :source
+                  :source,
+                  :links
 
-      def initialize(message, code: nil, detail: nil, parameter: nil, pointer: nil, header: nil)
+      def initialize(message, code: nil, detail: nil, parameter: nil, pointer: nil, header: nil, links: nil)
         @code   = code
         @detail = detail
         @source = { parameter:, pointer:, header: }.compact
+        @links  = links
 
         super(message)
       end
@@ -18,6 +20,26 @@ module Keygen
 
     class UnauthorizedError < JSONAPIError
       def initialize(message = 'is unauthorized', code:, **) = super(message, code:, **)
+    end
+
+    class InvalidCredentialsError < UnauthorizedError
+      def initialize(*, **) = super(detail: 'email and password must be valid', code: 'CREDENTIALS_INVALID', **)
+    end
+
+    class SingleSignOnRequiredError < UnauthorizedError
+      def initialize(*, **) = super(detail: 'single sign on is required', code: 'SSO_REQUIRED', **)
+    end
+
+    class SecondFactorRequiredError < UnauthorizedError
+      def initialize(*, **) = super(detail: 'second factor is required', code: 'OTP_REQUIRED', **)
+    end
+
+    class InvalidSecondFactorError < UnauthorizedError
+      def initialize(*, **) = super(detail: 'second factor must be valid', code: 'OTP_INVALID', **)
+    end
+
+    class InvalidSessionError < UnauthorizedError
+      def initialize(*, **) = super(detail: 'session is invalid', code: 'SESSION_INVALID', **)
     end
 
     class ForbiddenError < JSONAPIError

--- a/lib/keygen/sso.rb
+++ b/lib/keygen/sso.rb
@@ -99,10 +99,6 @@ module Keygen
                      .join('.')
 
         enc
-      rescue => e
-        Keygen.logger.error { "[sso.encrypt] Encrypt failed: err=#{e.message}" }
-
-        nil
       end
 
       def decrypt(ciphertext, secret_key:)
@@ -112,10 +108,6 @@ module Keygen
                           .join('--')
 
         crypt.decrypt_and_verify(enc)
-      rescue => e
-        Keygen.logger.warn { "[sso.decrypt] Decrypt failed: err=#{e.message}" }
-
-        nil
       end
 
       def derive_key(secret_key)

--- a/lib/keygen/sso.rb
+++ b/lib/keygen/sso.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+module Keygen
+  module SSO
+    class << self
+      def authorization_url(account:, email:, provider: nil)
+        state = { email: } # used to assert redeemer matches requestor
+
+        WorkOS::SSO.authorization_url(
+          client_id: WORKOS_CLIENT_ID,
+          organization: account.sso_organization_id,
+          state: encrypt(state, secret_key: account.secret_key),
+          redirect_uri:,
+          provider:,
+        )
+      end
+
+      # Redeem an authentication code for a user profile.
+      def redeem_code(code:)
+        WorkOS::SSO.profile_and_token(client_id: WORKOS_CLIENT_ID, code:)
+                   .profile
+      rescue WorkOS::APIError => e
+        raise Keygen::Error::InvalidSingleSignOnError.new(e.message)
+      end
+
+      # Lookup the account for a user profile.
+      def lookup_account(profile:)
+        Account.where.not(sso_organization_id: nil) # sanity-check
+                     .find_by!(
+                       sso_organization_id: profile.organization_id,
+                     )
+      rescue ActiveRecord::RecordNotFound
+        raise Keygen::Error::InvalidSingleSignOnError.new('account is invalid')
+      end
+
+      # WorkOS recommends JIT-user-provisioning: https://workos.com/docs/sso/jit-provisioning
+      #
+      # 1. First, we attempt to lookup the user by their profile ID.
+      # 2. Next, we attempt to lookup the user by their email.
+      # 3. Otherwise, initialize a new user.
+      #
+      # Lastly, we keep the user's attributes up-to-date.
+      def lookup_or_provision_user(profile:, account:, save: false, validate: false)
+        user = account.users.then do |users|
+          users.find_by(sso_profile_id: profile.id) || users.find_or_initialize_by(email: profile.email) do |u|
+            u.sso_profile_id    = profile.id
+            u.sso_connection_id = profile.connection_id
+            u.sso_idp_id        = profile.idp_id
+            u.first_name        = profile.first_name
+            u.last_name         = profile.last_name
+            u.email             = profile.email
+
+            # TODO(ezekg) eventually implement workos groups?
+            u.grant_role! :admin
+          end
+        end
+
+        # keep the user's attributes up-to-date with the IdP
+        user.assign_attributes(
+          sso_profile_id: profile.id,
+          sso_connection_id: profile.connection_id,
+          sso_idp_id: profile.idp_id,
+          first_name: profile.first_name,
+          last_name: profile.last_name,
+          email: profile.email,
+        )
+
+        user.save!(validate:) if save
+
+        user
+      end
+
+      def raise_on_request_error!(request)
+        if (code, message = request.query_parameters.values_at(:error, :error_description)).any?
+          raise Keygen::Error::InvalidSingleSignOnError.new(message, code: "SSO_#{code.upcase}")
+        end
+      end
+
+      def raise_on_state_error!(state, account:, profile:)
+        unless state.blank?
+          value = decrypt(state, secret_key: account.secret_key).with_indifferent_access
+
+          # assert the profile's email matches the email that initiated the authn
+          unless profile.email == value[:email]
+            raise Keygen::Error::InvalidSingleSignOnError.new('email is invalid')
+          end
+        end
+      end
+
+      private
+
+      def redirect_uri = Rails.application.routes.url_helpers.sso_callback_url
+
+      def encrypt(plaintext, secret_key:)
+        crypt = ActiveSupport::MessageEncryptor.new(derive_key(secret_key), serializer: JSON)
+        enc   = crypt.encrypt_and_sign(plaintext)
+                     .split('--')
+                     .map { |s| Base64.urlsafe_encode64(Base64.strict_decode64(s), padding: false) }
+                     .join('.')
+
+        enc
+      rescue => e
+        Keygen.logger.error { "[sso.encrypt] Encrypt failed: err=#{e.message}" }
+
+        nil
+      end
+
+      def decrypt(ciphertext, secret_key:)
+        crypt = ActiveSupport::MessageEncryptor.new(derive_key(secret_key), serializer: JSON)
+        enc   = ciphertext.split('.')
+                          .map { |s| Base64.strict_encode64(Base64.urlsafe_decode64(s)) }
+                          .join('--')
+
+        crypt.decrypt_and_verify(enc)
+      rescue => e
+        Keygen.logger.warn { "[sso.decrypt] Decrypt failed: err=#{e.message}" }
+
+        nil
+      end
+
+      def derive_key(secret_key)
+        keygen = ActiveSupport::KeyGenerator.new(secret_key)
+        salt   = 'sso'.freeze
+
+        keygen.generate_key(salt, 32)
+      end
+    end
+  end
+end

--- a/lib/keygen/url.rb
+++ b/lib/keygen/url.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Keygen
+  module URL
+    PORTAL_BASE_URL = 'https://portal.keygen.sh'.freeze
+    DOCS_BASE_URL   = 'https://keygen.sh/docs/api'.freeze
+
+    class << self
+      def portal_url(record_or_path = nil, **) = case record_or_path
+                                                 in Account => account
+                                                   url_for(PORTAL_BASE_URL, path: account.slug, **)
+                                                 in String | Symbol => path
+                                                   url_for(PORTAL_BASE_URL, path:, **)
+                                                 else
+                                                   url_for(PORTAL_BASE_URL, **)
+                                                 end
+
+      def docs_url(topic = nil, **) = url_for(DOCS_BASE_URL, trailing_slash: true, path: topic.presence, **)
+
+      private
+
+      def url_for(base_url, path: nil, query: nil, anchor: nil, trailing_slash: false)
+        url = URI.parse(base_url)
+
+        unless path.nil?
+          url.path += '/' unless path.to_s.starts_with?('/')
+          url.path += path.to_s
+          url.path += '/' if trailing_slash
+        end
+
+        url.query    = query.to_query unless query.nil?
+        url.fragment = anchor.to_s unless anchor.nil?
+
+        url.to_s
+      end
+    end
+  end
+end

--- a/lib/keygen/url_for.rb
+++ b/lib/keygen/url_for.rb
@@ -1,11 +1,14 @@
 # frozen_string_literal: true
 
 module Keygen
-  module URL
-    PORTAL_BASE_URL = 'https://portal.keygen.sh'.freeze
+  module UrlFor
+    extend ActiveSupport::Concern
+
+    PORTAL_HOST     = ENV.fetch('KEYGEN_PORTAL_HOST') { 'portal.keygen.sh' }.freeze
+    PORTAL_BASE_URL = "https://#{PORTAL_HOST}".freeze
     DOCS_BASE_URL   = 'https://keygen.sh/docs/api'.freeze
 
-    class << self
+    class_methods do
       def portal_url(record_or_path = nil, **) = case record_or_path
                                                  in Account => account
                                                    url_for(PORTAL_BASE_URL, path: account.slug, **)

--- a/spec/lib/union_of_spec.rb
+++ b/spec/lib/union_of_spec.rb
@@ -935,7 +935,10 @@ describe UnionOf do
           "users"."stdout_last_sent_at" AS t1_r12,
           "users"."banned_at" AS t1_r13,
           "users"."group_id" AS t1_r14,
-          "users"."environment_id" AS t1_r15
+          "users"."environment_id" AS t1_r15,
+          "users"."sso_profile_id" AS t1_r16,
+          "users"."sso_idp_id" AS t1_r17,
+          "users"."session_nonce" AS t1_r18
         FROM
           "licenses"
           LEFT OUTER JOIN "license_users" ON "license_users"."license_id" = "licenses"."id"
@@ -979,6 +982,9 @@ describe UnionOf do
           "users"."banned_at" AS t0_r13,
           "users"."group_id" AS t0_r14,
           "users"."environment_id" AS t0_r15,
+          "users"."sso_profile_id" AS t0_r16,
+          "users"."sso_idp_id" AS t0_r17,
+          "users"."session_nonce" AS t0_r18,
           "machines"."id" AS t1_r0,
           "machines"."fingerprint" AS t1_r1,
           "machines"."ip" AS t1_r2,

--- a/spec/lib/union_of_spec.rb
+++ b/spec/lib/union_of_spec.rb
@@ -938,7 +938,8 @@ describe UnionOf do
           "users"."environment_id" AS t1_r15,
           "users"."sso_profile_id" AS t1_r16,
           "users"."sso_idp_id" AS t1_r17,
-          "users"."session_nonce" AS t1_r18
+          "users"."session_nonce" AS t1_r18,
+          "users"."sso_connection_id" AS t1_r19
         FROM
           "licenses"
           LEFT OUTER JOIN "license_users" ON "license_users"."license_id" = "licenses"."id"
@@ -985,6 +986,7 @@ describe UnionOf do
           "users"."sso_profile_id" AS t0_r16,
           "users"."sso_idp_id" AS t0_r17,
           "users"."session_nonce" AS t0_r18,
+          "users"."sso_connection_id" AS t0_r19,
           "machines"."id" AS t1_r0,
           "machines"."fingerprint" AS t1_r1,
           "machines"."ip" AS t1_r2,


### PR DESCRIPTION
Closes #409. Implements SAML/SSO using [WorkOS](https://workos.com). Implements [JIT-provisioning](https://workos.com/docs/sso/jit-provisioning) for new users.

This includes support for the following:

- Google OAuth
- GitHub OAuth
- Microsoft OAuth
- Apple OAuth
- SAML

Each WorkOS connection costs us $125/mo, so this will be for Ent tiers only. Others can look into e.g. https://aglide.com.

Manual account setup right now, i.e. adding `sso_organization_id`, etc.:

```rb
account.update(
  sso_organization_domains: %w[example.com],
  sso_organization_id: 'org_123',
)
```

## Prereqs

- [ ] Write integration/unit tests for SSO.
- [ ] Write tests for session-based authentication.
- [ ] Third-party security review.

## Subreqs

- [ ] Update Keygen EE marketing pages to mention SSO.
- [ ] Add docs on new SSO-related error codes.
- [ ] Add docs on configuring SSO/SAML.
- [ ] Cut a new self-hosted release?
- [ ] Send Stdout 9.