### PR TITLE
fix typo in policy_entitlement_serializer.rb: polices -> policies

### DIFF
--- a/app/serializers/policy_entitlement_serializer.rb
+++ b/app/serializers/policy_entitlement_serializer.rb
@@ -49,7 +49,7 @@ class PolicyEntitlementSerializer < BaseSerializer
 
   relationship :policy do
     linkage always: true do
-      { type: :polices, id: @object.policy_id }
+      { type: :policies, id: @object.policy_id }
     end
     link :related do
       @url_helpers.v1_account_policy_path @object.account_id, @object.policy_id


### PR DESCRIPTION
This was caught by the test suite that I am writing for the Dart SDK for Keygen that I am writing