### PR TITLE
Relicense to FCL

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,93 +1,120 @@
-# Elastic License 2.0 (ELv2)
+# Fair Core License, Version 1.0, Apache 2.0 Future License
 
-URL: https://www.elastic.co/licensing/elastic-license
+## Abbreviation
 
-## Acceptance
+FCL-1.0-Apache-2.0
 
-By using the software, you agree to all of the terms and conditions below.
+## Notice
 
-## Copyright License
+Copyright 2016-present Keygen LLC
 
-The licensor grants you a non-exclusive, royalty-free, worldwide,
-non-sublicensable, non-transferable license to use, copy, distribute, make
-available, and prepare derivative works of the software, in each case subject to
-the limitations and conditions below.
+## Terms and Conditions
 
-## Limitations
+### Licensor ("We")
 
-You may not provide the software to third parties as a hosted or managed
-service, where the service provides users with access to any substantial set of
-the features or functionality of the software.
+The party offering the Software under these Terms and Conditions.
 
-You may not move, change, disable, or circumvent the license key functionality
-in the software, and you may not remove or obscure any functionality in the
-software that is protected by the license key.
+### The Software
 
-You may not alter, remove, or obscure any licensing, copyright, or other notices
-of the licensor in the software. Any use of the licensor’s trademarks is subject
-to applicable law.
+The "Software" is each version of the software that we make available under
+these Terms and Conditions, as indicated by our inclusion of these Terms and
+Conditions with the Software.
 
-## Patents
+### License Grant
 
-The licensor grants you a license, under any patent claims the licensor can
-license, or becomes able to license, to make, have made, use, sell, offer for
-sale, import and have imported the software, in each case subject to the
-limitations and conditions in this license. This license does not cover any
-patent claims that you cause to be infringed by modifications or additions to
-the software. If you or your company make any written claim that the software
-infringes or contributes to infringement of any patent, your patent license for
-the software granted under these terms ends immediately. If your company makes
-such a claim, your patent license ends immediately for work on behalf of your
-company.
+Subject to your compliance with this License Grant and the Limitations,
+Patents, Redistribution and Trademark clauses below, we hereby grant you the
+right to use, copy, modify, create derivative works, publicly perform, publicly
+display and redistribute the Software for any Permitted Purpose identified
+below.
 
-## Notices
+### Permitted Purpose
 
-You must ensure that anyone who gets a copy of any part of the software from you
-also gets a copy of these terms.
+A Permitted Purpose is any purpose other than a Competing Use. A Competing Use
+means making the Software available to others in a commercial product or
+service that:
 
-If you modify the software, you must include in any modified copies of the
-software prominent notices stating that you have modified the software.
+1. substitutes for the Software;
 
-## No Other Rights
+2. substitutes for any other product or service we offer using the Software
+   that exists as of the date we make the Software available; or
 
-These terms do not imply any licenses other than those expressly granted in
-these terms.
+3. offers the same or substantially similar functionality as the Software.
 
-## Termination
+Permitted Purposes specifically include using the Software:
 
-If you use the software in violation of these terms, such use is not licensed,
-and your licenses will automatically terminate. If the licensor provides you
-with a notice of your violation, and you cease all violation of this license no
-later than 30 days after you receive that notice, your licenses will be
-reinstated retroactively. However, if you violate these terms after such
-reinstatement, any additional violation of these terms will cause your licenses
-to terminate automatically and permanently.
+1. for your internal use and access;
 
-## No Liability
+2. for non-commercial education;
 
-*As far as the law allows, the software comes as is, without any warranty or
-condition, and the licensor will not be liable to you for any damages arising
-out of these terms or the use or nature of the software, under any kind of
-legal claim.*
+3. for non-commercial research; and
 
-## Definitions
+4. in connection with professional services that you provide to a licensee
+   using the Software in accordance with these Terms and Conditions.
 
-The **licensor** is the entity offering these terms, and the **software** is the
-software the licensor makes available under these terms, including any portion
-of it.
+### Limitations
 
-**you** refers to the individual or entity agreeing to these terms.
+You must not move, change, disable, or circumvent the license key functionality
+in the Software; or modify any portion of the Software protected by the license
+key to:
 
-**your company** is any legal entity, sole proprietorship, or other kind of
-organization that you work for, plus all organizations that have control over,
-are under the control of, or are under common control with that
-organization. **control** means ownership of substantially all the assets of an
-entity, or the power to direct its management and policies by vote, contract, or
-otherwise. Control can be direct or indirect.
+1. enable access to the protected functionality without a valid license key; or
 
-**your licenses** are all the licenses granted to you for the software under
-these terms.
+2. remove the protected functionality.
 
-**use** means anything you do with the software requiring one of your licenses.
+### Patents
 
-**trademark** means trademarks, service marks, and similar rights.
+To the extent your use for a Permitted Purpose would necessarily infringe our
+patents, the license grant above includes a license under our patents. If you
+make a claim against any party that the Software infringes or contributes to
+the infringement of any patent, then your patent license to the Software ends
+immediately.
+
+### Redistribution
+
+The Terms and Conditions apply to all copies, modifications and derivatives of
+the Software.
+
+If you redistribute any copies, modifications or derivatives of the Software,
+you must include a copy of or a link to these Terms and Conditions and not
+remove any copyright or other proprietary notices provided in or with the
+Software.
+
+### Disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+
+IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+
+In the event the provision of this Disclaimer section is unenforceable under
+applicable law, the licenses granted herein are void.
+
+### Trademarks
+
+Except for displaying the License Details and identifying us as the origin of
+the Software, you have no right under these Terms and Conditions to use our
+trademarks, trade names, service marks or product names.
+
+## Grant of Future License
+
+We hereby irrevocably grant you an additional license to use the Software,
+under the Apache License, Version 2.0, that is effective on the second
+anniversary of the date we make the Software available. On or after that date,
+you may use the Software under the Apache License, Version 2.0, in which case
+the following will apply:
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 # Keygen
 
-Keygen is an open, source-available software licensing and distribution API, built
+Keygen is a fair source software licensing and distribution API, built
 for developers, by developers. Use Keygen to add license key validation,
 entitlements, and device activation to your business's desktop apps,
 server applications, on-premise software, and other products.
@@ -20,8 +20,8 @@ server applications, on-premise software, and other products.
 Keygen comes in two editions. Keygen CE is our Community Edition, and is
 free (as in beer) to self-host for personal and commercial use. Keygen
 EE is our Enterprise Edition, and it requires a license key to use.
-Keygen EE comes with dedicated support, as well as enterprise-grade features like request logs,
-audit logs, permissions, environments, and more.
+Keygen EE comes with dedicated support, as well as enterprise-grade features
+like request logs, audit logs, permissions, environments, and more.
 
 I built Keygen to make software licensing accessible to everyone.
 
@@ -35,15 +35,15 @@ product.
 Our managed hosting can save a substantial amount of developer time and
 resources. For most businesses, this ends up being the best value
 option and the revenue goes to funding the maintenance and further
-development of Keygen. So you’ll be supporting open source software
-and getting a great service!
+development of Keygen. So you’ll be supporting [Fair Source](https://fair.io)
+software and getting a great service!
 
 ## Self hosting with Keygen CE
 
-Keygen is an open, source-available software licensing and distribution API, and
-we have a free (as in beer) [self-hosted solution][self-hosting]. Keygen Community
-Edition is exactly the same code base as our managed solution, Keygen Cloud, but with
-a less frequent release schedule (think of it as an LTS release).
+Keygen is a fair source software licensing and distribution API, and we have a
+free (as in beer) [self-hosted solution][self-hosting]. Keygen Community
+Edition is exactly the same code base as our managed solution, Keygen Cloud,
+but with a less frequent release schedule (think of it as an LTS release).
 
 Bug fixes and new features are released to Keygen Cloud several times
 per week. Features are battle-tested in Keygen Cloud which allows us to fix
@@ -92,8 +92,9 @@ to the long-term sustainability of the project.
 
 Keygen CE is a community supported project and there are **no guarantees** that
 you will receive support from the creators of Keygen to troubleshoot your
-self-hosting issues. Keygen offers **best-effort** support for Keygen CE. There is [a community-supported Discord server][discord]
-and [a forum][forum] where you can ask for help with self-hosting.
+self-hosting issues. Keygen offers **best-effort** support for Keygen CE. There
+is [a community-supported Discord server][discord] and [a forum][forum] where
+you can ask for help with self-hosting.
 
 If you do need support guantantees, consider becoming a [Keygen Cloud][keygen-cloud]
 customer, or [purchasing Keygen EE][sales].
@@ -102,7 +103,8 @@ customer, or [purchasing Keygen EE][sales].
 
 ### Secrets
 
-To generate a [secret key](https://guides.rubyonrails.org/security.html) for the application, run:
+To generate a [secret key](https://guides.rubyonrails.org/security.html) for
+the application, run:
 
 ```bash
 export SECRET_KEY_BASE="$(openssl rand -hex 64)"
@@ -192,39 +194,60 @@ bundle exec rake test:rspec[spec/models]
 
 ## License
 
-Keygen is licensed under the [Elastic License 2.0 (ELv2)](https://github.com/keygen-sh/keygen-api/blob/master/LICENSE.md) license because it provides the best balance between freedom and protection. The ELv2 license is a permissive license that allows you to use, modify, and distribute Keygen as long as you follow a few simple rules:
+Keygen is licensed under the [Fair Core License](https://fcl.dev). The Fair
+Core License, or FCL, provides the best balance between user freedom and
+developer sustainability for a project like Keygen that monetizes via SaaS and
+self-hosting. The FCL is a mostly-permissive non-compete [Fair Source](https://fair.io)
+license that eventually contributes to Open Source after 2 years.
 
-1. **You may not provide Keygen's API to others as a managed service.** For example, you _cannot_ host Keygen yourself and sell it as a cloud-based licensing service, competing with Keygen Cloud. However, you _can_ sell a product that directly exposes and utilizes Keygen's API, as long as Keygen cannot be used outside of your product for other purposes (such as your customer using an embedded Keygen EE instance to license _their_ product in addition to _your_ product).
+The 2-year timeframe applies to each software version made available, whether
+through pushing a Git commit, tagging a release on GitHub, or publishing an
+image to Docker Hub. After 2 years, the code licensed under the FCL becomes
+Open Source under the Apache 2.0 license.
 
-1. **You may not circumvent the license key functionality or remove/obscure features protected by license keys.** For example, our code contains [license gates](https://github.com/keygen-sh/keygen-api/blob/ddbeed71543627fc15d37342c937e8bb4ef97157/app/models/environment.rb#L2) that unlock functionality for Keygen EE. You _cannot_ remove or change the licensing code to, for example, unlock a Keygen EE feature in Keygen CE.
+To obtain an Open Source version of Keygen, run the following:
 
-1. You may not alter, remove, or obscure any licensing, copyright, or other notices.
+```bash
+git clone https://github.com/keygen-sh/keygen-api && cd keygen-api
+git checkout `git rev-list -n 1 --before='2 years ago' master`
+```
 
-Anything else is fair game. There's no clause that requires you to open source modifications made to Keygen or other derivative works.
+If the `LICENSE.md` file is FCL, and that code is 2 years old, you may use that
+version under the Open Source terms of the change license, which is currently
+the Apache 2.0 license.
 
-You can self-host Keygen EE to license your enterprise application.
+You can...
 
-You can embed Keygen CE in your on-premise application.
+1. self-host Keygen EE to license your enterprise applications.
+2. embed Keygen CE in your on-premise applications.
+3. run Keygen CE on a private network.
+3. modify Keygen to add additional functionality.
+4. fork Keygen into a private repo.
 
-You can run Keygen CE on a private network.
+There's no clause that requires you to Open Source modifications made to Keygen
+or other derivative works.
 
-You can fork Keygen into a private repo.
-
-If the ELv2 license doesn't work for your company, please [reach out][sales].
+If the FCL happens to not work for your company or use-case, please [reach out][sales].
 
 The license is available [here](https://keygen.sh/license/).
 
 ## Contributing
 
-If you discover an issue, or are interested in a new feature, please open an issue. If you want to contribute code, feel free to open a pull request. If the PR is substantial, it may be beneficial to open an issue beforehand to discuss.
+If you discover an issue, or are interested in a new feature, please open an
+issue. If you want to contribute code, feel free to open a pull request. If the
+PR is substantial, it may be beneficial to open an issue beforehand to discuss.
 
 The CLA is available [here](https://keygen.sh/cla/).
 
 ## Security
 
-We take security at Keygen very seriously. We perform annual pen-tests on our code base and infrastructure. In addition, we regularly perform code audits. Our most recent pen-test was performed by [Greg Molnar](https://greg.molnar.io/security-consultancy/), an OSCP-certified security researcher in the Ruby and Rails community.
+We take security at Keygen very seriously. We perform annual pen-tests on our
+code base and infrastructure. In addition, we regularly perform code audits.
+Our most recent pen-test was performed by [Greg Molnar](https://greg.molnar.io/security-consultancy/),
+an OSCP-certified security researcher in the Ruby and Rails community.
 
-If you believe you've found a vulnerability, please see our [`SECURITY.md`](https://github.com/keygen-sh/keygen-api/blob/master/SECURITY.md) file.
+If you believe you've found a vulnerability, please see our [`SECURITY.md`](https://github.com/keygen-sh/keygen-api/blob/master/SECURITY.md)
+file.
 
 ## Is it any good?
 

--- a/app/mailers/stdout_mailer.rb
+++ b/app/mailers/stdout_mailer.rb
@@ -782,6 +782,82 @@ class StdoutMailer < ApplicationMailer
     )
   end
 
+  def issue_eight(subscriber:)
+    return if
+      subscriber.stdout_unsubscribed_at?
+
+    enc_email = encrypt(subscriber.email)
+    return if
+      enc_email.nil?
+
+    unsub_link = stdout_unsubscribe_url(enc_email, protocol: 'https', host: 'stdout.keygen.sh')
+    greeting   = if subscriber.first_name?
+                    "Hey, #{subscriber.first_name}"
+                  else
+                    'Hey'
+                  end
+
+    mail(
+      content_type: 'text/plain',
+      to: subscriber.email,
+      subject: "Keygen relicenses to the FCL",
+      body: <<~TXT
+        (You're receiving this email because you or your team signed up for a Keygen account. If you don't find this email useful, you can unsubscribe below.)
+
+          #{unsub_link}
+
+        --
+
+        Zeke here, founder and the man-behind-the-cogs at Keygen.
+
+        As some of you may remember: last year, Keygen went source-available under the Elastic License 2.0. This has gone great -- even better than I imagined! (All the fears I had for "flipping the switch" proved to be unwarranted.)
+
+        But over the past year, I've come to notice some problems with the ELv2 license, some i.r.t. ease-of-sale, and some i.r.t. user-freedoms. And I've also been noticing some other initiatives in the software licensing space that have had me... intrigued.
+
+        One of those initiatives was the Functional Source License by Sentry, which is a mostly-permissive non-compete Fair Source license that eventually transitions to Open Source after 2 years.
+
+        I really liked how this eventually-OSS model balanced developer-sustainability and user-freedoms, while eventually contributing to Open Source. I liked it so much that I really wanted to adopt it for Keygen.
+
+        But I couldn't safely adopt the FSL outright, because the FSL offers no protection for a project like Keygen that monetizes self-hosting. (I nixed the BUSL for the same reasons way back when.)
+
+        So I teamed up with Heather Meeker -- a prolific lawyer in the Open Source licensing space, who also helped draft both the FSL and ELv2 -- to draft a new license based on the FSL... the Fair Core License.
+
+        The FCL is a mostly-permissive non-compete Fair Source license that, like the FSL it's derived from, eventually transitions to Open Source after 2 years.
+
+        You can think of the FCL as the perfect blend of the FSL and the ELv2 -- perfect for projects monetizing both SaaS and self-hosting (e.g. Open Core).
+
+        With that -- I'm excited to announce that Keygen is relicensing from the ELv2 to the FCL! I believe this will be a big win for Keygen, its users, and ultimately for Open Source.
+
+        Under the FCL, new releases of Keygen will transition to Open Source under the Apache 2.0 change license after 2 years.
+
+        You can read the announcement post below, which hits on the above points a bit more:
+
+          https://keygen.sh/blog/keygen-is-now-fair-source/
+
+        You can read more about the FCL here:
+
+          https://fcl.dev
+
+        If you also run a project that monetizes self-hosting, consider adopting the FCL (and in doing so, become Fair Source).
+
+        In other news, we've (re)started work on Portal (yes -- *we!*). We'll have more to share soon, but I'm excited to have somebody else handling front-end at Keygen.
+
+        In other-other news, we've cut a new release of Keygen CE and EE, v1.3.0, that includes multi-user licensing. Check it out below:
+
+          https://github.com/keygen-sh/keygen-api/releases/tag/v1.3.0
+
+        Until next time.
+
+        --
+        Zeke, Founder <https://keygen.sh>
+
+        p.s. we broke 700 stars on GitHub! Star us if you haven't already: https://github.com/keygen-sh/keygen-api
+
+        p.p.s. if you're wondering what Fair Source is, peek: https://fair.io
+      TXT
+    )
+  end
+
   private
 
   def secret_key = ENV.fetch('STDOUT_SECRET_KEY')

--- a/app/mailers/stdout_mailer.rb
+++ b/app/mailers/stdout_mailer.rb
@@ -846,6 +846,8 @@ class StdoutMailer < ApplicationMailer
 
           https://github.com/keygen-sh/keygen-api/releases/tag/v1.3.0
 
+        We'll cut another release soon, licensed under FCL.
+
         Until next time.
 
         --

--- a/lib/tasks/keygen/stdout.rake
+++ b/lib/tasks/keygen/stdout.rake
@@ -37,7 +37,7 @@ namespace :keygen do
       end
 
       task eight: %i[environment] do
-        subscribers = User.stdout_subscribers
+        subscribers = User.stdout_subscribers(with_activity_from: 1.year.ago)
                           .where('stdout_last_sent_at IS NULL OR stdout_last_sent_at < ?', 7.days.ago)
                           .select(:id, :email, :first_name)
                           .reorder(:email, :created_at)

--- a/lib/tasks/keygen/stdout.rake
+++ b/lib/tasks/keygen/stdout.rake
@@ -33,20 +33,24 @@ namespace :keygen do
       end
 
       task seven: %i[environment] do
+        raise NotImplementedError, 'Stdout issue #7 has already been sent'
+      end
+
+      task eight: %i[environment] do
         subscribers = User.stdout_subscribers
                           .where('stdout_last_sent_at IS NULL OR stdout_last_sent_at < ?', 7.days.ago)
                           .select(:id, :email, :first_name)
                           .reorder(:email, :created_at)
                           .to_a
 
-        Keygen.logger.info "Sending issue #7 to #{subscribers.size} Stdout subscribers"
+        Keygen.logger.info "Sending issue #8 to #{subscribers.size} Stdout subscribers"
 
         subscribers.each do |subscriber|
           subscriber.touch(:stdout_last_sent_at)
 
-          Keygen.logger.info "Sending issue #7 to #{subscriber.email}"
+          Keygen.logger.info "Sending issue #8 to #{subscriber.email}"
 
-          StdoutMailer.issue_seven(subscriber:)
+          StdoutMailer.issue_eight(subscriber:)
                       .deliver_later(
                         # Fan out deliveries
                         in: rand(1.minute..3.hours),

--- a/spec/mailers/previews/stdout_mailer_preview.rb
+++ b/spec/mailers/previews/stdout_mailer_preview.rb
@@ -32,4 +32,8 @@ class StdoutMailerPreview < ActionMailer::Preview
   def issue_7
     StdoutMailer.issue_seven(subscriber: User.first)
   end
+
+  def issue_8
+    StdoutMailer.issue_eight(subscriber: User.first)
+  end
 end


### PR DESCRIPTION
Part of https://github.com/fairsource/fair.io/issues/14 and https://github.com/keygen-sh/keygen-web/pull/94. Relicensing from ELv2 to FCL.

## Prereqs

- [x] Update website to use FCL and Fair Source verbiage.
- [ ] Publish blog post on relicensing to FCL.
- [x] Launch website for FCL, https://fcl.dev.
- [x] Make repo for FCL public.

## Subreqs

- [ ] Send Stdout 8.
- [ ] Tweet.

Launch for Fair Source is [August ~~5th~~](https://github.com/fairsource/fair.io/issues/14#issuecomment-2228866203) [6th](https://github.com/fairsource/fair.io/issues/14#issuecomment-2240059340).