### PR TITLE
Add note about lowercase format requirement for KEYGEN_ACCOUNT_ID in .env.sample

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -62,6 +62,7 @@ KEYGEN_MODE=singleplayer
 # The account ID used for setting the tenant of Keygen in singleplayer mode.
 # Use `uuidgen` or `cat /proc/sys/kernel/random/uuid` to set a pre-determined ID.
 # Required in singleplayer mode.
+# Note: The account ID must be in lowercase format.
 KEYGEN_ACCOUNT_ID=
 
 # The admin email used during setup. Must be a valid email address for your organization.


### PR DESCRIPTION
# Motivation

While setting up a self-hosted Keygen server, I found that using a UUID generated with `uuidgen` (which outputs uppercase by default) causes API requests to fail with an account is invalid error. Converting the UUID to lowercase resolves the issue.

To prevent this confusion for future users, I propose adding a note to the .env.sample file to clearly state that KEYGEN_ACCOUNT_ID must be in lowercase format.

## Changes
- Added a note in .env.sample to indicate that KEYGEN_ACCOUNT_ID must be in lowercase format.


## Impact

No breaking changes.
This is a documentation-only update to improve setup clarity for self-hosted users.