### PR TITLE
Add Rubygems release engine.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -100,6 +100,9 @@ gem 'lograge'
 gem 'aws-sdk-s3', '~> 1'
 gem 'semverse'
 
+# Rubygems release engine
+gem 'compact_index'
+
 # Misc
 gem 'null_association'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -135,6 +135,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    compact_index (0.15.0)
     concurrent-ruby (1.3.1)
     connection_pool (2.4.1)
     crack (0.4.5)
@@ -530,6 +531,7 @@ DEPENDENCIES
   bcrypt (~> 3.1.7)
   bullet (~> 7.1.6)
   byebug
+  compact_index
   cucumber-rails (~> 2.5)
   cuke_modeler (~> 3.19)
   database_cleaner (~> 2.0)

--- a/app/controllers/api/v1/release_engines/rubygems/specs_controller.rb
+++ b/app/controllers/api/v1/release_engines/rubygems/specs_controller.rb
@@ -1,0 +1,162 @@
+# frozen_string_literal: true
+
+require 'open-uri'
+require 'rubygems/package'
+require 'compact_index'
+
+module Api::V1::ReleaseEngines
+  class Rubygems::SpecsController < Api::V1::BaseController
+    before_action :scope_to_current_account!
+    before_action :require_active_subscription!
+    before_action :authenticate_with_token
+    before_action :set_release_package, only: %i[show info quick_gemspec]
+    before_action :set_artifact, only: %i[show quick_gemspec]
+
+    def index
+    end
+
+    def prerelease_specs
+      release_packages = authorized_scope(apply_scopes(current_account.release_packages.rubygems)).preload(releases: :channel)
+
+      authorize! release_packages, to: :index?
+
+      specs = release_packages.flat_map do |release_package|
+        release_package.releases.map do |release|
+          next if release.stable?
+
+          [release_package.key, Gem::Version.new(release.version), "ruby"]
+        end.compact
+      end
+
+      serve_gziped_specs(specs)
+    end
+
+    def specs
+      release_packages = authorized_scope(apply_scopes(current_account.release_packages.rubygems)).preload(:releases)
+
+      authorize! release_packages, to: :index?
+
+      specs = release_packages.flat_map do |release_package|
+        release_package.releases.map do |release|
+          next unless release.stable?
+
+          [reletease_package.key, Gem::Version.new(release.version), "ruby"]
+        end.compact
+      end
+
+      serve_gziped_specs(specs)
+    end
+
+    def latest_specs
+      release_packages = authorized_scope(apply_scopes(current_account.release_packages.rubygems)).preload(:ordered_releases)
+
+      authorize! release_packages, to: :index?
+
+      specs = release_packages.map do |release_package|
+        release = release_package.ordered_releases.first
+        next if !release || !release.stable?
+
+        [release_package.key, Gem::Version.new(release.version), "ruby"]
+      end.compact
+
+      serve_gziped_specs(specs)
+    end
+
+    def quick_gemspec
+      gemfile = open(artifact.download!.url)
+      spec_file = Gem::Package.new(gemfile).spec
+
+      serve_gziped_specs(spec_file)
+    end
+
+    def info
+      versions = release_package.releases.flat_map do |release|
+        release.artifacts.map do |artifact|
+          gemfile = open(artifact.download!.url)
+          spec_file = Gem::Package.new(gemfile).spec
+
+          dependencies = spec_file.dependencies.map do |dependency|
+            CompactIndex::Dependency.new(
+              dependency.name.to_s, dependency.requirement.to_s
+            )
+          end
+
+          CompactIndex::GemVersion.new(
+            spec_file.version.to_s, spec_file.platform.to_s, nil, nil, dependencies
+          )
+        end
+      end
+
+      render plain: CompactIndex.info(versions)
+    end
+
+    def versions
+      release_packages = authorized_scope(apply_scopes(current_account.release_packages.rubygems)).preload(:ordered_releases)
+
+      authorize! release_packages, to: :index?
+
+      packages = release_packages.map do |release_package|
+        versions = release_package.ordered_releases.reverse_each.map do |release|
+          CompactIndex::GemVersion.new(release.version, 'ruby')
+        end
+
+        CompactIndex::Gem.new(release_package.key, versions)
+      end
+
+      versions_file = CompactIndex::VersionsFile.new(Tempfile.new)
+      versions_file.create(packages)
+
+      render plain: CompactIndex.versions(versions_file)
+    end
+
+    def show
+      gemfile = open(artifact.download!.url)
+
+      send_data gemfile
+    end
+
+    private
+
+    attr_reader :artifact, :release_package
+
+    def set_release_package
+      package_key, _ = parse_package_name(params[:package])
+
+      @release_package = FindByAliasService.call(
+        authorized_scope(apply_scopes(current_account.release_packages.rubygems)).preload(:releases),
+        id: package_key,
+        aliases: :key,
+      )
+
+      authorize! @release_package
+    end
+
+    def set_artifact
+      _, version = parse_package_name(params[:package])
+
+      release = release_package.releases.find { |release| release.version == version }
+      render_not_found unless release
+
+      @artifact = release.artifacts.find { |artifact| artifact.filename.include?(params[:package]) }
+      render_not_found unless @artifact
+
+      authorize! @artifact
+    end
+
+    def parse_package_name(package)
+      package_key, _, version = package.partition(/-(?=\d)/)
+
+      [package_key, version]
+    end
+
+    def serve_gziped_specs(specs)
+      buffer = StringIO.new
+
+      Zlib::GzipWriter.wrap(buffer) do |gz|
+        gz.write(Marshal.dump(specs))
+      end
+
+      send_data(buffer.string)
+    end
+  end
+end

--- a/app/controllers/api/v1/release_packages_controller.rb
+++ b/app/controllers/api/v1/release_packages_controller.rb
@@ -32,7 +32,7 @@ module Api::V1
         param :attributes, type: :hash do
           param :name, type: :string
           param :key, type: :string
-          param :engine, type: :string, inclusion: { in: %w[pypi tauri] }, optional: true, allow_nil: true,
+          param :engine, type: :string, inclusion: { in: %w[pypi tauri rubygems] }, optional: true, allow_nil: true,
             transform: -> (_, key) {
               [:engine_attributes, { key: }]
             }

--- a/app/models/release_package.rb
+++ b/app/models/release_package.rb
@@ -19,6 +19,9 @@ class ReleasePackage < ApplicationRecord
   has_many :releases,
     inverse_of: :package,
     dependent: :destroy_async
+  has_many :ordered_releases,
+    -> { order_by_version },
+    class_name: "Release"
   has_many :artifacts,
     through: :releases,
     source: :artifacts
@@ -96,6 +99,7 @@ class ReleasePackage < ApplicationRecord
   scope :for_engine_key, -> key { joins(:engine).where(release_engines: { key: }) }
   scope :pypi,           ->     { for_engine_key('pypi') }
   scope :tauri,          ->     { for_engine_key('tauri') }
+  scope :rubygems,       ->     { for_engine_key('rubygems') }
 
   def engine_id? = release_engine_id?
   def engine_id  = release_engine_id

--- a/features/api/v1/engines/rubygems/specs.feature
+++ b/features/api/v1/engines/rubygems/specs.feature
@@ -1,0 +1,91 @@
+@api/v1
+Feature: Rubygems simple package index
+  Background:
+    Given the following "accounts" exist:
+      | name   | slug  |
+      | Test 1 | test1 |
+      | Test 2 | test2 |
+    And the current account is "test1"
+    And the current account has the following "product" rows:
+      | id                                   | name |
+      | 6198261a-48b5-4445-a045-9fed4afc7735 | Test |
+    And the current account has the following "package" rows:
+      | id                                   | product_id                           | engine   | key |
+      | 46e034fe-2312-40f8-bbeb-7d9957fb6fcf | 6198261a-48b5-4445-a045-9fed4afc7735 | rubygems | foo |
+      | 2f8af04a-2424-4ca2-8480-6efe24318d1a | 6198261a-48b5-4445-a045-9fed4afc7735 | rubygems | bar |
+      | 7b113ac2-ae81-406a-b44e-f356126e2faa | 6198261a-48b5-4445-a045-9fed4afc7735 | rubygems | baz |
+      | 5666d47e-936e-4d48-8dd7-382d32462b4e | 6198261a-48b5-4445-a045-9fed4afc7735 | npm      | qux |
+    And the current account has the following "release" rows:
+      | id                                   | product_id                           | release_package_id                   | version      | channel  |
+      | 757e0a41-835e-42ad-bad8-84cabd29c72a | 6198261a-48b5-4445-a045-9fed4afc7735 | 46e034fe-2312-40f8-bbeb-7d9957fb6fcf | 1.0.0        | stable   |
+      | 3ff04fc6-9f10-4b84-b548-eb40f92ea331 | 6198261a-48b5-4445-a045-9fed4afc7735 | 46e034fe-2312-40f8-bbeb-7d9957fb6fcf | 1.0.1        | stable   |
+      | 028a38a2-0d17-4871-acb8-c5e6f040fc12 | 6198261a-48b5-4445-a045-9fed4afc7735 | 46e034fe-2312-40f8-bbeb-7d9957fb6fcf | 1.1.0        | stable   |
+      | 972aa5b8-b12c-49f4-8ba4-7c9ae053dfa2 | 6198261a-48b5-4445-a045-9fed4afc7735 | 2f8af04a-2424-4ca2-8480-6efe24318d1a | 1.0.0-beta.1 | beta     |
+      | 28a6e16d-c2a6-4be7-8578-e236182ee5c3 | 6198261a-48b5-4445-a045-9fed4afc7735 | 7b113ac2-ae81-406a-b44e-f356126e2faa | 2.0.0        | stable   |
+      | 70c40946-4b23-408c-aa1c-fa35421ff46a | 6198261a-48b5-4445-a045-9fed4afc7735 |                                      | 1.1.0        | stable   |
+    And the current account has the following "artifact" rows:
+      | release_id                           | filename            | filetype |
+      | 757e0a41-835e-42ad-bad8-84cabd29c72a | foo-1.0.0.gem       | gem      |
+      | 3ff04fc6-9f10-4b84-b548-eb40f92ea331 | foo-1.0.1.gem       | gem      |
+      | 028a38a2-0d17-4871-acb8-c5e6f040fc12 | foo-1.1.0.gem       | gem      |
+      | 972aa5b8-b12c-49f4-8ba4-7c9ae053dfa2 | bar-1.0.0-beta1.gem | gem      |
+      | 28a6e16d-c2a6-4be7-8578-e236182ee5c3 | baz-2.0.0.gem       | gem      |
+      | 70c40946-4b23-408c-aa1c-fa35421ff46a | qux-1.1.0.gem       | gem      |
+    And I send the following raw headers:
+      """
+      User-Agent: Ruby, RubyGems/3.5.11 arm64-darwin-23 Ruby/3.3.4 (2024-07-09 patchlevel 94)
+      Accept: text/html
+      Content-Type: text/html
+      """
+
+  Scenario: Endpoint should be inaccessible when account is disabled
+    Given the account "test1" is canceled
+    And I am an admin of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/engines/rubygems/specs.4.8.gz"
+    Then the response status should be "403"
+    And the response should contain the following headers:
+      """
+      { "Content-Type": "text/html; charset=utf-8" }
+      """
+
+  Scenario: Endpoint should return gziped specs of released gems
+    Given I am an admin of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/engines/rubygems/specs.4.8.gz"
+    Then the response status should be "200"
+    And the response should contain gziped spec file with the following content:
+      """
+      [
+        ["foo", #<Gem::Version "1.0.0">, "ruby"],
+        ["foo", #<Gem::Version "1.0.1">, "ruby"],
+        ["foo", #<Gem::Version "1.1.0">, "ruby"],
+        ["baz", #<Gem::Version "2.0.0">, "ruby"]
+      ]
+      """
+
+  Scenario: Endpoint should return gziped latest specs of released gems
+    Given I am an admin of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/engines/rubygems/latest_specs.4.8.gz"
+    Then the response status should be "200"
+    And the response should contain gziped spec file with the following content:
+      """
+      [
+        ["foo", #<Gem::Version "1.1.0">, "ruby"],
+        ["baz", #<Gem::Version "2.0.0">, "ruby"]
+      ]
+      """
+
+  Scenario: Endpoint should return gziped specs of prereleased gems
+    Given I am an admin of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/engines/rubygems/prerelease_specs.4.8.gz"
+    Then the response status should be "200"
+    And the response should contain gziped spec file with the following content:
+      """
+      [
+        ["bar", #<Gem::Version "1.0.0.pre.beta.1">, "ruby"]
+      ]
+      """
+

--- a/features/step_definitions/request_steps.rb
+++ b/features/step_definitions/request_steps.rb
@@ -1226,6 +1226,13 @@ Then /^the response body should be an HTML document with the following xpaths:$/
   end
 end
 
+Then /^the response should contain gziped spec file with the following content:$/ do |content|
+  gz = Zlib::GzipReader.new(StringIO.new(last_response.body))
+  uncompressed_string = gz.read
+
+  expect(content.squish.delete(' ')).to eq(Marshal.load(uncompressed_string).to_s.squish.delete(' '))
+end
+
 Given /^the JSON data should be sorted by "([^\"]+)"$/ do |key|
   data = JSON.parse(last_response.body)
              .fetch('data')


### PR DESCRIPTION
@ezekg here's my a bit more than a POC of the Rubygems release engine. Would be great if you could take a look and see if that's something you like where it's going.

A couple of notes/questions:

- currently all the code is in controller. Even though it's a bit "fat" I think it still makes sense to keep it there without extracting it to some service. On the other hand it makes sense to extract it since it would be easier to write unit (acceptance?) tests for it but as far as I can see this project is mostly covered by system tests (cucumber features). Do you have a strong opinion about it?
- even though I've been testing it both with installing gem by `gem install` and by `bundle install` I had to comment out all authorization code to make it work since I was having issue with making it work with my data from seeds. Any tips on how can I ensure I have a list of releases that accessible by some user?
- how do you test artifacts in dev/test envs if this project uses S3 only without any fallback to filesystem? Do I need an S3 account for testing?

/claim #491