### PR TITLE
Add denormalized policy association to machines

### DIFF
--- a/app/controllers/api/v1/groups/relationships/machines_controller.rb
+++ b/app/controllers/api/v1/groups/relationships/machines_controller.rb
@@ -10,7 +10,7 @@ module Api::V1::Groups::Relationships
     authorize :group
 
     def index
-      machines = apply_pagination(authorized_scope(apply_scopes(group.machines), with: Groups::MachinePolicy).preload(:product, :policy, :owner, license: %i[owner]))
+      machines = apply_pagination(authorized_scope(apply_scopes(group.machines), with: Groups::MachinePolicy).preload(:product, :policy, :owner, license: %i[policy owner]))
       authorize! machines,
         with: Groups::MachinePolicy
 

--- a/app/controllers/api/v1/licenses/relationships/machines_controller.rb
+++ b/app/controllers/api/v1/licenses/relationships/machines_controller.rb
@@ -14,7 +14,7 @@ module Api::V1::Licenses::Relationships
     authorize :license
 
     def index
-      machines = apply_pagination(authorized_scope(apply_scopes(license.machines)).preload(:product, :policy, :owner, license: %i[owner]))
+      machines = apply_pagination(authorized_scope(apply_scopes(license.machines)).preload(:product, :policy, :owner, license: %i[policy owner]))
       authorize! machines,
         with: Licenses::MachinePolicy
 

--- a/app/controllers/api/v1/machines_controller.rb
+++ b/app/controllers/api/v1/machines_controller.rb
@@ -21,7 +21,7 @@ module Api::V1
     before_action :set_machine, only: [:show, :update, :destroy]
 
     def index
-      machines = apply_pagination(authorized_scope(apply_scopes(current_account.machines)).preload(:product, :policy, :owner, license: %i[owner]))
+      machines = apply_pagination(authorized_scope(apply_scopes(current_account.machines)).preload(:product, :policy, :owner, license: %i[policy owner]))
       authorize! machines
 
       render jsonapi: machines

--- a/app/controllers/api/v1/products/relationships/machines_controller.rb
+++ b/app/controllers/api/v1/products/relationships/machines_controller.rb
@@ -14,7 +14,7 @@ module Api::V1::Products::Relationships
     authorize :product
 
     def index
-      machines = apply_pagination(authorized_scope(apply_scopes(product.machines)).preload(:product, :policy, :owner, license: %i[owner]))
+      machines = apply_pagination(authorized_scope(apply_scopes(product.machines)).preload(:product, :policy, :owner, license: %i[policy owner]))
       authorize! machines,
         with: Products::MachinePolicy
 

--- a/app/controllers/api/v1/users/relationships/machines_controller.rb
+++ b/app/controllers/api/v1/users/relationships/machines_controller.rb
@@ -14,7 +14,7 @@ module Api::V1::Users::Relationships
     authorize :user
 
     def index
-      machines = apply_pagination(authorized_scope(apply_scopes(user.machines)).preload(:product, :policy, :owner, license: %i[owner]))
+      machines = apply_pagination(authorized_scope(apply_scopes(user.machines)).preload(:product, :policy, :owner, license: %i[policy owner]))
       authorize! machines,
         with: Users::MachinePolicy
 

--- a/app/models/license.rb
+++ b/app/models/license.rb
@@ -50,6 +50,8 @@ class License < ApplicationRecord
     ]
 
   denormalizes :product_id, from: :policy
+  denormalizes :policy_id, to: :machines
+
   encrypts :key,
     deterministic: true
 

--- a/app/models/machine_process.rb
+++ b/app/models/machine_process.rb
@@ -135,13 +135,13 @@ class MachineProcess < ApplicationRecord
   scope :for_owner,   -> id { joins(:owner).where(owner: { id: }) }
 
   scope :alive, -> {
-    joins(license: :policy).where(<<~SQL.squish, Time.current, HEARTBEAT_TTL.to_i)
+    joins(:policy).where(<<~SQL.squish, Time.current, HEARTBEAT_TTL.to_i)
       machine_processes.last_heartbeat_at >= ?::timestamp - INTERVAL '1 second' * COALESCE(policies.heartbeat_duration, ?)
     SQL
   }
 
   scope :dead, -> {
-    joins(license: :policy).where(<<~SQL.squish, Time.current, HEARTBEAT_TTL.to_i)
+    joins(:policy).where(<<~SQL.squish, Time.current, HEARTBEAT_TTL.to_i)
       machine_processes.last_heartbeat_at < ?::timestamp - INTERVAL '1 second' * COALESCE(policies.heartbeat_duration, ?)
     SQL
   }

--- a/app/models/policy.rb
+++ b/app/models/policy.rb
@@ -143,7 +143,7 @@ class Policy < ApplicationRecord
   belongs_to :product
   has_many :licenses, dependent: :destroy_async
   has_many :users, -> { distinct.reorder("#{table_name}.created_at": DEFAULT_SORT_ORDER) }, through: :licenses
-  has_many :machines, through: :licenses
+  has_many :machines, dependent: :destroy_async
   has_many :pool, class_name: "Key", dependent: :destroy_async
   has_many :policy_entitlements, dependent: :delete_all
   has_many :entitlements, through: :policy_entitlements

--- a/app/workers/cull_dead_machines_worker.rb
+++ b/app/workers/cull_dead_machines_worker.rb
@@ -5,7 +5,7 @@ class CullDeadMachinesWorker < BaseWorker
                   cronitor_disabled: false
 
   def perform
-    machines = Machine.joins(license: :policy)
+    machines = Machine.joins(:policy)
                       .where.not(policies: { heartbeat_cull_strategy: 'ALWAYS_REVIVE' })
                       .where(heartbeat_jid: nil)
                       .dead

--- a/app/workers/cull_dead_processes_worker.rb
+++ b/app/workers/cull_dead_processes_worker.rb
@@ -5,7 +5,7 @@ class CullDeadProcessesWorker < BaseWorker
                   cronitor_disabled: false
 
   def perform
-    processes = MachineProcess.joins(license: :policy)
+    processes = MachineProcess.joins(:policy)
                               .where.not(policies: { heartbeat_cull_strategy: 'ALWAYS_REVIVE' })
                               .where(heartbeat_jid: nil)
                               .dead

--- a/db/migrate/20250404171439_add_policy_to_machines.rb
+++ b/db/migrate/20250404171439_add_policy_to_machines.rb
@@ -1,0 +1,10 @@
+class AddPolicyToMachines < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+  verbose!
+
+  def change
+    add_column :machines, :policy_id, :uuid, null: true, if_not_exists: true
+
+    add_index :machines, :policy_id, algorithm: :concurrently, if_not_exists: true
+  end
+end

--- a/db/migrate/20250404171451_denormalize_policy_for_machines.rb
+++ b/db/migrate/20250404171451_denormalize_policy_for_machines.rb
@@ -1,0 +1,73 @@
+class DenormalizePolicyForMachines < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+  verbose!
+
+  BATCH_SIZE = 10_000
+
+  def up
+    update_count = nil
+    batch_count  = 0
+
+    until update_count == 0
+      batch_count  += 1
+      update_count  = exec_update(<<~SQL.squish, batch_count:, batch_size: BATCH_SIZE)
+        WITH batch AS (
+          SELECT
+            machines.id AS machine_id,
+            licenses.policy_id
+          FROM
+            machines
+            INNER JOIN licenses ON licenses.id = machines.license_id
+          WHERE
+            machines.policy_id IS NULL
+          LIMIT
+            :batch_size
+        )
+        UPDATE
+          machines
+        SET
+          policy_id = batch.policy_id
+        FROM
+          batch
+        WHERE
+          machines.id = batch.machine_id
+        /* batch=:batch_count */
+      SQL
+    end
+  end
+
+  def down
+    update_count = nil
+    batch_count  = 0
+
+    until update_count == 0
+      batch_count  += 1
+      update_count  = exec_update(<<~SQL.squish, batch_count:, batch_size: BATCH_SIZE)
+        UPDATE
+          machines
+        SET
+          policy_id = NULL
+        WHERE
+          machines.id IN (
+            SELECT
+              machines.id
+            FROM
+              machines
+            WHERE
+              machines.policy_id IS NOT NULL
+            LIMIT
+              :batch_size
+          )
+        /* batch=:batch_count */
+      SQL
+    end
+  end
+
+  private
+
+  def exec_update(sql, **binds)
+    ActiveRecord::Base.connection.exec_update(
+      ActiveRecord::Base.sanitize_sql([sql, **binds]),
+    )
+  end
+end

--- a/db/migrate/20250407173652_add_heartbeat_cull_indexes_to_policies.rb
+++ b/db/migrate/20250407173652_add_heartbeat_cull_indexes_to_policies.rb
@@ -1,0 +1,9 @@
+class AddHeartbeatCullIndexesToPolicies < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+  verbose!
+
+  def change
+    add_index :policies, :heartbeat_cull_strategy, algorithm: :concurrently
+    add_index :policies, :require_heartbeat, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_04_04_171451) do
+ActiveRecord::Schema[7.2].define(version: 2025_04_07_173652) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_stat_statements"
@@ -447,8 +447,10 @@ ActiveRecord::Schema[7.2].define(version: 2025_04_04_171451) do
     t.index ["account_id", "created_at"], name: "index_policies_on_account_id_and_created_at"
     t.index ["created_at"], name: "index_policies_on_created_at", order: :desc
     t.index ["environment_id"], name: "index_policies_on_environment_id"
+    t.index ["heartbeat_cull_strategy"], name: "index_policies_on_heartbeat_cull_strategy"
     t.index ["id", "created_at", "account_id"], name: "index_policies_on_id_and_created_at_and_account_id", unique: true
     t.index ["product_id", "created_at"], name: "index_policies_on_product_id_and_created_at"
+    t.index ["require_heartbeat"], name: "index_policies_on_require_heartbeat"
   end
 
   create_table "policy_entitlements", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_04_03_140401) do
+ActiveRecord::Schema[7.2].define(version: 2025_04_04_171451) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_stat_statements"
@@ -320,6 +320,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_04_03_140401) do
     t.uuid "environment_id"
     t.string "heartbeat_jid"
     t.uuid "owner_id"
+    t.uuid "policy_id"
     t.index "license_id, md5((fingerprint)::text)", name: "machines_license_id_fingerprint_unique_idx", unique: true
     t.index "to_tsvector('simple'::regconfig, COALESCE((id)::text, ''::text))", name: "machines_tsv_id_idx", using: :gist
     t.index "to_tsvector('simple'::regconfig, COALESCE((metadata)::text, ''::text))", name: "machines_tsv_metadata_idx", using: :gist
@@ -334,6 +335,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_04_03_140401) do
     t.index ["last_heartbeat_at"], name: "index_machines_on_last_heartbeat_at"
     t.index ["license_id", "created_at"], name: "index_machines_on_license_id_and_created_at"
     t.index ["owner_id"], name: "index_machines_on_owner_id"
+    t.index ["policy_id"], name: "index_machines_on_policy_id"
   end
 
   create_table "metrics", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|


### PR DESCRIPTION
With more and more accounts utilizing machine heartbeats, we're starting to see slow queries for [the cull crons](https://github.com/keygen-sh/keygen-api/blob/master/app/workers/cull_dead_machines_worker.rb) because we have to join across licenses in order to get a machine's heartbeat duration from its policy. I've tried really hard to optimize that query, but there doesn't really seem to be a good way to do that due to table size. This issue will continue to get worse since culling is run every 2 minutes. Rather than try to move `next_heartbeat_at` from a virtual attribute to a column — and keep that in sync across policy changes — I decided to simply denormalize the policy onto the machine.

## Subreqs

- [ ] Run `VACUUM ANALYZE machines`.