### PR TITLE
Update authn error codes to determine flow

### DIFF
--- a/app/migrations/rename_credential_error_codes_for_token_migration.rb
+++ b/app/migrations/rename_credential_error_codes_for_token_migration.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class RenameCredentialErrorCodesForTokenMigration < BaseMigration
+  description %(renames the EMAIL/PASSWORD_REQUIRED, EMAIL/PASSWORD_INVALID and PASSWORD_NOT_SUPPORTED error codes to CREDENTIALS_INVALID when generating a new Token)
+
+  migrate if: -> body { body in errors: [*] } do |body|
+    case body
+    in errors: [*, { code: 'EMAIL_REQUIRED' | 'EMAIL_INVALID' | 'PASSWORD_REQUIRED' | 'PASSWORD_INVALID' | 'PASSWORD_NOT_SUPPORTED' }, *] => errs
+      errs.each do |err|
+        next unless
+          err in code: 'EMAIL_REQUIRED' | 'EMAIL_INVALID' | 'PASSWORD_REQUIRED' | 'PASSWORD_INVALID' | 'PASSWORD_NOT_SUPPORTED'
+
+        err.merge!(
+          detail: 'email and password must be valid',
+          code: 'CREDENTIALS_INVALID',
+        )
+      end
+    else
+    end
+  end
+
+  response if: -> res { res.status == 401 && res.request.params in controller: 'api/v1/tokens',
+                                                                   action: 'generate' } do |res|
+    body = JSON.parse(res.body, symbolize_names: true)
+
+    migrate!(body)
+
+    res.body = JSON.generate(body)
+  end
+end

--- a/app/validators/email_validator.rb
+++ b/app/validators/email_validator.rb
@@ -9,8 +9,6 @@ class EmailValidator < ActiveModel::EachValidator
   def self.valid?(value)
     return false if value.nil?
 
-    m = value =~ /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i
-
-    !m.nil?
+    value in EMAIL_RE
   end
 end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -140,10 +140,14 @@ unless ENV.key?('NO_RACK_ATTACK')
     next unless
       auth.present? && auth.starts_with?('Basic ')
 
-    dec   = Base64.decode64(auth.remove('Basic '))
-    email = dec.split(':', 2).first
+    dec      = Base64.decode64(auth.delete_prefix('Basic '))
+    email,
+    password = dec.split(':', 2)
+
+    # NOTE(ezekg) we're only rate limiting real authn attempts i.e. with a password
     next unless
-      email.present? && email.include?('@')
+      email.present? && email.include?('@') &&
+      password.present?
 
     hash = Digest::SHA2.hexdigest(email.to_s.downcase)
 

--- a/config/initializers/regexp.rb
+++ b/config/initializers/regexp.rb
@@ -19,3 +19,6 @@ BASE64_RE = /\A(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{4}|[A-Za-z0-9+\/]{3}=|[A-
 
 # used to check if a value is hex encoded
 HEX_RE = /\A(0x)?\p{Hex_Digit}+\z/
+
+# used to check if a value is an email
+EMAIL_RE = /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i

--- a/config/initializers/request_migrations.rb
+++ b/config/initializers/request_migrations.rb
@@ -18,6 +18,9 @@ RequestMigrations.configure do |config|
 
   config.current_version = CURRENT_API_VERSION
   config.versions        = {
+    '1.7' => %i[
+      rename_credential_error_codes_for_token_migration
+    ],
     '1.6' => %i[
       rename_process_leasing_strategy_to_leasing_strategy_for_policies_migration
       rename_process_leasing_strategy_to_leasing_strategy_for_policy_migration

--- a/features/api/v1/accounts/create.feature
+++ b/features/api/v1/accounts/create.feature
@@ -143,11 +143,11 @@ Feature: Create account
     Then the response status should be "201"
     And the response should contain the following headers:
       """
-      { "Keygen-Version": "1.7" }
+      { "Keygen-Version": "1.8" }
       """
     And the response body should be an "account" with the following attributes:
       """
-      { "apiVersion": "1.7" }
+      { "apiVersion": "1.8" }
       """
 
   Scenario: Anonymous creates an account (specific API version)

--- a/features/step_definitions/authentication_steps.rb
+++ b/features/step_definitions/authentication_steps.rb
@@ -90,7 +90,7 @@ Given /^I send the following headers:$/ do |body|
 
   # Base64 encode basic credentials
   if headers["Authorization"]&.starts_with? "Basic"
-    /Basic "([.@\w\d]+):(.+)"/ =~ headers["Authorization"]
+    /Basic "([.@\w\d]+):(.*)"/ =~ headers["Authorization"]
     credentials = Base64.encode64 "#{$1}:#{$2}"
     headers["Authorization"] = "Basic \"#{credentials}\""
   end
@@ -106,7 +106,7 @@ Given /^I send the following badly encoded headers:$/ do |body|
 
   # Base64 encode basic credentials
   if headers.key? "Authorization"
-    /Basic "([.@\w\d]+):(.+)"/ =~ headers["Authorization"]
+    /Basic "([.@\w\d]+):(.*)"/ =~ headers["Authorization"]
     credentials = Base64.encode64 "#{128.chr + $1}:#{128.chr + $2}"
     headers["Authorization"] = "Basic \"#{credentials}\""
   end

--- a/lib/keygen/version.rb
+++ b/lib/keygen/version.rb
@@ -3,7 +3,7 @@
 require_relative './logger'
 
 module Keygen
-  VERSION = '1.7.0'.freeze
+  VERSION = '1.8.0'.freeze
 
   module Version
     class << self

--- a/spec/migrations/rename_credential_error_codes_for_token_migration_spec.rb
+++ b/spec/migrations/rename_credential_error_codes_for_token_migration_spec.rb
@@ -1,0 +1,251 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'spec_helper'
+
+describe RenameCredentialErrorCodesForTokenMigration do
+  before do
+    RequestMigrations.configure do |config|
+      config.current_version = '1.0'
+      config.versions        = {
+        '1.0' => [RenameCredentialErrorCodesForTokenMigration],
+      }
+    end
+  end
+
+  context 'the errors contain an EMAIL_REQUIRED error code' do
+    it 'should migrate the error' do
+      migrator = RequestMigrations::Migrator.new(from: '1.0', to: '1.0')
+      data    = {
+        errors: [
+          {
+            title: 'Unauthorized',
+            detail: 'email is required',
+            code: 'EMAIL_REQUIRED'
+          },
+          {
+            title: 'Unprocessable resource',
+            detail: 'must be a valid iso8601 timestamp',
+            code: 'EXPIRY_INVALID',
+            source: {
+              pointer: '/data/attributes/expiry',
+            },
+          },
+        ],
+      }
+
+      migrator.migrate!(data:)
+
+      expect(data).to include(
+        errors: [
+          include(
+            detail: 'email and password must be valid',
+            code: 'CREDENTIALS_INVALID',
+          ),
+          include(
+            code: 'EXPIRY_INVALID',
+            source: {
+              pointer: '/data/attributes/expiry',
+            },
+          ),
+        ],
+      )
+    end
+  end
+
+  context 'the errors contain an EMAIL_INVALID error code' do
+    it 'should migrate the error' do
+      migrator = RequestMigrations::Migrator.new(from: '1.0', to: '1.0')
+      data    = {
+        errors: [
+          {
+            title: 'Unauthorized',
+            detail: 'email must be valid',
+            code: 'EMAIL_INVALID'
+          },
+          {
+            title: 'Unprocessable resource',
+            detail: 'must be a valid iso8601 timestamp',
+            code: 'EXPIRY_INVALID',
+            source: {
+              pointer: '/data/attributes/expiry',
+            },
+          },
+        ],
+      }
+
+      migrator.migrate!(data:)
+
+      expect(data).to include(
+        errors: [
+          include(
+            detail: 'email and password must be valid',
+            code: 'CREDENTIALS_INVALID',
+          ),
+          include(
+            code: 'EXPIRY_INVALID',
+            source: {
+              pointer: '/data/attributes/expiry',
+            },
+          ),
+        ],
+      )
+    end
+  end
+
+  context 'the errors contain a PASSWORD_REQUIRED error code' do
+    it 'should migrate the error' do
+      migrator = RequestMigrations::Migrator.new(from: '1.0', to: '1.0')
+      data    = {
+        errors: [
+          {
+            title: 'Unauthorized',
+            detail: 'password is required',
+            code: 'PASSWORD_REQUIRED'
+          },
+          {
+            title: 'Unprocessable resource',
+            detail: 'must be a valid iso8601 timestamp',
+            code: 'EXPIRY_INVALID',
+            source: {
+              pointer: '/data/attributes/expiry',
+            },
+          },
+        ],
+      }
+
+      migrator.migrate!(data:)
+
+      expect(data).to include(
+        errors: [
+          include(
+            detail: 'email and password must be valid',
+            code: 'CREDENTIALS_INVALID',
+          ),
+          include(
+            code: 'EXPIRY_INVALID',
+            source: {
+              pointer: '/data/attributes/expiry',
+            },
+          ),
+        ],
+      )
+    end
+  end
+
+  context 'the errors contain a PASSWORD_INVALID error code' do
+    it 'should migrate the error' do
+      migrator = RequestMigrations::Migrator.new(from: '1.0', to: '1.0')
+      data    = {
+        errors: [
+          {
+            title: 'Unauthorized',
+            detail: 'password must be valid',
+            code: 'PASSWORD_INVALID'
+          },
+          {
+            title: 'Unprocessable resource',
+            detail: 'must be a valid iso8601 timestamp',
+            code: 'EXPIRY_INVALID',
+            source: {
+              pointer: '/data/attributes/expiry',
+            },
+          },
+        ],
+      }
+
+      migrator.migrate!(data:)
+
+      expect(data).to include(
+        errors: [
+          include(
+            detail: 'email and password must be valid',
+            code: 'CREDENTIALS_INVALID',
+          ),
+          include(
+            code: 'EXPIRY_INVALID',
+            source: {
+              pointer: '/data/attributes/expiry',
+            },
+          ),
+        ],
+      )
+    end
+  end
+
+  context 'the errors contain a PASSWORD_NOT_SUPPORTED error code' do
+    it 'should migrate the error' do
+      migrator = RequestMigrations::Migrator.new(from: '1.0', to: '1.0')
+      data    = {
+        errors: [
+          {
+            title: 'Unauthorized',
+            detail: 'password is unsupported',
+            code: 'PASSWORD_NOT_SUPPORTED'
+          },
+          {
+            title: 'Unprocessable resource',
+            detail: 'must be a valid iso8601 timestamp',
+            code: 'EXPIRY_INVALID',
+            source: {
+              pointer: '/data/attributes/expiry',
+            },
+          },
+        ],
+      }
+
+      migrator.migrate!(data:)
+
+      expect(data).to include(
+        errors: [
+          include(
+            detail: 'email and password must be valid',
+            code: 'CREDENTIALS_INVALID',
+          ),
+          include(
+            code: 'EXPIRY_INVALID',
+            source: {
+              pointer: '/data/attributes/expiry',
+            },
+          ),
+        ],
+      )
+    end
+  end
+
+  context 'the errors do not contain any credential error codes' do
+    it 'should not migrate the error' do
+      migrator = RequestMigrations::Migrator.new(from: '1.0', to: '1.0')
+      data    = {
+        errors: [
+          {
+            title: 'Unprocessable resource',
+            detail: 'must be a valid iso8601 timestamp',
+            code: 'EXPIRY_INVALID',
+            source: {
+              pointer: '/data/attributes/expiry',
+            },
+          },
+        ],
+      }
+
+      migrator.migrate!(data:)
+
+      expect(data).to include(
+        errors: [
+          include(
+            code: 'EXPIRY_INVALID',
+            source: {
+              pointer: '/data/attributes/expiry',
+            },
+          ).and(
+            exclude(
+              detail: 'email and password must be valid',
+              code: 'CREDENTIALS_INVALID',
+            ),
+          ),
+        ],
+      )
+    end
+  end
+end


### PR DESCRIPTION
Follow up to #935. Prerequisite of #409.

We now allow an email to be provided without a password during authentication to determine a user's configured authn flow. We return a `PASSWORD_REQUIRED` error code when the user has a password set. We'll eventually add an `SSO_REQUIRED` error code in case the user has SSO enabled. No other changes to the authn flow.

Has migrations for backwards compat. Bumps API version to v1.8.