### PR TITLE
Add null plan to account using null object pattern

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -12,7 +12,7 @@ class Account < ApplicationRecord
   include Billable
 
   belongs_to :plan, optional: true, null_object: NullPlan.name
-  has_one :billing
+  has_one :billing, null_object: NullBilling.name
   has_many :environments, dependent: :destroy_async
   has_many :webhook_endpoints, dependent: :destroy_async
   has_many :webhook_events, dependent: :destroy_async
@@ -280,31 +280,10 @@ class Account < ApplicationRecord
     total_licensed_users
   end
 
-  def trialing_or_free?
-    return true if billing.nil?
-
-    return (billing.trialing? && billing.card.nil?) ||
-            plan.free?
-  end
-
-  def free?
-    return false if billing.nil?
-
-    plan.free?
-  end
-
-  def paid?
-    return false if billing.nil?
-
-    return (billing.active? || billing.card.present?) &&
-           plan.paid?
-  end
-
-  def ent?
-    return false if billing.nil?
-
-    return plan.ent?
-  end
+  def trialing_or_free? = (billing.trialing? && billing.card.nil?) || plan.free?
+  def paid?             = (billing.active? || billing.card.present?) && plan.paid?
+  def free?             = plan.free?
+  def ent?              = plan.ent?
 
   def protected?
     protected

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -2,7 +2,7 @@
 
 class Account < ApplicationRecord
   include Keygen::PortableClass
-  include NullAssociation::Macro
+  include NullAssociation::Concern
   include UnionOf::Macro
   include Welcomeable
   include Limitable

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -2,6 +2,7 @@
 
 class Account < ApplicationRecord
   include Keygen::PortableClass
+  include NullAssociation::Macro
   include UnionOf::Macro
   include Welcomeable
   include Limitable
@@ -10,7 +11,7 @@ class Account < ApplicationRecord
   include Pageable
   include Billable
 
-  belongs_to :plan, optional: true
+  belongs_to :plan, optional: true, null_object: NullPlan.name
   has_one :billing
   has_many :environments, dependent: :destroy_async
   has_many :webhook_endpoints, dependent: :destroy_async

--- a/app/models/concerns/billable.rb
+++ b/app/models/concerns/billable.rb
@@ -19,12 +19,7 @@ module Billable
       delegate "#{state}",  to: :billing, allow_nil: true
     end
 
-    def active?
-       # The only time this could happen is if Stripe hasn't sent us a "customer.created" event yet
-      return true if billing.nil?
-
-      billing.active?
-    end
+    def active? = billing.active?
   end
 
   def initialize_billing

--- a/app/models/null_billing.rb
+++ b/app/models/null_billing.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class NullBilling < NullObject
+  def subscribed? = true
+  def canceled?   = false
+  def trialing?   = false
+  def active?     = true
+  def card        = nil
+end

--- a/app/models/null_billing.rb
+++ b/app/models/null_billing.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class NullBilling < NullObject
+  def state       = 'subscribed'
   def subscribed? = true
   def canceled?   = false
   def trialing?   = false

--- a/app/models/null_object.rb
+++ b/app/models/null_object.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class NullObject
+  def present? = false
+  def blank?   = true
+  def nil?     = true
+end

--- a/app/models/null_plan.rb
+++ b/app/models/null_plan.rb
@@ -1,8 +1,15 @@
 # frozen_string_literal: true
 
 class NullPlan < NullObject
-  def name  = 'Null'
-  def free? = false
-  def paid? = true
-  def ent?  = true
+  def name         = 'Null'
+  def price        = 0
+  def max_products = nil
+  def max_policies = nil
+  def max_licenses = nil
+  def max_users    = nil
+  def max_admins   = nil
+  def max_reqs     = nil
+  def free?        = false
+  def paid?        = true
+  def ent?         = true
 end

--- a/app/models/null_plan.rb
+++ b/app/models/null_plan.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class NullPlan < NullAssociation::NullObject
+  def name  = 'Null'
+  def free? = false
+  def paid? = true
+  def ent?  = true
+end

--- a/app/models/null_plan.rb
+++ b/app/models/null_plan.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class NullPlan < NullAssociation::NullObject
+class NullPlan < NullObject
   def name  = 'Null'
   def free? = false
   def paid? = true

--- a/config/initializers/null_association.rb
+++ b/config/initializers/null_association.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require_dependency Rails.root / 'lib' / 'null_association'

--- a/db/seeds/development.rb
+++ b/db/seeds/development.rb
@@ -18,8 +18,6 @@ loop do
     domain  = Faker::Internet.unique.domain_name
     account = Account.create!(
       users_attributes: Array.new(rand(1..5)) {{ email: Faker::Internet.unique.email(domain:), password: Faker::Internet.password }},
-      billing_attributes: { state: %w[subscribed canceled].sample },
-      plan_attributes: { name: %w[Ent Std Dev].sample, price: 1 },
       name: Faker::Company.name,
     )
 

--- a/lib/null_association.rb
+++ b/lib/null_association.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module NullAssociation
+  class NullObject
+    def nil?                            = true # considered nil when asked
+    def respond_to_method_missing?(...) = true # respond to everything
+    def method_missing(...)             = nil
+  end
+
+  module Macro
+    extend ActiveSupport::Concern
+
+    class_methods do
+      def belongs_to(name, scope = nil, null_object: nil, **options, &extension)
+        return super(name, scope, **options, &extension) if null_object.nil?
+
+        unless options[:optional]
+          raise ArgumentError, 'must be :optional to use :null_object'
+        end
+
+        super(name, scope, **options, &extension)
+
+        null_class = case null_object
+                     in Class => klass
+                       klass
+                     in String => class_name
+                       class_name.classify.constantize
+                     else
+                       raise ArgumentError, 'invalid :null_object (expected class or string)'
+                     end
+
+        define_method name do
+          super().presence || null_class.new
+        end
+      end
+
+      def has_one(name, scope = nil, null_object: nil, **options, &extension)
+        return super(name, scope, **options, &extension) if null_object.nil?
+
+        super(name, scope, **options, &extension)
+
+        null_class = case null_object
+                     in Class => klass
+                       klass
+                     in String => class_name
+                       class_name.classify.constantize
+                     else
+                       raise ArgumentError, 'invalid :null_object (expected class or string)'
+                     end
+
+        define_method name do
+          super().presence || null_class.new
+        end
+      end
+    end
+  end
+end

--- a/lib/null_association.rb
+++ b/lib/null_association.rb
@@ -14,17 +14,8 @@ module NullAssociation
 
         super(name, scope, **options, &extension)
 
-        null_class = case null_object
-                     in Class => klass
-                       klass
-                     in String => class_name
-                       class_name.classify.constantize
-                     else
-                       raise ArgumentError, 'invalid :null_object (expected class or string)'
-                     end
-
         define_method name do
-          super().presence || null_class.new
+          super().presence || to_null_object(null_object)
         end
       end
 
@@ -33,17 +24,27 @@ module NullAssociation
 
         super(name, scope, **options, &extension)
 
-        null_class = case null_object
-                     in Class => klass
-                       klass
-                     in String => class_name
-                       class_name.classify.constantize
-                     else
-                       raise ArgumentError, 'invalid :null_object (expected class or string)'
-                     end
-
         define_method name do
-          super().presence || null_class.new
+          super().presence || to_null_object(null_object)
+        end
+      end
+    end
+
+    included do
+      def to_null_object(null_object)
+        case null_object
+        in String => class_name
+          class_name.classify.constantize.new
+        in Class => klass if klass < Singleton
+          klass.instance
+        in Singleton => singleton
+          singleton
+        in Class => klass
+          klass.new
+        in Object => instance
+          instance
+        else
+          nil
         end
       end
     end

--- a/lib/null_association.rb
+++ b/lib/null_association.rb
@@ -1,12 +1,6 @@
 # frozen_string_literal: true
 
 module NullAssociation
-  class NullObject
-    def nil?                            = true # considered nil when asked
-    def respond_to_method_missing?(...) = true # respond to everything
-    def method_missing(...)             = nil
-  end
-
   module Macro
     extend ActiveSupport::Concern
 

--- a/lib/null_association.rb
+++ b/lib/null_association.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module NullAssociation
-  module Macro
+  module Concern
     extend ActiveSupport::Concern
 
     class_methods do

--- a/lib/tasks/keygen/setup.rake
+++ b/lib/tasks/keygen/setup.rake
@@ -63,9 +63,7 @@ namespace :keygen do
         }
 
         account = Account.create!(
-          billing_attributes: { state: 'subscribed' },
           users_attributes: [{ email:, password: }],
-          plan_attributes: { name: 'Ent 0', price: 1 },
           protected: true,
           id:,
         )

--- a/lib/temporary_tables.rb
+++ b/lib/temporary_tables.rb
@@ -26,8 +26,8 @@ module TemporaryTables
 
         before do |example|
           klass = Class.new *base_class do
-                    define_method(:table_name) { table_name } unless table_name.nil?
-                    define_method(:name)       { class_name }
+                    define_singleton_method(:table_name) { table_name } unless table_name.nil?
+                    define_singleton_method(:name)       { class_name }
                   end
 
           unless extension.nil?

--- a/lib/temporary_tables.rb
+++ b/lib/temporary_tables.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module TemporaryTables
+  module Methods
+    extend ActiveSupport::Concern
+
+    class_methods do
+      def temporary_table(name, ...)
+        table_name = name.to_s.pluralize
+
+        before do
+          ActiveRecord::Migration.suppress_messages do
+            ActiveRecord::Migration.create_table(table_name, ...)
+          end
+        end
+
+        after do
+          ActiveRecord::Migration.suppress_messages do
+            ActiveRecord::Migration.drop_table(table_name, if_exists: true)
+          end
+        end
+      end
+
+      def temporary_model(name, table_name: name.to_s.pluralize, base_class: ActiveRecord::Base, &extension)
+        class_name = name.to_s.classify
+
+        before do
+          klass = Class.new *base_class do
+                    define_method(:table_name) { table_name } unless table_name.nil?
+                    define_method(:name)       { class_name }
+                  end
+
+          unless extension.nil?
+            klass.class_eval(&extension)
+          end
+
+          stub_const(class_name, klass)
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/null_association_spec.rb
+++ b/spec/lib/null_association_spec.rb
@@ -21,7 +21,7 @@ describe NullAssociation do
 
     context 'with a class' do
       temporary_model :tmp_account do
-        include NullAssociation::Macro
+        include NullAssociation::Concern
 
         belongs_to :tmp_plan, optional: true, null_object: TmpNullPlan
       end
@@ -41,7 +41,7 @@ describe NullAssociation do
 
     context 'with a string' do
       temporary_model :tmp_account do
-        include NullAssociation::Macro
+        include NullAssociation::Concern
 
         belongs_to :tmp_plan, optional: true, null_object: 'TmpNullPlan'
       end
@@ -65,7 +65,7 @@ describe NullAssociation do
       end
 
       temporary_model :tmp_account do
-        include NullAssociation::Macro
+        include NullAssociation::Concern
 
         belongs_to :tmp_plan, optional: true, null_object: TmpNullPlanSingleton.instance
       end
@@ -87,7 +87,7 @@ describe NullAssociation do
       let(:tmp_null_plan) { TmpNullPlan.new }
 
       temporary_model :tmp_account do |context|
-        include NullAssociation::Macro
+        include NullAssociation::Concern
 
         belongs_to :tmp_plan, optional: true, null_object: context.tmp_null_plan
       end
@@ -107,7 +107,7 @@ describe NullAssociation do
 
     context 'without :optional' do
       temporary_model :tmp_account do
-        include NullAssociation::Macro
+        include NullAssociation::Concern
       end
 
       it 'should raise' do
@@ -118,7 +118,7 @@ describe NullAssociation do
 
     context 'with :required' do
       temporary_model :tmp_account do
-        include NullAssociation::Macro
+        include NullAssociation::Concern
       end
 
       it 'should raise' do
@@ -143,7 +143,7 @@ describe NullAssociation do
 
     context 'with a class' do
       temporary_model :tmp_account do
-        include NullAssociation::Macro
+        include NullAssociation::Concern
 
         has_one :tmp_billing, null_object: TmpNullBilling
       end
@@ -163,7 +163,7 @@ describe NullAssociation do
 
     context 'with a string' do
       temporary_model :tmp_account do
-        include NullAssociation::Macro
+        include NullAssociation::Concern
 
         has_one :tmp_billing, null_object: 'TmpNullBilling'
       end
@@ -187,7 +187,7 @@ describe NullAssociation do
       end
 
       temporary_model :tmp_account do
-        include NullAssociation::Macro
+        include NullAssociation::Concern
 
         has_one :tmp_billing, null_object: TmpNullBillingSingleton.instance
       end
@@ -209,7 +209,7 @@ describe NullAssociation do
       let(:tmp_null_billing) { TmpNullBilling.new }
 
       temporary_model :tmp_account do |context|
-        include NullAssociation::Macro
+        include NullAssociation::Concern
 
         has_one :tmp_billing, null_object: context.tmp_null_billing
       end

--- a/spec/lib/null_association_spec.rb
+++ b/spec/lib/null_association_spec.rb
@@ -1,0 +1,205 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'spec_helper'
+
+require_dependency Rails.root / 'lib' / 'null_association'
+
+describe NullAssociation do
+  subject do
+    Class.new ActiveRecord::Base do
+      def self.table_name = 'accounts'
+      def self.name       = 'Account'
+
+      include NullAssociation::Macro
+    end
+  end
+
+  describe '.belongs_to' do
+    let(:null_plan_class) { NullPlan }
+    let(:plan_class)      { Plan }
+
+    context 'with a class' do
+      subject do
+        null_object = null_plan_class
+
+        super().tap do |klass|
+          klass.belongs_to :plan, optional: true, null_object:
+        end
+      end
+
+      it 'should return a null object for a nil association' do
+        instance = subject.new(plan: nil)
+
+        expect(instance.plan).to be_a null_plan_class
+      end
+
+      it 'should not return a null object for a present association' do
+        instance = subject.new(plan: plan_class.new)
+
+        expect(instance.plan).to be_a plan_class
+      end
+    end
+
+    context 'with a string' do
+      subject do
+        null_object = null_plan_class.name
+
+        super().tap do |klass|
+          klass.belongs_to :plan, optional: true, null_object:
+        end
+      end
+
+      it 'should return a null object for a nil association' do
+        instance = subject.new(plan: nil)
+
+        expect(instance.plan).to be_a null_plan_class
+      end
+
+      it 'should not return a null object for a present association' do
+        instance = subject.new(plan: plan_class.new)
+
+        expect(instance.plan).to be_a plan_class
+      end
+    end
+
+    # FIXME(ezekg) implement support for singletons?
+    context 'with a singleton' do
+      subject do
+        null_object = Class.new(null_plan_class) { include Singleton }
+                           .instance
+
+        super().tap do |klass|
+          klass.belongs_to :plan, optional: true, null_object:
+        end
+      end
+
+      it 'should raise' do
+        expect { subject }.to raise_error ArgumentError
+      end
+    end
+
+    # FIXME(ezekg) implement support for instances?
+    context 'with an instance' do
+      subject do
+        null_object = null_plan_class.new
+
+        super().tap do |klass|
+          klass.belongs_to :plan, optional: true, null_object:
+        end
+      end
+
+      it 'should raise' do
+        expect { subject }.to raise_error ArgumentError
+      end
+    end
+
+    context 'without :optional' do
+      subject do
+        null_object = null_plan_class
+
+        super().tap do |klass|
+          klass.belongs_to :plan, optional: false, null_object:
+        end
+      end
+
+      it 'should raise' do
+        expect { subject }.to raise_error ArgumentError
+      end
+    end
+
+    context 'with :required' do
+      subject do
+        null_object = null_plan_class
+
+        super().tap do |klass|
+          klass.belongs_to :plan, required: true, null_object:
+        end
+      end
+
+      it 'should raise' do
+        expect { subject }.to raise_error ArgumentError
+      end
+    end
+  end
+
+  describe '.has_one' do
+    let(:null_billing_class) { NullPlan } # FIXME(ezekg) NullBilling doesn't exist
+    let(:billing_class)      { Billing }
+
+    context 'with a class' do
+      subject do
+        null_object = null_billing_class
+
+        super().tap do |klass|
+          klass.has_one :billing, null_object:
+        end
+      end
+
+      it 'should return a null object for a nil association' do
+        instance = subject.new(billing: nil)
+
+        expect(instance.billing).to be_a null_billing_class
+      end
+
+      it 'should not return a null object for a present association' do
+        instance = subject.new(billing: billing_class.new)
+
+        expect(instance.billing).to be_a billing_class
+      end
+    end
+
+    context 'with a string' do
+      subject do
+        null_object = null_billing_class.name
+
+        super().tap do |klass|
+          klass.has_one :billing, null_object:
+        end
+      end
+
+      it 'should return a null object for a nil association' do
+        instance = subject.new(billing: nil)
+
+        expect(instance.billing).to be_a null_billing_class
+      end
+
+      it 'should not return a null object for a present association' do
+        instance = subject.new(billing: billing_class.new)
+
+        expect(instance.billing).to be_a billing_class
+      end
+    end
+
+    # FIXME(ezekg) implement support for singletons?
+    context 'with a singleton' do
+      subject do
+        null_object = Class.new(null_billing_class) { include Singleton }
+                           .instance
+
+        super().tap do |klass|
+          klass.has_one :billing, null_object:
+        end
+      end
+
+      it 'should raise' do
+        expect { subject }.to raise_error ArgumentError
+      end
+    end
+
+    # FIXME(ezekg) implement support for instances?
+    context 'with an instance' do
+      subject do
+        null_object = null_billing_class.new
+
+        super().tap do |klass|
+          klass.has_one :billing, null_object:
+        end
+      end
+
+      it 'should raise' do
+        expect { subject }.to raise_error ArgumentError
+      end
+    end
+  end
+end

--- a/spec/lib/null_association_spec.rb
+++ b/spec/lib/null_association_spec.rb
@@ -59,7 +59,6 @@ describe NullAssociation do
       end
     end
 
-    # FIXME(ezekg) implement support for singletons?
     context 'with a singleton' do
       temporary_model :tmp_null_plan_singleton, table_name: nil, base_class: nil do
         include Singleton
@@ -67,23 +66,42 @@ describe NullAssociation do
 
       temporary_model :tmp_account do
         include NullAssociation::Macro
+
+        belongs_to :tmp_plan, optional: true, null_object: TmpNullPlanSingleton.instance
       end
 
-      it 'should raise' do
-        expect { TmpAccount.belongs_to :tmp_plan, optional: true, null_object: TmpNullPlanSingleton.instance }
-          .to raise_error ArgumentError
+      it 'should return a null object singleton for a nil association' do
+        instance = TmpAccount.new(tmp_plan: nil)
+
+        expect(instance.tmp_plan).to eq TmpNullPlanSingleton.instance
+      end
+
+      it 'should not return a null object for a present association' do
+        instance = TmpAccount.new(tmp_plan: tmp_plan = TmpPlan.new)
+
+        expect(instance.tmp_plan).to eq tmp_plan
       end
     end
 
-    # FIXME(ezekg) implement support for instances?
     context 'with an instance' do
-      temporary_model :tmp_account do
+      let(:tmp_null_plan) { TmpNullPlan.new }
+
+      temporary_model :tmp_account do |context|
         include NullAssociation::Macro
+
+        belongs_to :tmp_plan, optional: true, null_object: context.tmp_null_plan
       end
 
-      it 'should raise' do
-        expect { TmpAccount.belongs_to :tmp_plan, optional: true, null_object: TmpNullPlan.new }
-          .to raise_error ArgumentError
+      it 'should return a null object instance for a nil association' do
+        instance = TmpAccount.new(tmp_plan: nil)
+
+        expect(instance.tmp_plan).to eq tmp_null_plan
+      end
+
+      it 'should not return a null object for a present association' do
+        instance = TmpAccount.new(tmp_plan: tmp_plan = TmpPlan.new)
+
+        expect(instance.tmp_plan).to eq tmp_plan
       end
     end
 
@@ -163,7 +181,6 @@ describe NullAssociation do
       end
     end
 
-    # FIXME(ezekg) implement support for singletons?
     context 'with a singleton' do
       temporary_model :tmp_null_billing_singleton, table_name: nil, base_class: nil do
         include Singleton
@@ -171,23 +188,42 @@ describe NullAssociation do
 
       temporary_model :tmp_account do
         include NullAssociation::Macro
+
+        has_one :tmp_billing, null_object: TmpNullBillingSingleton.instance
       end
 
-      it 'should raise' do
-        expect { TmpAccount.has_one :tmp_billing, null_object: TmpNullBillingSingleton.instance }
-          .to raise_error ArgumentError
+      it 'should return a null object singleton for a nil association' do
+        instance = TmpAccount.new(tmp_billing: nil)
+
+        expect(instance.tmp_billing).to eq TmpNullBillingSingleton.instance
+      end
+
+      it 'should not return a null object for a present association' do
+        instance = TmpAccount.new(tmp_billing: tmp_billing = TmpBilling.new)
+
+        expect(instance.tmp_billing).to eq tmp_billing
       end
     end
 
-    # FIXME(ezekg) implement support for instances?
     context 'with an instance' do
-      temporary_model :tmp_account do
+      let(:tmp_null_billing) { TmpNullBilling.new }
+
+      temporary_model :tmp_account do |context|
         include NullAssociation::Macro
+
+        has_one :tmp_billing, null_object: context.tmp_null_billing
       end
 
-      it 'should raise' do
-        expect { TmpAccount.has_one :tmp_billing, null_object: TmpNullBilling.new }
-          .to raise_error ArgumentError
+      it 'should return a null object instance for a nil association' do
+        instance = TmpAccount.new(tmp_billing: nil)
+
+        expect(instance.tmp_billing).to eq tmp_null_billing
+      end
+
+      it 'should not return a null object for a present association' do
+        instance = TmpAccount.new(tmp_billing: tmp_billing = TmpBilling.new)
+
+        expect(instance.tmp_billing).to eq tmp_billing
       end
     end
   end

--- a/spec/lib/temporary_tables_spec.rb
+++ b/spec/lib/temporary_tables_spec.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'spec_helper'
+
+require_dependency Rails.root / 'lib' / 'temporary_tables'
+
+describe TemporaryTables do
+  include TemporaryTables::Methods
+
+  describe '.temporary_table' do
+    temporary_table :tmp_records do |t|
+      t.string :name
+    end
+
+    # FIXME(ezekg) is there a better way to test this?
+    before :all do
+      expect(ActiveRecord::Base.connection.table_exists?(:tmp_records)).to be_falsey
+    end
+
+    it 'creates a temporary table' do
+      expect(ActiveRecord::Base.connection.table_exists?(:tmp_records)).to be_truthy
+    end
+
+    after :all do
+      expect(ActiveRecord::Base.connection.table_exists?(:tmp_records)).to be_falsey
+    end
+  end
+
+  describe '.temporary_model' do
+    describe 'ActiveRecord' do
+      temporary_table :tmp_records do |t|
+        t.string :name
+      end
+
+      temporary_model :tmp_record
+
+      before :all do
+        expect('TmpRecord'.safe_constantize).to be nil
+      end
+
+      it 'creates a temporary active record' do
+        expect(klass = 'TmpRecord'.safe_constantize).to_not be nil
+        expect(klass.table_name).to eq 'tmp_records'
+        expect(klass.name).to eq 'TmpRecord'
+        expect(record = klass.create).to be_an ActiveRecord::Base
+        expect(record.id).to be_an Integer
+        expect(instance = klass.new(name: 'test')).to be_an ActiveRecord::Base
+        expect(instance.name).to eq 'test'
+      end
+
+      after :all do
+        expect('TmpRecord'.safe_constantize).to be nil
+      end
+    end
+
+    describe 'ActiveModel' do
+      temporary_model :tmp_model, table_name: nil, base_class: nil do
+        include ActiveModel::Model, ActiveModel::Attributes, ActiveModel::API
+
+        attribute :name, :string
+      end
+
+      before :all do
+        expect('TmpModel'.safe_constantize).to be nil
+      end
+
+      it 'creates a temporary active model' do
+        expect(klass = 'TmpModel'.safe_constantize).to_not be nil
+        expect(klass.respond_to?(:table_name)).to be false
+        expect(klass.name).to eq 'TmpModel'
+        expect(instance = klass.new(name: 'test')).to be_an ActiveModel::Model
+        expect(instance.name).to eq 'test'
+      end
+
+      after :all do
+        expect('TmpModel'.safe_constantize).to be nil
+      end
+    end
+
+    describe 'PORO' do
+      temporary_model :tmp_model, table_name: nil, base_class: BasicObject do
+        attr_accessor :name
+
+        def initialize(name:) = @name = name
+
+        def kind_of?(_) = true
+      end
+
+      before :all do
+        expect('TmpModel'.safe_constantize).to be nil
+      end
+
+      it 'creates a temporary active model' do
+        expect(klass = 'TmpModel'.safe_constantize).to_not be nil
+        expect(klass.ancestors).to eq [TmpModel, BasicObject]
+        expect(klass.respond_to?(:table_name)).to be false
+        expect(klass.name).to eq 'TmpModel'
+        expect(instance = klass.new(name: 'test')).to be_a BasicObject
+        expect(instance.name).to eq 'test'
+      end
+
+      after :all do
+        expect('TmpModel'.safe_constantize).to be nil
+      end
+    end
+
+    describe 'context' do
+      let(:test_variable) { :test_value }
+
+      temporary_model :tmp_model, table_name: nil, base_class: nil do |context|
+        define_singleton_method(:test_method) { context.test_variable }
+      end
+
+      it 'accesses the example context' do
+        expect(TmpModel.test_method).to eq test_variable
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -45,6 +45,7 @@ RSpec.configure do |config|
   config.include ActiveSupport::Testing::TimeHelpers
   config.include ActiveJob::TestHelper
   config.include FactoryBot::Syntax::Methods
+  config.include TemporaryTables::Methods
   config.include Rails.application.routes.url_helpers
   config.include AuthorizationHelper, type: :policy
   config.include ApplicationHelper


### PR DESCRIPTION
Closes #865. Reserved the `null_association` gem name: https://rubygems.org/gems/null_association.

Also implements the `temporary_tables` gem, which we also have reserved.