### PR TITLE
Move touched attributes into license model

### DIFF
--- a/app/models/license.rb
+++ b/app/models/license.rb
@@ -893,7 +893,7 @@ class License < ApplicationRecord
   # Set the last validated attributes for a license. This is used to store
   # temporary changes to the license that are not persisted to the database
   # until the license has been validated.
-  # @param attrs_hash [Hash] A hash of attributes to set
+  # @param [Hash] attrs_hash A hash of attributes to set
   def set_last_validated_attributes(**attrs_hash)
     last_validated_attributes_updates.merge!(attrs_hash)
   end


### PR DESCRIPTION
Hi Keygen :wave:

Last summer you responded to [a tweet that I wrote](https://x.com/keygen_sh/status/1797727382264250509), offering to refactor service objects into oblivion.

I have prepared some PRs that (I hope) will make the `LicenseValidationService` (your pet dragon) a lot easier to maintain.

---

- [PR 1: Extract touches from the service](https://github.com/keygen-sh/keygen-api/pull/927) <= you are here

This first PR extracts some of the behaviour from the license validation service into the license model. Specifically the attributes that are conditionally updated upon a successful validation check. 

I felt that this behaviour was a leaky abstraction that really belonged inside the license model.