### PR TITLE
Update permissions to be GA

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem 'redis', '~> 4.7.1'
 gem 'request_migrations', '~> 1.1'
 
 # API params
-gem 'typed_params', '~> 1.2.7'
+gem 'typed_params', '~> 1.3.0'
 
 # Serializers
 gem 'json', '~> 2.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -503,7 +503,7 @@ GEM
     timecop (0.9.5)
     timeout (0.4.3)
     tracer (0.1.1)
-    typed_params (1.2.7)
+    typed_params (1.3.0)
       rails (>= 6.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
@@ -611,7 +611,7 @@ DEPENDENCIES
   temporary_tables
   timecop (~> 0.9.5)
   tracer
-  typed_params (~> 1.2.7)
+  typed_params (~> 1.3.0)
   union_of
   uri (>= 0.12.2)
   uuid7

--- a/app/controllers/api/v1/accounts/relationships/settings_controller.rb
+++ b/app/controllers/api/v1/accounts/relationships/settings_controller.rb
@@ -98,7 +98,7 @@ module Api::V1::Accounts::Relationships
     def set_setting
       scoped_settings = authorized_scope(current_account.settings)
 
-      @setting = scoped_settings.find(params[:id])
+      @setting = scoped_settings.find_by_alias(params[:id], aliases: %i[key])
 
       Current.resource = current_account
     end

--- a/app/controllers/api/v1/accounts/relationships/settings_controller.rb
+++ b/app/controllers/api/v1/accounts/relationships/settings_controller.rb
@@ -98,7 +98,7 @@ module Api::V1::Accounts::Relationships
     def set_setting
       scoped_settings = authorized_scope(current_account.settings)
 
-      @setting = scoped_settings.find_by_alias(params[:id], aliases: %i[key])
+      @setting = scoped_settings.find_by_alias(params[:id])
 
       Current.resource = current_account
     end

--- a/app/controllers/api/v1/accounts/relationships/settings_controller.rb
+++ b/app/controllers/api/v1/accounts/relationships/settings_controller.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+module Api::V1::Accounts::Relationships
+  class SettingsController < Api::V1::BaseController
+    before_action :scope_to_current_account!
+    before_action :authenticate_with_token!
+    before_action :set_setting, only: %i[show update destroy]
+
+    def index
+      settings = apply_pagination(authorized_scope(apply_scopes(current_account.settings)))
+      authorize! settings,
+        with: Accounts::SettingPolicy
+
+      render jsonapi: settings
+    end
+
+    def show
+      authorize! setting,
+        with: Accounts::SettingPolicy
+
+      render jsonapi: setting
+    end
+
+    typed_params {
+      format :jsonapi
+
+      param :data, type: :hash do
+        param :type, type: :string, inclusion: { in: %w[setting settings] }
+        param :attributes, type: :hash do
+          param :key, type: :string, transform: -> k, v { [k, v.underscore] }
+          param :value, type: :any
+        end
+      end
+    }
+    def create
+      setting = current_account.settings.new(**setting_params)
+      authorize! setting,
+        with: Accounts::SettingPolicy
+
+      if setting.save
+        BroadcastEventService.call(
+          event: 'account.settings.created',
+          account: current_account,
+          resource: setting,
+        )
+
+        render jsonapi: setting, status: :created, location: v1_account_setting_url(setting.account_id, setting)
+      else
+        render_unprocessable_resource setting
+      end
+    end
+
+    typed_params {
+      format :jsonapi
+
+      param :data, type: :hash do
+        param :type, type: :string, inclusion: { in: %w[setting settings] }
+        param :id, type: :string, optional: true, noop: true
+        param :attributes, type: :hash do
+          param :value, type: :any
+        end
+      end
+    }
+    def update
+      authorize! setting,
+        with: Accounts::SettingPolicy
+
+      if setting.update(setting_params)
+        BroadcastEventService.call(
+          event: 'account.settings.updated',
+          account: current_account,
+          resource: setting,
+        )
+
+        render jsonapi: setting
+      else
+        render_unprocessable_resource setting
+      end
+    end
+
+    def destroy
+      authorize! setting,
+        with: Accounts::SettingPolicy
+
+      BroadcastEventService.call(
+        event: 'account.settings.deleted',
+        account: current_account,
+        resource: setting,
+      )
+
+      setting.destroy
+    end
+
+    private
+
+    attr_reader :setting
+
+    def set_setting
+      scoped_settings = authorized_scope(current_account.settings)
+
+      @setting = scoped_settings.find(params[:id])
+
+      Current.resource = current_account
+    end
+  end
+end

--- a/app/controllers/api/v1/environments/relationships/tokens_controller.rb
+++ b/app/controllers/api/v1/environments/relationships/tokens_controller.rb
@@ -37,7 +37,7 @@ module Api::V1::Environments::Relationships
             next unless
               license.entitled?(:permissions)
 
-            param :permissions, type: :array, optional: true, if: -> { current_account.ent? && current_bearer&.has_role?(:admin, :environment) } do
+            param :permissions, type: :array, optional: true do
               items type: :string
             end
           end

--- a/app/controllers/api/v1/environments/relationships/tokens_controller.rb
+++ b/app/controllers/api/v1/environments/relationships/tokens_controller.rb
@@ -37,7 +37,7 @@ module Api::V1::Environments::Relationships
             next unless
               license.entitled?(:permissions)
 
-            param :permissions, type: :array, optional: true do
+            param :permissions, type: :array, optional: true, if: -> { current_bearer&.has_role?(:admin, :developer, :environment) } do
               items type: :string
             end
           end

--- a/app/controllers/api/v1/licenses/relationships/tokens_controller.rb
+++ b/app/controllers/api/v1/licenses/relationships/tokens_controller.rb
@@ -40,7 +40,7 @@ module Api::V1::Licenses::Relationships
             next unless
               license.entitled?(:permissions)
 
-            param :permissions, type: :array, optional: true do
+            param :permissions, type: :array, optional: true, if: -> { current_bearer&.has_role?(:admin, :developer, :product, :environment) } do
               items type: :string
             end
           end

--- a/app/controllers/api/v1/licenses/relationships/tokens_controller.rb
+++ b/app/controllers/api/v1/licenses/relationships/tokens_controller.rb
@@ -40,7 +40,7 @@ module Api::V1::Licenses::Relationships
             next unless
               license.entitled?(:permissions)
 
-            param :permissions, type: :array, optional: true, if: -> { current_account.ent? && current_bearer&.has_role?(:admin, :product, :environment) } do
+            param :permissions, type: :array, optional: true do
               items type: :string
             end
           end

--- a/app/controllers/api/v1/licenses_controller.rb
+++ b/app/controllers/api/v1/licenses_controller.rb
@@ -69,7 +69,7 @@ module Api::V1
             next unless
               license.entitled?(:permissions)
 
-            param :permissions, type: :array, optional: true, if: -> { current_bearer&.has_role?(:admin, :developer, :sales_agent, :product, :environment) } do
+            param :permissions, type: :array, optional: true, if: -> { current_bearer&.has_role?(:admin, :developer, :product, :environment) } do
               items type: :string
             end
           end
@@ -149,7 +149,7 @@ module Api::V1
             next unless
               license.entitled?(:permissions)
 
-            param :permissions, type: :array, optional: true, if: -> { current_bearer&.has_role?(:admin, :developer, :sales_agent, :product, :environment) } do
+            param :permissions, type: :array, optional: true, if: -> { current_bearer&.has_role?(:admin, :developer, :product, :environment) } do
               items type: :string
             end
           end

--- a/app/controllers/api/v1/licenses_controller.rb
+++ b/app/controllers/api/v1/licenses_controller.rb
@@ -69,7 +69,7 @@ module Api::V1
             next unless
               license.entitled?(:permissions)
 
-            param :permissions, type: :array, optional: true, if: -> { current_account.ent? && current_bearer&.has_role?(:admin, :product, :environment) } do
+            param :permissions, type: :array, optional: true, if: -> { current_bearer&.has_role?(:admin, :developer, :sales_agent, :product, :environment) } do
               items type: :string
             end
           end
@@ -149,7 +149,7 @@ module Api::V1
             next unless
               license.entitled?(:permissions)
 
-            param :permissions, type: :array, optional: true, if: -> { current_account.ent? && current_bearer&.has_role?(:admin, :product, :environment) } do
+            param :permissions, type: :array, optional: true, if: -> { current_bearer&.has_role?(:admin, :developer, :sales_agent, :product, :environment) } do
               items type: :string
             end
           end

--- a/app/controllers/api/v1/products/relationships/tokens_controller.rb
+++ b/app/controllers/api/v1/products/relationships/tokens_controller.rb
@@ -38,7 +38,7 @@ module Api::V1::Products::Relationships
             next unless
               license.entitled?(:permissions)
 
-            param :permissions, type: :array, optional: true, if: -> { current_account.ent? && current_bearer&.has_role?(:admin, :product, :environment) } do
+            param :permissions, type: :array, optional: true do
               items type: :string
             end
           end

--- a/app/controllers/api/v1/products/relationships/tokens_controller.rb
+++ b/app/controllers/api/v1/products/relationships/tokens_controller.rb
@@ -38,7 +38,7 @@ module Api::V1::Products::Relationships
             next unless
               license.entitled?(:permissions)
 
-            param :permissions, type: :array, optional: true do
+            param :permissions, type: :array, optional: true, if: -> { current_bearer&.has_role?(:admin, :developer, :product, :environment) } do
               items type: :string
             end
           end

--- a/app/controllers/api/v1/products_controller.rb
+++ b/app/controllers/api/v1/products_controller.rb
@@ -39,7 +39,7 @@ module Api::V1
             next unless
               license.entitled?(:permissions)
 
-            param :permissions, type: :array, optional: true do
+            param :permissions, type: :array, optional: true, if: -> { current_bearer&.has_role?(:admin, :developer, :environment) } do
               items type: :string
             end
           end
@@ -96,7 +96,7 @@ module Api::V1
             next unless
               license.entitled?(:permissions)
 
-            param :permissions, type: :array, optional: true do
+            param :permissions, type: :array, optional: true, if: -> { current_bearer&.has_role?(:admin, :developer, :environment) } do
               items type: :string
             end
           end

--- a/app/controllers/api/v1/products_controller.rb
+++ b/app/controllers/api/v1/products_controller.rb
@@ -39,7 +39,7 @@ module Api::V1
             next unless
               license.entitled?(:permissions)
 
-            param :permissions, type: :array, optional: true, if: -> { current_account.ent? && current_bearer&.has_role?(:admin, :developer, :environment) } do
+            param :permissions, type: :array, optional: true do
               items type: :string
             end
           end
@@ -96,7 +96,7 @@ module Api::V1
             next unless
               license.entitled?(:permissions)
 
-            param :permissions, type: :array, optional: true, if: -> { current_account.ent? && current_bearer&.has_role?(:admin, :developer, :environment) } do
+            param :permissions, type: :array, optional: true do
               items type: :string
             end
           end

--- a/app/controllers/api/v1/tokens_controller.rb
+++ b/app/controllers/api/v1/tokens_controller.rb
@@ -38,7 +38,7 @@ module Api::V1
             next unless
               license.entitled?(:permissions)
 
-            param :permissions, type: :array, optional: true, if: -> { current_account.ent? } do
+            param :permissions, type: :array, optional: true do
               items type: :string
             end
           end

--- a/app/controllers/api/v1/users/relationships/tokens_controller.rb
+++ b/app/controllers/api/v1/users/relationships/tokens_controller.rb
@@ -38,7 +38,7 @@ module Api::V1::Users::Relationships
             next unless
               license.entitled?(:permissions)
 
-            param :permissions, type: :array, optional: true, if: -> { current_account.ent? && current_bearer&.has_role?(:admin, :product, :environment) } do
+            param :permissions, type: :array, optional: true do
               items type: :string
             end
           end

--- a/app/controllers/api/v1/users/relationships/tokens_controller.rb
+++ b/app/controllers/api/v1/users/relationships/tokens_controller.rb
@@ -38,7 +38,7 @@ module Api::V1::Users::Relationships
             next unless
               license.entitled?(:permissions)
 
-            param :permissions, type: :array, optional: true do
+            param :permissions, type: :array, optional: true, if: -> { current_bearer&.has_role?(:admin, :developer, :product, :environment) } do
               items type: :string
             end
           end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -56,7 +56,7 @@ module Api::V1
             next unless
               license.entitled?(:permissions)
 
-            param :permissions, type: :array, optional: true, if: -> { current_account.ent? && current_bearer&.has_role?(:admin, :product, :environment) } do
+              param :permissions, type: :array, optional: true, if: -> { current_bearer&.has_role?(:admin, :developer, :sales_agent, :product, :environment) } do
               items type: :string
             end
           end
@@ -110,7 +110,7 @@ module Api::V1
           param :first_name, type: :string, allow_blank: true, allow_nil: true, optional: true
           param :last_name, type: :string, allow_blank: true, allow_nil: true, optional: true
           param :email, type: :string, optional: true
-          param :password, type: :string, allow_nil: true, optional: true, if: -> { current_bearer&.has_role?(:admin, :product, :environment) }
+          param :password, type: :string, allow_nil: true, optional: true, if: -> { current_bearer&.has_role?(:admin, :developer, :product, :environment) }
           param :metadata, type: :metadata, allow_blank: true, optional: true, if: -> { current_bearer&.has_role?(:admin, :developer, :sales_agent, :product, :environment) }
           param :role, type: :string, inclusion: { in: %w[user admin developer sales-agent support-agent read-only] }, optional: true,
             if: -> { current_bearer&.has_role?(:admin) },
@@ -122,7 +122,7 @@ module Api::V1
             next unless
               license.entitled?(:permissions)
 
-            param :permissions, type: :array, optional: true, if: -> { current_account.ent? && current_bearer&.has_role?(:admin, :product, :environment) } do
+            param :permissions, type: :array, optional: true, if: -> { current_bearer&.has_role?(:admin, :developer, :sales_agent, :product, :environment) } do
               items type: :string
             end
           end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -56,7 +56,7 @@ module Api::V1
             next unless
               license.entitled?(:permissions)
 
-            param :permissions, type: :array, optional: true, if: -> { current_bearer&.has_role?(:admin, :developer, :sales_agent, :product, :environment) } do
+            param :permissions, type: :array, optional: true, if: -> { current_bearer&.has_role?(:admin, :developer, :product, :environment) } do
               items type: :string
             end
           end
@@ -122,7 +122,7 @@ module Api::V1
             next unless
               license.entitled?(:permissions)
 
-            param :permissions, type: :array, optional: true, if: -> { current_bearer&.has_role?(:admin, :developer, :sales_agent, :product, :environment) } do
+            param :permissions, type: :array, optional: true, if: -> { current_bearer&.has_role?(:admin, :developer, :product, :environment) } do
               items type: :string
             end
           end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -56,7 +56,7 @@ module Api::V1
             next unless
               license.entitled?(:permissions)
 
-              param :permissions, type: :array, optional: true, if: -> { current_bearer&.has_role?(:admin, :developer, :sales_agent, :product, :environment) } do
+            param :permissions, type: :array, optional: true, if: -> { current_bearer&.has_role?(:admin, :developer, :sales_agent, :product, :environment) } do
               items type: :string
             end
           end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -12,6 +12,11 @@ class Account < ApplicationRecord
 
   belongs_to :plan, optional: true, null_object: NullPlan.name
   has_one :billing, null_object: NullBilling.name
+  has_many :settings, class_name: 'AccountSetting' do
+    def default_license_permissions = find_by(key: :default_license_permissions)&.value
+    def default_user_permissions    = find_by(key: :default_user_permissions)&.value
+  end
+
   has_many :environments, dependent: :destroy_async
   has_many :webhook_endpoints, dependent: :destroy_async
   has_many :webhook_events, dependent: :destroy_async

--- a/app/models/account_setting.rb
+++ b/app/models/account_setting.rb
@@ -16,17 +16,13 @@ class AccountSetting < ApplicationRecord
   validates :key, presence: true, uniqueness: { scope: :account_id }, inclusion: { in: VALID_KEYS, message: "must be one of: #{VALID_KEYS.join(', ')}" }
   validate on: %i[create update] do
     case self
-    in key: :default_license_permissions | 'default_license_permissions', value: [*]
-      permissions = value.uniq
-
+    in key: :default_license_permissions | 'default_license_permissions', value: [*] => permissions
       unless (permissions & License.allowed_permissions).size == permissions.size
-        errors.add :value, :invalid, message: 'must be an array of valid license permissions'
+        errors.add :value, :not_allowed, message: 'must be an array of valid license permissions'
       end
-    in key: :default_user_permissions | 'default_user_permissions', value: [*]
-      permissions = value.uniq
-
+    in key: :default_user_permissions | 'default_user_permissions', value: [*] => permissions
       unless (permissions & User.allowed_permissions).size == permissions.size
-        errors.add :value, :invalid, message: 'must be an array of valid user permissions'
+        errors.add :value, :not_allowed, message: 'must be an array of valid user permissions'
       end
     else
       errors.add :value, :not_allowed, message: 'must be a valid setting'

--- a/app/models/account_setting.rb
+++ b/app/models/account_setting.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class AccountSetting < ApplicationRecord
+  include Keygen::PortableClass
+  include Limitable
+  include Orderable
+  include Dirtyable
+  include Pageable
+
+  VALID_KEYS = %w[
+    default_license_permissions
+    default_user_permissions
+  ]
+
+  belongs_to :account
+
+  validates :key, presence: true, uniqueness: { scope: :account_id }, inclusion: { in: VALID_KEYS, message: "must be one of: #{VALID_KEYS.join(', ')}" }
+  validate on: %i[create update] do
+    case self
+    in key: :default_license_permissions | 'default_license_permissions', value: [*]
+      permissions = value.uniq
+
+      unless (permissions & License.allowed_permissions).size == permissions.size
+        errors.add :value, :invalid, message: 'must be an array of valid license permissions'
+      end
+    in key: :default_user_permissions | 'default_user_permissions', value: [*]
+      permissions = value.uniq
+
+      unless (permissions & User.allowed_permissions).size == permissions.size
+        errors.add :value, :invalid, message: 'must be an array of valid user permissions'
+      end
+    else
+      errors.add :value, :not_allowed, message: 'must be a valid setting'
+    end
+  end
+end

--- a/app/models/account_setting.rb
+++ b/app/models/account_setting.rb
@@ -12,6 +12,8 @@ class AccountSetting < ApplicationRecord
 
   belongs_to :account
 
+  has_aliases :key
+
   validates :key, presence: true, uniqueness: { scope: :account_id }, inclusion: { in: VALID_KEYS, message: "must be one of: #{VALID_KEYS.join(', ')}" }
   validate on: %i[create update] do
     case self

--- a/app/models/account_setting.rb
+++ b/app/models/account_setting.rb
@@ -3,15 +3,14 @@
 class AccountSetting < ApplicationRecord
   include Keygen::PortableClass
   include Limitable, Orderable, Pageable
-  include Aliasable, Dirtyable
+  include Accountable, Dirtyable, Aliasable
 
   VALID_KEYS = %w[
     default_license_permissions
     default_user_permissions
   ]
 
-  belongs_to :account
-
+  has_account touch: true
   has_aliases :key
 
   validates :key, presence: true, uniqueness: { scope: :account_id }, inclusion: { in: VALID_KEYS, message: "must be one of: #{VALID_KEYS.join(', ')}" }

--- a/app/models/account_setting.rb
+++ b/app/models/account_setting.rb
@@ -2,10 +2,8 @@
 
 class AccountSetting < ApplicationRecord
   include Keygen::PortableClass
-  include Limitable
-  include Orderable
-  include Dirtyable
-  include Pageable
+  include Limitable, Orderable, Pageable
+  include Aliasable, Dirtyable
 
   VALID_KEYS = %w[
     default_license_permissions

--- a/app/models/concerns/aliasable.rb
+++ b/app/models/concerns/aliasable.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Aliasable
+  extend ActiveSupport::Concern
+
+  class_methods do
+    def find_by_alias!(id, aliases:) = FindByAliasService.call(self, id:, aliases:)
+    def find_by_alias(...)
+      find_by_alias!(...)
+    rescue ActiveRecord::RecordNotFound
+      nil
+    end
+  end
+end

--- a/app/models/concerns/aliasable.rb
+++ b/app/models/concerns/aliasable.rb
@@ -4,11 +4,17 @@ module Aliasable
   extend ActiveSupport::Concern
 
   class_methods do
-    def find_by_alias!(id, aliases:) = FindByAliasService.call(self, id:, aliases:)
+    cattr_reader :default_aliases, default: Set.new
+
+    def find_by_alias!(id, aliases: default_aliases) = FindByAliasService.call(self, id:, aliases:)
     def find_by_alias(...)
       find_by_alias!(...)
     rescue ActiveRecord::RecordNotFound
       nil
     end
+
+    private
+
+    def has_aliases(*aliases) = default_aliases.merge(aliases)
   end
 end

--- a/app/models/concerns/permissible.rb
+++ b/app/models/concerns/permissible.rb
@@ -138,10 +138,21 @@ module Permissible
       #             like the permissions arg and :default kwarg.
       module_eval do
         define_singleton_method :allowed_permissions do
-          perms = resolver.call(self, permissions)
+          perms = resolver.call(nil, permissions)
 
           # Wildcards are always allowed.
           perms << Permission::WILDCARD_PERMISSION
+
+          perms.freeze
+        end
+
+        define_singleton_method :default_permissions do
+          perms = resolver.call(nil, default)
+
+          # When no defaults are provided, default to allowed minus wildcard.
+          next allowed_permissions.reject { _1 == Permission::WILDCARD_PERMISSION }
+                                  .freeze if
+            perms.empty?
 
           perms.freeze
         end
@@ -151,17 +162,6 @@ module Permissible
 
           # Wildcards are always allowed.
           perms << Permission::WILDCARD_PERMISSION
-
-          perms.freeze
-        end
-
-        define_singleton_method :default_permissions do
-          perms = resolver.call(self, default)
-
-          # When no defaults are provided, default to allowed minus wildcard.
-          next allowed_permissions.reject { _1 == Permission::WILDCARD_PERMISSION }
-                                  .freeze if
-            perms.empty?
 
           perms.freeze
         end

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -150,20 +150,16 @@ class Role < ApplicationRecord
   def name=(...)
     super(...)
 
-    # Reset permissions on role change, and for Ent accounts, using the
-    # intersection of our current role's permissions and the new role's
-    # default permisisons. This helps prevent prevents accidental
-    # privilege escalation, e.g. for user => admin => user.
+    # Reset permissions on role change by using the intersection of our
+    # current role's permissions and the new role's default permisisons.
+    # This helps prevent prevents accidental privilege escalation, e.g.
+    # for user => admin => user.
     #
     # Only run when role is persisted, i.e. on updates.
     return unless
       persisted?
 
-    if account.ent?
-      self.permissions = permission_ids & (default_permission_ids << Permission.wildcard_id)
-    else
-      self.reset_permissions
-    end
+    self.permissions = permission_ids & (default_permission_ids << Permission.wildcard_id)
   end
 
   ##

--- a/app/policies/accounts/setting_policy.rb
+++ b/app/policies/accounts/setting_policy.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+module Accounts
+  class SettingPolicy < ApplicationPolicy
+    scope_for :active_record_relation do |relation|
+      case bearer
+      in role: Role(:admin | :developer)
+        relation.all
+      else
+        relation.none
+      end
+    end
+
+    def index?
+      verify_permissions!('account.read')
+      verify_environment!(
+        strict: false,
+      )
+
+      case bearer
+      in role: Role(:admin | :developer)
+        allow!
+      else
+        deny!
+      end
+    end
+
+    def show?
+      verify_permissions!('account.read')
+      verify_environment!(
+        strict: false,
+      )
+
+      case bearer
+      in role: Role(:admin | :developer)
+        allow!
+      else
+        deny!
+      end
+    end
+
+    def create?
+      verify_permissions!('account.update')
+      verify_environment!
+
+      case bearer
+      in role: Role(:admin | :developer)
+        allow!
+      else
+        deny!
+      end
+    end
+
+    def update?
+      verify_permissions!('account.update')
+      verify_environment!
+
+      case bearer
+      in role: Role(:admin | :developer)
+        allow!
+      else
+        deny!
+      end
+    end
+
+    def destroy?
+      verify_permissions!('account.update')
+      verify_environment!
+
+      case bearer
+      in role: Role(:admin | :developer)
+        allow!
+      else
+        deny!
+      end
+    end
+  end
+end

--- a/app/serializers/account_serializer.rb
+++ b/app/serializers/account_serializer.rb
@@ -35,6 +35,12 @@ class AccountSerializer < BaseSerializer
     end
   end
 
+  relationship :settings do
+    link :related do
+      @url_helpers.v1_account_settings_path @object
+    end
+  end
+
   relationship :webhook_endpoints do
     link :related do
       @url_helpers.v1_account_webhook_endpoints_path @object

--- a/app/serializers/account_setting_serializer.rb
+++ b/app/serializers/account_setting_serializer.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class AccountSettingSerializer < BaseSerializer
+  type 'settings'
+
+  attribute :key
+  attribute :value
+  attribute :created do
+    @object.created_at
+  end
+  attribute :updated do
+    @object.updated_at
+  end
+
+  relationship :account do
+    linkage always: true do
+      { type: :accounts, id: @object.account_id }
+    end
+    link :related do
+      @url_helpers.v1_account_path @object.account_id
+    end
+  end
+
+  link :self do
+    @url_helpers.v1_account_setting_path @object.account_id, @object
+  end
+end

--- a/app/serializers/license_serializer.rb
+++ b/app/serializers/license_serializer.rb
@@ -55,7 +55,7 @@ class LicenseSerializer < BaseSerializer
     @object.last_check_out_at
   end
   ee do
-    attribute :permissions, if: -> { @account.ent? } do
+    attribute :permissions do
       @object.permissions.actions
     end
   end

--- a/app/serializers/product_serializer.rb
+++ b/app/serializers/product_serializer.rb
@@ -9,7 +9,7 @@ class ProductSerializer < BaseSerializer
   attribute :url
   attribute :platforms
   ee do
-    attribute :permissions, if: -> { @account.ent? } do
+    attribute :permissions do
       @object.permissions.actions
     end
   end

--- a/app/serializers/token_serializer.rb
+++ b/app/serializers/token_serializer.rb
@@ -14,7 +14,7 @@ class TokenSerializer < BaseSerializer
   attribute :max_deactivations, if: -> { @object.activation_token? }
   attribute :deactivations, if: -> { @object.activation_token? }
   ee do
-    attribute :permissions, if: -> { @account.ent? } do
+    attribute :permissions do
       @object.permissions.actions
     end
   end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -12,7 +12,7 @@ class UserSerializer < BaseSerializer
     @object.role&.name&.dasherize
   end
   ee do
-    attribute :permissions, if: -> { @account.ent? } do
+    attribute :permissions do
       @object.permissions.actions
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -555,9 +555,9 @@ Rails.application.routes.draw do
         # Routes with :account_id scope i.e. multiplayer mode. Most of these
         # routes are also available in singleplayer mode for compatibility.
         scope 'accounts/:account_id', as: :account do
-          if Keygen.multiplayer?
+          scope constraints: MimeTypeConstraint.new(:jsonapi, :json, raise_on_no_match: true), defaults: { format: :jsonapi } do
             constraints subdomain: Keygen::SUBDOMAIN do
-              scope constraints: MimeTypeConstraint.new(:jsonapi, :json, raise_on_no_match: true), defaults: { format: :jsonapi } do
+              if Keygen.multiplayer?
                 scope module: 'accounts/relationships' do
                   resource :billing, only: %i[show update]
                   resource :plan,    only: %i[show update]
@@ -570,6 +570,10 @@ Rails.application.routes.draw do
                   post :cancel_subscription, path: 'cancel-subscription', to: 'subscription#cancel'
                   post :renew_subscription,  path: 'renew-subscription',  to: 'subscription#renew'
                 end
+              end
+
+              scope module: 'accounts/relationships' do
+                resources :settings
               end
             end
           end

--- a/db/migrate/20250502170156_create_account_settings.rb
+++ b/db/migrate/20250502170156_create_account_settings.rb
@@ -1,0 +1,15 @@
+class CreateAccountSettings < ActiveRecord::Migration[7.2]
+  verbose!
+
+  def change
+    create_table :account_settings, id: :uuid, default: -> { 'uuid_generate_v4()' } do |t|
+      t.uuid :account_id, null: false
+      t.string :key, null: false
+      t.jsonb :value, null: false
+      t.timestamps
+
+      t.index %i[account_id created_at], order: { created_at: :desc }
+      t.index %i[account_id key], unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,22 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_04_08_141534) do
+ActiveRecord::Schema[7.2].define(version: 2025_05_02_170156) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
+
+  create_table "account_settings", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
+    t.uuid "account_id", null: false
+    t.string "key", null: false
+    t.jsonb "value", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["account_id", "created_at"], name: "index_account_settings_on_account_id_and_created_at", order: { created_at: :desc }
+    t.index ["account_id", "key"], name: "index_account_settings_on_account_id_and_key", unique: true
+  end
 
   create_table "accounts", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
     t.string "name"

--- a/features/api/v1/accounts/relationships/settings.feature
+++ b/features/api/v1/accounts/relationships/settings.feature
@@ -96,6 +96,122 @@ Feature: Account settings
     And sidekiq should have 0 "request-log" jobs
     And sidekiq should have 1 "event-log" job
 
+  Scenario: Admin creates a default license permission account setting with duplicates
+    Given I am an admin of account "test1"
+    And the current account is "test1"
+    And I use an authentication token
+    And the current account has 1 "webhook-endpoint"
+    When I send a POST request to "/accounts/test1/settings" with the following:
+      """
+      {
+        "data": {
+          "type": "settings",
+          "attributes": {
+            "key": "default_license_permissions",
+            "value": [
+              "license.validate",
+              "license.validate",
+              "machine.read",
+              "machine.create"
+            ]
+          }
+        }
+      }
+      """
+    Then the response status should be "422"
+    And the response body should be an array of 1 errors
+    And the first error should have the following properties:
+      """
+      {
+        "title": "Unprocessable resource",
+        "detail": "must be an array of valid license permissions",
+        "code": "VALUE_NOT_ALLOWED",
+        "source": {
+          "pointer": "/data/attributes/value"
+        }
+      }
+      """
+    And sidekiq should have 0 "webhook" jobs
+    And sidekiq should have 0 "request-log" jobs
+    And sidekiq should have 0 "event-log" jobs
+
+  Scenario: Admin creates a default license permission account setting with nils
+    Given I am an admin of account "test1"
+    And the current account is "test1"
+    And I use an authentication token
+    And the current account has 1 "webhook-endpoint"
+    When I send a POST request to "/accounts/test1/settings" with the following:
+      """
+      {
+        "data": {
+          "type": "settings",
+          "attributes": {
+            "key": "default_user_permissions",
+            "value": [
+              "license.validate",
+              "license.read",
+              null,
+              "user.read"
+            ]
+          }
+        }
+      }
+      """
+    Then the response status should be "422"
+    And the response body should be an array of 1 errors
+    And the first error should have the following properties:
+      """
+      {
+        "title": "Unprocessable resource",
+        "detail": "must be an array of valid user permissions",
+        "code": "VALUE_NOT_ALLOWED",
+        "source": {
+          "pointer": "/data/attributes/value"
+        }
+      }
+      """
+    And sidekiq should have 0 "webhook" jobs
+    And sidekiq should have 0 "request-log" jobs
+    And sidekiq should have 0 "event-log" jobs
+
+  Scenario: Admin creates a default license permission account setting with unknowns
+    Given I am an admin of account "test1"
+    And the current account is "test1"
+    And I use an authentication token
+    And the current account has 1 "webhook-endpoint"
+    When I send a POST request to "/accounts/test1/settings" with the following:
+      """
+      {
+        "data": {
+          "type": "settings",
+          "attributes": {
+            "key": "default_user_permissions",
+            "value": [
+              "license.validate",
+              "license.read",
+              "foo.bar"
+            ]
+          }
+        }
+      }
+      """
+    Then the response status should be "422"
+    And the response body should be an array of 1 errors
+    And the first error should have the following properties:
+      """
+      {
+        "title": "Unprocessable resource",
+        "detail": "must be an array of valid user permissions",
+        "code": "VALUE_NOT_ALLOWED",
+        "source": {
+          "pointer": "/data/attributes/value"
+        }
+      }
+      """
+    And sidekiq should have 0 "webhook" jobs
+    And sidekiq should have 0 "request-log" jobs
+    And sidekiq should have 0 "event-log" jobs
+
   Scenario: Admin creates a duplicate default license permission account setting
     Given I am an admin of account "test1"
     And the current account is "test1"

--- a/features/api/v1/accounts/relationships/settings.feature
+++ b/features/api/v1/accounts/relationships/settings.feature
@@ -1,0 +1,324 @@
+@api/v1
+Feature: Account settings
+  Background:
+    Given the following "accounts" exist:
+      | Name    | Slug  |
+      | Test 1  | test1 |
+      | Test 2  | test2 |
+    And I send and accept JSON
+
+  Scenario: Endpoint should be accessible when account is disabled
+    Given the account "test1" is canceled
+    When I send a GET request to "/accounts/test1/settings"
+    Then the response status should not be "403"
+
+  Scenario: Admin creates a default license permission account setting
+    Given I am an admin of account "test1"
+    And the current account is "test1"
+    And I use an authentication token
+    And the current account has 1 "webhook-endpoint"
+    When I send a POST request to "/accounts/test1/settings" with the following:
+      """
+      {
+        "data": {
+          "type": "settings",
+          "attributes": {
+            "key": "default_license_permissions",
+            "value": [
+              "product.read",
+              "policy.read",
+              "license.read",
+              "license.validate",
+              "machine.read",
+              "machine.create"
+            ]
+          }
+        }
+      }
+      """
+    Then the response status should be "201"
+    And the response body should be a "setting" with the following attributes:
+      """
+      {
+        "key": "default_license_permissions",
+        "value": [
+          "product.read",
+          "policy.read",
+          "license.read",
+          "license.validate",
+          "machine.read",
+          "machine.create"
+        ]
+      }
+      """
+    And sidekiq should have 1 "webhook" job
+    And sidekiq should have 0 "request-log" jobs
+    And sidekiq should have 1 "event-log" job
+
+  Scenario: Admin creates a default user permission account setting
+    Given I am an admin of account "test1"
+    And the current account is "test1"
+    And I use an authentication token
+    And the current account has 1 "webhook-endpoint"
+    When I send a POST request to "/accounts/test1/settings" with the following:
+      """
+      {
+        "data": {
+          "type": "settings",
+          "attributes": {
+            "key": "defaultUserPermissions",
+            "value": [
+              "user.read",
+              "license.read",
+              "license.validate",
+              "machine.read",
+              "machine.create"
+            ]
+          }
+        }
+      }
+      """
+    Then the response status should be "201"
+    And the response body should be a "setting" with the following attributes:
+      """
+      {
+        "key": "default_user_permissions",
+        "value": [
+          "user.read",
+          "license.read",
+          "license.validate",
+          "machine.read",
+          "machine.create"
+        ]
+      }
+      """
+    And sidekiq should have 1 "webhook" job
+    And sidekiq should have 0 "request-log" jobs
+    And sidekiq should have 1 "event-log" job
+
+  Scenario: Admin creates an invalid default user permission account setting
+    Given I am an admin of account "test1"
+    And the current account is "test1"
+    And I use an authentication token
+    And the current account has 1 "webhook-endpoint"
+    When I send a POST request to "/accounts/test1/settings" with the following:
+      """
+      {
+        "data": {
+          "type": "settings",
+          "attributes": {
+            "key": "defaultUserPermissions",
+            "value": {
+              "user.read": true
+            }
+          }
+        }
+      }
+      """
+    Then the response status should be "422"
+    And the response body should be an array of 1 errors
+    And the first error should have the following properties:
+      """
+      {
+        "title": "Unprocessable resource",
+        "detail": "must be a valid setting",
+        "code": "VALUE_NOT_ALLOWED"
+      }
+      """
+    And sidekiq should have 0 "webhook" jobs
+    And sidekiq should have 0 "request-log" jobs
+    And sidekiq should have 0 "event-log" jobs
+
+  Scenario: Admin creates an invalid account setting
+    Given I am an admin of account "test1"
+    And the current account is "test1"
+    And I use an authentication token
+    And the current account has 1 "webhook-endpoint"
+    When I send a POST request to "/accounts/test1/settings" with the following:
+      """
+      {
+        "data": {
+          "type": "settings",
+          "attributes": {
+            "key": "foo",
+            "value": "bar"
+          }
+        }
+      }
+      """
+    Then the response status should be "422"
+    And the response body should be an array of 2 errors
+    And the first error should have the following properties:
+      """
+      {
+        "title": "Unprocessable resource",
+        "detail": "must be one of: default_license_permissions, default_user_permissions",
+        "code": "KEY_NOT_ALLOWED"
+      }
+      """
+     And the second error should have the following properties:
+      """
+      {
+        "title": "Unprocessable resource",
+        "detail": "must be a valid setting",
+        "code": "VALUE_NOT_ALLOWED"
+      }
+      """
+    And sidekiq should have 0 "webhook" jobs
+    And sidekiq should have 0 "request-log" jobs
+    And sidekiq should have 0 "event-log" jobs
+
+  Scenario: Admin lists their account settings
+    Given I am an admin of account "test1"
+    And the current account is "test1"
+    And I use an authentication token
+    And the current account has 1 "webhook-endpoint"
+    And the current account has 1 "setting" with the following:
+      """
+      {
+        "key": "default_license_permissions",
+        "value": [
+          "license.validate",
+          "license.read"
+        ]
+      }
+      """
+    And the current account has 1 "setting" with the following:
+      """
+      {
+        "key": "default_user_permissions",
+        "value": [
+          "license.validate",
+          "license.read",
+          "user.read"
+        ]
+      }
+      """
+    When I send a GET request to "/accounts/test1/settings"
+    Then the response status should be "200"
+    And the response body should be an array of 2 "settings"
+    And sidekiq should have 0 "webhook" jobs
+    And sidekiq should have 0 "request-log" jobs
+    And sidekiq should have 0 "event-log" jobs
+
+  Scenario: Admin retrieves an account setting
+    Given I am an admin of account "test1"
+    And the current account is "test1"
+    And I use an authentication token
+    And the current account has 1 "webhook-endpoint"
+    And the current account has 1 "setting" with the following:
+      """
+      {
+        "key": "default_license_permissions",
+        "value": [
+          "license.validate",
+          "license.read"
+        ]
+      }
+      """
+    And the current account has 1 "setting" with the following:
+      """
+      {
+        "key": "default_user_permissions",
+        "value": [
+          "license.validate",
+          "license.read",
+          "user.read"
+        ]
+      }
+      """
+    When I send a GET request to "/accounts/test1/settings/$1"
+    Then the response status should be "200"
+    And the response body should be a "setting" with the following attributes:
+      """
+      {
+        "key": "default_user_permissions",
+        "value": [
+          "license.validate",
+          "license.read",
+          "user.read"
+        ]
+      }
+      """
+    And sidekiq should have 0 "webhook" jobs
+    And sidekiq should have 0 "request-log" jobs
+    And sidekiq should have 0 "event-log" jobs
+
+  Scenario: Admin updates an account setting
+    Given I am an admin of account "test1"
+    And the current account is "test1"
+    And I use an authentication token
+    And the current account has 1 "webhook-endpoint"
+    And the current account has 1 "setting" with the following:
+      """
+      {
+        "key": "default_license_permissions",
+        "value": [
+          "license.validate",
+          "license.read"
+        ]
+      }
+      """
+    And the current account has 1 "setting" with the following:
+      """
+      {
+        "key": "default_user_permissions",
+        "value": [
+          "license.validate",
+          "license.read",
+          "user.read"
+        ]
+      }
+      """
+    When I send a PATCH request to "/accounts/test1/settings/$0" with the following:
+      """
+      {
+        "data": {
+          "type": "settings",
+          "attributes": {
+            "value": ["license.validate"]
+          }
+        }
+      }
+      """
+    Then the response status should be "200"
+    And the response body should be a "setting" with the following attributes:
+      """
+      { "value": ["license.validate"] }
+      """
+    And sidekiq should have 1 "webhook" job
+    And sidekiq should have 0 "request-log" jobs
+    And sidekiq should have 1 "event-log" job
+
+  Scenario: Admin deletes an account setting
+    Given I am an admin of account "test1"
+    And the current account is "test1"
+    And I use an authentication token
+    And the current account has 1 "webhook-endpoint"
+    And the current account has 1 "setting" with the following:
+      """
+      {
+        "key": "default_license_permissions",
+        "value": [
+          "license.validate",
+          "license.read"
+        ]
+      }
+      """
+    And the current account has 1 "setting" with the following:
+      """
+      {
+        "key": "default_user_permissions",
+        "value": [
+          "license.validate",
+          "license.read",
+          "user.read"
+        ]
+      }
+      """
+    When I send a DELETE request to "/accounts/test1/settings/$1"
+    Then the response status should be "204"
+    And the current account should have 1 "setting"
+    And sidekiq should have 1 "webhook" job
+    And sidekiq should have 0 "request-log" jobs
+    And sidekiq should have 1 "event-log" job

--- a/features/api/v1/accounts/relationships/settings.feature
+++ b/features/api/v1/accounts/relationships/settings.feature
@@ -201,7 +201,50 @@ Feature: Account settings
     And sidekiq should have 0 "request-log" jobs
     And sidekiq should have 0 "event-log" jobs
 
-  Scenario: Admin retrieves an account setting
+  Scenario: Admin retrieves an account setting by key
+    Given I am an admin of account "test1"
+    And the current account is "test1"
+    And I use an authentication token
+    And the current account has 1 "webhook-endpoint"
+    And the current account has 1 "setting" with the following:
+      """
+      {
+        "key": "default_license_permissions",
+        "value": [
+          "license.validate",
+          "license.read"
+        ]
+      }
+      """
+    And the current account has 1 "setting" with the following:
+      """
+      {
+        "key": "default_user_permissions",
+        "value": [
+          "license.validate",
+          "license.read",
+          "user.read"
+        ]
+      }
+      """
+    When I send a GET request to "/accounts/test1/settings/default_user_permissions"
+    Then the response status should be "200"
+    And the response body should be a "setting" with the following attributes:
+      """
+      {
+        "key": "default_user_permissions",
+        "value": [
+          "license.validate",
+          "license.read",
+          "user.read"
+        ]
+      }
+      """
+    And sidekiq should have 0 "webhook" jobs
+    And sidekiq should have 0 "request-log" jobs
+    And sidekiq should have 0 "event-log" jobs
+
+  Scenario: Admin retrieves an account setting by ID
     Given I am an admin of account "test1"
     And the current account is "test1"
     And I use an authentication token

--- a/features/api/v1/environments/relationships/tokens.feature
+++ b/features/api/v1/environments/relationships/tokens.feature
@@ -497,20 +497,22 @@ Feature: Generate authentication token for environment
         }
       }
       """
-    Then the response status should be "400"
-    And the response body should be an array of 1 errors
-    And the first error should have the following properties:
+    Then the response status should be "201"
+    And the response body should be a "token" with the following attributes:
       """
       {
-        "title": "Bad request",
-        "detail": "unpermitted parameter",
-        "source": {
-          "pointer": "/data/attributes/permissions"
-        }
+        "permissions": [
+          "license.read",
+          "license.suspend",
+          "license.validate",
+          "machine.create",
+          "machine.read",
+          "machine.update"
+        ]
       }
       """
-    And sidekiq should have 0 "webhook" jobs
-    And sidekiq should have 0 "metric" jobs
+    And sidekiq should have 2 "webhook" jobs
+    And sidekiq should have 1 "metric" job
     And sidekiq should have 1 "request-log" job
 
   Scenario: Admin generates an environment token with custom permissions (ent tier, EE)
@@ -596,15 +598,19 @@ Feature: Generate authentication token for environment
         }
       }
       """
-    Then the response status should be "400"
+    Then the response status should be "422"
     And the response body should be an array of 1 errors
     And the first error should have the following properties:
       """
       {
-        "title": "Bad request",
-        "detail": "unpermitted parameter",
+        "title": "Unprocessable resource",
+        "detail": "unsupported permissions",
+        "code": "PERMISSIONS_NOT_ALLOWED",
         "source": {
           "pointer": "/data/attributes/permissions"
+        },
+        "links": {
+          "about": "https://keygen.sh/docs/api/tokens/#tokens-object-attrs-permissions"
         }
       }
       """
@@ -690,15 +696,19 @@ Feature: Generate authentication token for environment
         }
       }
       """
-    Then the response status should be "400"
+    Then the response status should be "422"
     And the response body should be an array of 1 errors
     And the first error should have the following properties:
       """
       {
-        "title": "Bad request",
-        "detail": "unpermitted parameter",
+        "title": "Unprocessable resource",
+        "detail": "unsupported permissions",
+        "code": "PERMISSIONS_NOT_ALLOWED",
         "source": {
           "pointer": "/data/attributes/permissions"
+        },
+        "links": {
+          "about": "https://keygen.sh/docs/api/tokens/#tokens-object-attrs-permissions"
         }
       }
       """
@@ -770,15 +780,19 @@ Feature: Generate authentication token for environment
         }
       }
       """
-    Then the response status should be "400"
+    Then the response status should be "422"
     And the response body should be an array of 1 errors
     And the first error should have the following properties:
       """
       {
-        "title": "Bad request",
-        "detail": "unpermitted parameter",
+        "title": "Unprocessable resource",
+        "detail": "unsupported permissions",
+        "code": "PERMISSIONS_NOT_ALLOWED",
         "source": {
           "pointer": "/data/attributes/permissions"
+        },
+        "links": {
+          "about": "https://keygen.sh/docs/api/tokens/#tokens-object-attrs-permissions"
         }
       }
       """
@@ -864,20 +878,26 @@ Feature: Generate authentication token for environment
         }
       }
       """
-    Then the response status should be "400"
-    And the response body should be an array of 1 errors
-    And the first error should have the following properties:
+    Then the response status should be "201"
+    And the response body should be a "token" with the following attributes:
       """
       {
-        "title": "Bad request",
-        "detail": "unpermitted parameter",
-        "source": {
-          "pointer": "/data/attributes/permissions"
-        }
+        "permissions": [
+          "license.create",
+          "license.read",
+          "license.suspend",
+          "license.validate",
+          "machine.create",
+          "machine.read",
+          "machine.update",
+          "policy.create",
+          "policy.read",
+          "policy.update"
+        ]
       }
       """
-    And sidekiq should have 0 "webhook" jobs
-    And sidekiq should have 0 "metric" jobs
+    And sidekiq should have 2 "webhook" jobs
+    And sidekiq should have 1 "metric" job
     And sidekiq should have 1 "request-log" job
 
   Scenario: Admin generates an environment token with permissions for environment with wildcard permission (ent tier)

--- a/features/api/v1/licenses/create.feature
+++ b/features/api/v1/licenses/create.feature
@@ -5125,18 +5125,20 @@ Feature: Create license
         }
       }
       """
-    Then the response status should be "400"
-    And the response body should be an array of 1 error
-    And the first error should have the following properties:
+    Then the response status should be "201"
+    And the current account should have 1 "license"
+    And the response body should be a "license" with the following attributes:
       """
       {
-        "title": "Bad request",
-        "detail": "unpermitted parameter",
-        "source": {
-          "pointer": "/data/attributes/permissions"
-        }
+        "permissions": [
+          "license.read",
+          "license.validate"
+        ]
       }
       """
+    And sidekiq should have 1 "webhook" job
+    And sidekiq should have 1 "metric" job
+    And sidekiq should have 1 "request-log" job
 
   @ee
   Scenario: Product creates a license with custom permissions (ent tier, EE)
@@ -5226,18 +5228,19 @@ Feature: Create license
         }
       }
       """
-    Then the response status should be "400"
-    And the response body should be an array of 1 error
-    And the first error should have the following properties:
+    Then the response status should be "201"
+    And the current account should have 1 "license"
+    And the response body should be a "license" with the following attributes:
       """
       {
-        "title": "Bad request",
-        "detail": "unpermitted parameter",
-        "source": {
-          "pointer": "/data/attributes/permissions"
-        }
+        "permissions": [
+          "license.read",
+          "license.validate"
+        ]
       }
       """
+    And sidekiq should have 1 "webhook" job
+    And sidekiq should have 1 "metric" job
 
   @ee
   Scenario: Product creates a user license with custom permissions (ent tier)
@@ -5326,18 +5329,25 @@ Feature: Create license
         }
       }
       """
-    Then the response status should be "400"
-    And the response body should be an array of 1 error
+    Then the response status should be "422"
+    And the response body should be an array of 1 errors
     And the first error should have the following properties:
       """
       {
-        "title": "Bad request",
-        "detail": "unpermitted parameter",
-        "source": {
-          "pointer": "/data/attributes/permissions"
+          "title": "Unprocessable resource",
+          "detail": "unsupported permissions",
+          "code": "PERMISSIONS_NOT_ALLOWED",
+          "source": {
+            "pointer": "/data/attributes/permissions"
+          },
+          "links": {
+            "about": "https://keygen.sh/docs/api/licenses/#licenses-object-attrs-permissions"
+          }
         }
-      }
       """
+    And sidekiq should have 0 "webhook" jobs
+    And sidekiq should have 0 "metric" jobs
+    And sidekiq should have 1 "request-log" job
 
   @ee
   Scenario: Product creates a license with unsupported permissions (ent tier)
@@ -5417,18 +5427,25 @@ Feature: Create license
         }
       }
       """
-    Then the response status should be "400"
-    And the response body should be an array of 1 error
+    Then the response status should be "422"
+    And the response body should be an array of 1 errors
     And the first error should have the following properties:
       """
       {
-        "title": "Bad request",
-        "detail": "unpermitted parameter",
-        "source": {
-          "pointer": "/data/attributes/permissions"
+          "title": "Unprocessable resource",
+          "detail": "unsupported permissions",
+          "code": "PERMISSIONS_NOT_ALLOWED",
+          "source": {
+            "pointer": "/data/attributes/permissions"
+          },
+          "links": {
+            "about": "https://keygen.sh/docs/api/licenses/#licenses-object-attrs-permissions"
+          }
         }
-      }
       """
+    And sidekiq should have 0 "webhook" jobs
+    And sidekiq should have 0 "metric" jobs
+    And sidekiq should have 1 "request-log" job
 
   @ee
   Scenario: Product creates a license with invalid permissions (ent tier)

--- a/features/api/v1/licenses/create.feature
+++ b/features/api/v1/licenses/create.feature
@@ -5301,6 +5301,131 @@ Feature: Create license
     And sidekiq should have 1 "request-log" job
 
   @ee
+  Scenario: Product creates a user license with default permissions (without override)
+    Given the current account is "test1"
+    And the current account has 1 "webhook-endpoint"
+    And the current account has 1 "product"
+    And the current account has 1 "policy" for the last "product"
+    And I am a product of account "test1"
+    And I use an authentication token
+    When I send a POST request to "/accounts/test1/licenses" with the following:
+      """
+      {
+        "data": {
+          "type": "licenses",
+          "relationships": {
+            "policy": {
+              "data": {
+                "type": "policies",
+                "id": "$policies[0]"
+              }
+            }
+          }
+        }
+      }
+      """
+    Then the response status should be "201"
+    And the current account should have 1 "license"
+    And the response body should be a "license" with the following attributes:
+      """
+      {
+        "permissions": [
+          "arch.read",
+          "artifact.read",
+          "channel.read",
+          "component.create",
+          "component.delete",
+          "component.read",
+          "component.update",
+          "constraint.read",
+          "engine.read",
+          "entitlement.read",
+          "group.owners.read",
+          "group.read",
+          "license.check-in",
+          "license.check-out",
+          "license.read",
+          "license.usage.increment",
+          "license.validate",
+          "machine.check-out",
+          "machine.create",
+          "machine.delete",
+          "machine.heartbeat.ping",
+          "machine.proofs.generate",
+          "machine.read",
+          "machine.update",
+          "package.read",
+          "platform.read",
+          "process.create",
+          "process.delete",
+          "process.heartbeat.ping",
+          "process.read",
+          "process.update",
+          "release.download",
+          "release.read",
+          "release.upgrade",
+          "token.read",
+          "token.regenerate",
+          "token.revoke"
+        ]
+      }
+      """
+    And sidekiq should have 1 "webhook" job
+    And sidekiq should have 1 "metric" job
+
+  @ee
+  Scenario: Product creates a user license with default permissions (with override)
+    Given the current account is "ent1"
+    And the current account has 1 "webhook-endpoint"
+    And the current account has 1 "product"
+    And the current account has 1 "policy" for the last "product"
+     And the current account has 1 "setting" with the following:
+      """
+      {
+        "key": "default_license_permissions",
+        "value":  [
+          "license.read",
+          "license.validate",
+          "machine.create",
+          "machine.read"
+        ]
+      }
+      """
+    And I am a product of account "ent1"
+    And I use an authentication token
+    When I send a POST request to "/accounts/ent1/licenses" with the following:
+      """
+      {
+        "data": {
+          "type": "licenses",
+          "relationships": {
+            "policy": {
+              "data": {
+                "type": "policies",
+                "id": "$policies[0]"
+              }
+            }
+          }
+        }
+      }
+      """
+    Then the response status should be "201"
+    And the current account should have 1 "license"
+    And the response body should be a "license" with the following attributes:
+      """
+      {
+        "permissions": [
+          "license.read",
+          "license.validate",
+          "machine.create",
+          "machine.read"
+        ]
+      }
+      """
+    And sidekiq should have 1 "webhook" job
+    And sidekiq should have 1 "metric" job
+
+  @ee
   Scenario: Product creates a license with unsupported permissions (standard tier)
     Given the current account is "test1"
     And the current account has 1 "webhook-endpoint"
@@ -5597,6 +5722,67 @@ Feature: Create license
     And sidekiq should have 0 "webhook" jobs
     And sidekiq should have 0 "metric" jobs
     And sidekiq should have 1 "request-log" job
+
+  @ee
+  Scenario: User creates a license with default permissions (ent tier)
+    Given the current account is "ent1"
+    And the current account has 1 unprotected "policy"
+    And the current account has 1 "webhook-endpoint"
+    And the current account has 1 "user"
+    And the current account has 1 "setting" with the following:
+      """
+      {
+        "key": "default_license_permissions",
+        "value": [
+          "license.read",
+          "license.validate",
+          "machine.create",
+          "machine.read",
+          "user.read"
+        ]
+      }
+      """
+    And I am a user of account "ent1"
+    And I use an authentication token
+    When I send a POST request to "/accounts/ent1/licenses" with the following:
+      """
+      {
+        "data": {
+          "type": "licenses",
+          "relationships": {
+            "policy": {
+              "data": {
+                "type": "policies",
+                "id": "$policies[0]"
+              }
+            },
+            "user": {
+              "data": {
+                "type": "users",
+                "id": "$users[1]"
+              }
+            }
+          }
+        }
+      }
+      """
+    Then the response status should be "201"
+    And the current account should have 1 "license"
+    And the response body should be a "license" with the following attributes:
+      """
+      {
+        "permissions": [
+          "license.read",
+          "license.validate",
+          "machine.create",
+          "machine.read",
+          "user.read"
+        ]
+      }
+      """
+    And sidekiq should have 1 "webhook" job
+    And sidekiq should have 1 "request-log" job
+    And sidekiq should have 1 "event-log" job
 
   Scenario: User creates a license using an unprotected policy
     Given the current account is "test1"

--- a/features/api/v1/licenses/relationships/tokens.feature
+++ b/features/api/v1/licenses/relationships/tokens.feature
@@ -1040,7 +1040,7 @@ Feature: Generate authentication token for license
       { "Keygen-Environment": "shared" }
       """
   @ce
-  Scenario: Product generates a license token with custom permissions (standard tier, ECEE)
+  Scenario: Product generates a license token with custom permissions (standard tier, CE)
     Given the current account is "test1"
     And the current account has 1 "product"
     And the current account has 1 "policy" for the last "product"

--- a/features/api/v1/products/create.feature
+++ b/features/api/v1/products/create.feature
@@ -502,18 +502,21 @@ Feature: Create product
         }
       }
       """
-    Then the response status should be "400"
-    And the response body should be an array of 1 error
-    And the first error should have the following properties:
+    Then the response status should be "201"
+    And the current account should have 1 "product"
+    And the response body should be a "product" with the following attributes:
       """
       {
-        "title": "Bad request",
-        "detail": "unpermitted parameter",
-        "source": {
-          "pointer": "/data/attributes/permissions"
-        }
+        "permissions": [
+          "license.create",
+          "license.read",
+          "license.validate"
+        ]
       }
       """
+    And sidekiq should have 1 "webhook" job
+    And sidekiq should have 1 "metric" job
+    And sidekiq should have 1 "request-log" job
 
   @ee
   Scenario: Admin creates a product with custom permissions (ent tier, EE)
@@ -573,18 +576,25 @@ Feature: Create product
         }
       }
       """
-    Then the response status should be "400"
-    And the response body should be an array of 1 error
+    Then the response status should be "422"
+    And the response body should be an array of 1 errors
     And the first error should have the following properties:
       """
       {
-        "title": "Bad request",
-        "detail": "unpermitted parameter",
+        "title": "Unprocessable resource",
+        "detail": "unsupported permissions",
+        "code": "PERMISSIONS_NOT_ALLOWED",
         "source": {
           "pointer": "/data/attributes/permissions"
+        },
+        "links": {
+          "about": "https://keygen.sh/docs/api/products/#products-object-attrs-permissions"
         }
       }
       """
+    And sidekiq should have 0 "webhook" jobs
+    And sidekiq should have 0 "metric" jobs
+    And sidekiq should have 1 "request-log" job
 
   @ee
   Scenario: Admin creates a product with unsupported permissions (ent tier)
@@ -646,18 +656,25 @@ Feature: Create product
         }
       }
       """
-    Then the response status should be "400"
-    And the response body should be an array of 1 error
+    Then the response status should be "422"
+    And the response body should be an array of 1 errors
     And the first error should have the following properties:
       """
       {
-        "title": "Bad request",
-        "detail": "unpermitted parameter",
+        "title": "Unprocessable resource",
+        "detail": "unsupported permissions",
+        "code": "PERMISSIONS_NOT_ALLOWED",
         "source": {
           "pointer": "/data/attributes/permissions"
+        },
+        "links": {
+          "about": "https://keygen.sh/docs/api/products/#products-object-attrs-permissions"
         }
       }
       """
+    And sidekiq should have 0 "webhook" jobs
+    And sidekiq should have 0 "metric" jobs
+    And sidekiq should have 1 "request-log" job
 
   @ee
   Scenario: Admin creates a product with invalid permissions (ent tier)

--- a/features/api/v1/products/relationships/tokens.feature
+++ b/features/api/v1/products/relationships/tokens.feature
@@ -811,20 +811,22 @@ Feature: Generate authentication token for product
         }
       }
       """
-    Then the response status should be "400"
-    And the response body should be an array of 1 errors
-    And the first error should have the following properties:
+    Then the response status should be "200"
+    And the response body should be a "token" with the following attributes:
       """
       {
-        "title": "Bad request",
-        "detail": "unpermitted parameter",
-        "source": {
-          "pointer": "/data/attributes/permissions"
-        }
+        "permissions": [
+          "license.read",
+          "license.suspend",
+          "license.validate",
+          "machine.create",
+          "machine.read",
+          "machine.update"
+        ]
       }
       """
-    And sidekiq should have 0 "webhook" jobs
-    And sidekiq should have 0 "metric" jobs
+    And sidekiq should have 2 "webhook" jobs
+    And sidekiq should have 1 "metric" job
     And sidekiq should have 1 "request-log" job
 
   @ee
@@ -902,15 +904,19 @@ Feature: Generate authentication token for product
         }
       }
       """
-    Then the response status should be "400"
+    Then the response status should be "422"
     And the response body should be an array of 1 errors
     And the first error should have the following properties:
       """
       {
-        "title": "Bad request",
-        "detail": "unpermitted parameter",
+        "title": "Unprocessable resource",
+        "detail": "unsupported permissions",
+        "code": "PERMISSIONS_NOT_ALLOWED",
         "source": {
           "pointer": "/data/attributes/permissions"
+        },
+        "links": {
+          "about": "https://keygen.sh/docs/api/tokens/#tokens-object-attrs-permissions"
         }
       }
       """
@@ -970,6 +976,7 @@ Feature: Generate authentication token for product
     And sidekiq should have 0 "metric" jobs
     And sidekiq should have 1 "request-log" job
 
+  @ee
   Scenario: Admin generates a product token with unsupported permissions (standard tier)
     Given I am an admin of account "test1"
     And the current account is "test1"
@@ -987,15 +994,19 @@ Feature: Generate authentication token for product
         }
       }
       """
-    Then the response status should be "400"
+    Then the response status should be "422"
     And the response body should be an array of 1 errors
     And the first error should have the following properties:
       """
       {
-        "title": "Bad request",
-        "detail": "unpermitted parameter",
+        "title": "Unprocessable resource",
+        "detail": "unsupported permissions",
+        "code": "PERMISSIONS_NOT_ALLOWED",
         "source": {
           "pointer": "/data/attributes/permissions"
+        },
+        "links": {
+          "about": "https://keygen.sh/docs/api/tokens/#tokens-object-attrs-permissions"
         }
       }
       """
@@ -1059,15 +1070,19 @@ Feature: Generate authentication token for product
         }
       }
       """
-    Then the response status should be "400"
+    Then the response status should be "422"
     And the response body should be an array of 1 errors
     And the first error should have the following properties:
       """
       {
-        "title": "Bad request",
-        "detail": "unpermitted parameter",
+        "title": "Unprocessable resource",
+        "detail": "unsupported permissions",
+        "code": "PERMISSIONS_NOT_ALLOWED",
         "source": {
           "pointer": "/data/attributes/permissions"
+        },
+        "links": {
+          "about": "https://keygen.sh/docs/api/tokens/#tokens-object-attrs-permissions"
         }
       }
       """
@@ -1145,20 +1160,26 @@ Feature: Generate authentication token for product
         }
       }
       """
-    Then the response status should be "400"
-    And the response body should be an array of 1 errors
-    And the first error should have the following properties:
+    Then the response status should be "200"
+    And the response body should be a "token" with the following attributes:
       """
       {
-        "title": "Bad request",
-        "detail": "unpermitted parameter",
-        "source": {
-          "pointer": "/data/attributes/permissions"
-        }
+        "permissions": [
+          "license.create",
+          "license.read",
+          "license.suspend",
+          "license.validate",
+          "machine.create",
+          "machine.read",
+          "machine.update",
+          "policy.create",
+          "policy.read",
+          "policy.update"
+        ]
       }
       """
-    And sidekiq should have 0 "webhook" jobs
-    And sidekiq should have 0 "metric" jobs
+    And sidekiq should have 2 "webhook" jobs
+    And sidekiq should have 1 "metric" job
     And sidekiq should have 1 "request-log" job
 
   @ee

--- a/features/api/v1/users/create.feature
+++ b/features/api/v1/users/create.feature
@@ -2035,6 +2035,136 @@ Feature: Create user
     And sidekiq should have 1 "request-log" job
 
   @ee
+  Scenario: Product creates a user with default permissions (without override)
+    Given the current account is "test1"
+    And the current account has 3 "webhook-endpoints"
+    And the current account has 1 "product"
+    And I am a product of account "test1"
+    And I use an authentication token
+    When I send a POST request to "/accounts/test1/users" with the following:
+      """
+      {
+        "data": {
+          "type": "users",
+          "attributes": {
+            "email": "mark.s@lumon.example"
+          }
+        }
+      }
+      """
+    Then the response status should be "201"
+    And the current account should have 1 "user"
+    And the response body should be a "user" with the following attributes:
+      """
+      {
+        "permissions": [
+          "arch.read",
+          "artifact.read",
+          "channel.read",
+          "component.create",
+          "component.delete",
+          "component.read",
+          "component.update",
+          "constraint.read",
+          "engine.read",
+          "entitlement.read",
+          "group.licenses.read",
+          "group.machines.read",
+          "group.owners.read",
+          "group.read",
+          "group.users.read",
+          "license.check-in",
+          "license.check-out",
+          "license.create",
+          "license.delete",
+          "license.policy.update",
+          "license.read",
+          "license.renew",
+          "license.revoke",
+          "license.usage.increment",
+          "license.validate",
+          "machine.check-out",
+          "machine.create",
+          "machine.delete",
+          "machine.heartbeat.ping",
+          "machine.proofs.generate",
+          "machine.read",
+          "machine.update",
+          "package.read",
+          "platform.read",
+          "process.create",
+          "process.delete",
+          "process.heartbeat.ping",
+          "process.read",
+          "process.update",
+          "release.download",
+          "release.read",
+          "release.upgrade",
+          "token.generate",
+          "token.read",
+          "token.regenerate",
+          "token.revoke",
+          "user.password.reset",
+          "user.password.update",
+          "user.read",
+          "user.second-factors.create",
+          "user.second-factors.delete",
+          "user.second-factors.read",
+          "user.second-factors.update",
+          "user.update"
+        ]
+      }
+      """
+    And sidekiq should have 3 "webhook" jobs
+    And sidekiq should have 1 "metric" job
+    And sidekiq should have 1 "request-log" job
+
+  @ee
+  Scenario: Product creates a user with default permissions (with override)
+    Given the current account is "ent1"
+    And the current account has 3 "webhook-endpoints"
+    And the current account has 1 "product"
+    And the current account has 1 "setting" with the following:
+      """
+      {
+        "key": "default_user_permissions",
+        "value":  [
+          "license.read",
+          "license.validate",
+          "user.read"
+        ]
+      }
+      """
+    And I am a product of account "ent1"
+    And I use an authentication token
+    When I send a POST request to "/accounts/ent1/users" with the following:
+      """
+      {
+        "data": {
+          "type": "users",
+          "attributes": {
+            "email": "mark.s@lumon.example"
+          }
+        }
+      }
+      """
+    Then the response status should be "201"
+    And the current account should have 1 "user"
+    And the response body should be a "user" with the following attributes:
+      """
+      {
+        "permissions": [
+          "license.read",
+          "license.validate",
+          "user.read"
+        ]
+      }
+      """
+    And sidekiq should have 3 "webhook" jobs
+    And sidekiq should have 1 "metric" job
+    And sidekiq should have 1 "request-log" job
+
+  @ee
   Scenario: Product creates a user with unsupported permissions (standard tier)
     Given the current account is "test1"
     And the current account has 3 "webhook-endpoints"
@@ -2634,6 +2764,112 @@ Feature: Create user
     And sidekiq should have 0 "webhook" jobs
     And sidekiq should have 0 "metric" jobs
     And sidekiq should have 1 "request-log" job
+
+  @ee
+  Scenario: Anonymous creates a user with default permissions (without override)
+    Given the current account is "ent1"
+    And the current account has 3 "webhook-endpoints"
+    And the current account has 1 "product"
+    And the current account has 1 "setting" with the following:
+      """
+      {
+        "key": "default_user_permissions",
+        "value":  [
+          "license.read",
+          "license.validate",
+          "machine.create",
+          "machine.read",
+          "user.password.reset",
+          "user.password.update",
+          "user.read",
+          "user.update"
+        ]
+      }
+      """
+    When I send a POST request to "/accounts/ent1/users" with the following:
+      """
+      {
+        "data": {
+          "type": "users",
+          "attributes": {
+            "email": "mark.s@lumon.example"
+          }
+        }
+      }
+      """
+    Then the response status should be "201"
+    And the current account should have 1 "user"
+    And the response body should be a "user" with the following attributes:
+      """
+      {
+        "permissions": [
+          "license.read",
+          "license.validate",
+          "machine.create",
+          "machine.read",
+          "user.password.reset",
+          "user.password.update",
+          "user.read",
+          "user.update"
+        ]
+      }
+      """
+    And sidekiq should have 3 "webhook" jobs
+    And sidekiq should have 1 "request-log" job
+    And sidekiq should have 1 "event-log" job
+
+  @ee
+  Scenario: Anonymous creates a user with default permissions (with override)
+    Given the current account is "ent1"
+    And the current account has 3 "webhook-endpoints"
+    And the current account has 1 "product"
+    And the current account has 1 "setting" with the following:
+      """
+      {
+        "key": "default_user_permissions",
+        "value":  [
+          "license.read",
+          "license.validate",
+          "machine.create",
+          "machine.read",
+          "user.password.reset",
+          "user.password.update",
+          "user.read",
+          "user.update"
+        ]
+      }
+      """
+    When I send a POST request to "/accounts/ent1/users" with the following:
+      """
+      {
+        "data": {
+          "type": "users",
+          "attributes": {
+            "email": "mark.s@lumon.example",
+            "permissions": [
+              "license.read",
+              "license.validate",
+              "user.read"
+            ]
+          }
+        }
+      }
+      """
+    Then the response status should be "400"
+    And the response body should be an array of 1 error
+    And the first error should have the following properties:
+      """
+      {
+        "title": "Bad request",
+        "detail": "unpermitted parameter",
+        "source": {
+          "pointer": "/data/attributes/permissions"
+        }
+      }
+      """
+    And sidekiq should have 0 "webhook" jobs
+    And sidekiq should have 1 "request-log" job
+    And sidekiq should have 0 "event-log" jobs
 
   Scenario: Anonymous attempts to send a request containing an invalid byte sequence (bad UTF-8 encoding)
     Given the current account is "test1"

--- a/features/api/v1/users/create.feature
+++ b/features/api/v1/users/create.feature
@@ -1709,18 +1709,17 @@ Feature: Create user
         }
       }
       """
-    Then the response status should be "400"
-    And the response body should be an array of 1 errors
-    And the first error should have the following properties:
+    Then the response status should be "201"
+    And the response body should be a "user" with the following attributes:
       """
       {
-        "title": "Bad request",
-        "detail": "unpermitted parameter",
-        "source": {
-          "pointer": "/data/attributes/permissions"
-        }
+        "permissions": ["policy.create", "product.create"]
       }
       """
+    And the current account should have 2 "admins"
+    And sidekiq should have 1 "webhook" job
+    And sidekiq should have 1 "metric" job
+    And sidekiq should have 1 "request-log" job
 
   @ee
   Scenario: Admin attempts to create another admin with custom permissions (ent tier, EE)
@@ -1980,18 +1979,20 @@ Feature: Create user
         }
       }
       """
-    Then the response status should be "400"
-    And the response body should be an array of 1 errors
-    And the first error should have the following properties:
+    Then the response status should be "201"
+    And the current account should have 1 "user"
+    And the response body should be a "user" with the following attributes:
       """
       {
-        "title": "Bad request",
-        "detail": "unpermitted parameter",
-        "source": {
-          "pointer": "/data/attributes/permissions"
-        }
+        "permissions": [
+          "license.read",
+          "license.validate"
+        ]
       }
       """
+    And sidekiq should have 3 "webhook" jobs
+    And sidekiq should have 1 "metric" job
+    And sidekiq should have 1 "request-log" job
 
   @ee
   Scenario: Product creates a user with custom permissions (ent tier, EE)
@@ -2057,18 +2058,25 @@ Feature: Create user
         }
       }
       """
-    Then the response status should be "400"
+    Then the response status should be "422"
     And the response body should be an array of 1 errors
     And the first error should have the following properties:
       """
       {
-        "title": "Bad request",
-        "detail": "unpermitted parameter",
+        "title": "Unprocessable resource",
+        "detail": "unsupported permissions",
+        "code": "PERMISSIONS_NOT_ALLOWED",
         "source": {
           "pointer": "/data/attributes/permissions"
+        },
+        "links": {
+          "about": "https://keygen.sh/docs/api/users/#users-object-attrs-permissions"
         }
       }
       """
+    And sidekiq should have 0 "webhook" jobs
+    And sidekiq should have 0 "metric" jobs
+    And sidekiq should have 1 "request-log" job
 
   @ee
   Scenario: Product creates a user with unsupported permissions (ent tier)
@@ -2138,18 +2146,25 @@ Feature: Create user
         }
       }
       """
-    Then the response status should be "400"
+    Then the response status should be "422"
     And the response body should be an array of 1 errors
     And the first error should have the following properties:
       """
       {
-        "title": "Bad request",
-        "detail": "unpermitted parameter",
+        "title": "Unprocessable resource",
+        "detail": "unsupported permissions",
+        "code": "PERMISSIONS_NOT_ALLOWED",
         "source": {
           "pointer": "/data/attributes/permissions"
+        },
+        "links": {
+          "about": "https://keygen.sh/docs/api/users/#users-object-attrs-permissions"
         }
       }
       """
+    And sidekiq should have 0 "webhook" jobs
+    And sidekiq should have 0 "metric" jobs
+    And sidekiq should have 1 "request-log" job
 
   @ee
   Scenario: Product creates a user with invalid permissions (ent tier)
@@ -2217,18 +2232,15 @@ Feature: Create user
         }
       }
       """
-    Then the response status should be "400"
-    And the response body should be an array of 1 errors
-    And the first error should have the following properties:
+    Then the response status should be "201"
+    And the current account should have 1 "user"
+    And the response body should be a "user" with the following attributes:
       """
-      {
-        "title": "Bad request",
-        "detail": "unpermitted parameter",
-        "source": {
-          "pointer": "/data/attributes/permissions"
-        }
-      }
+      { "permissions": [] }
       """
+    And sidekiq should have 3 "webhook" jobs
+    And sidekiq should have 1 "metric" job
+    And sidekiq should have 1 "request-log" job
 
   @ee
   Scenario: Product creates a user with no permissions (ent tier)
@@ -2256,9 +2268,7 @@ Feature: Create user
     And the current account should have 1 "user"
     And the response body should be a "user" with the following attributes:
       """
-      {
-        "permissions": []
-      }
+      { "permissions": [] }
       """
     And sidekiq should have 3 "webhook" jobs
     And sidekiq should have 1 "metric" job

--- a/features/api/v1/users/create.feature
+++ b/features/api/v1/users/create.feature
@@ -2766,7 +2766,7 @@ Feature: Create user
     And sidekiq should have 1 "request-log" job
 
   @ee
-  Scenario: Anonymous creates a user with default permissions (without override)
+  Scenario: Anonymous creates a user with default permissions (with override)
     Given the current account is "ent1"
     And the current account has 3 "webhook-endpoints"
     And the current account has 1 "product"
@@ -2819,7 +2819,7 @@ Feature: Create user
     And sidekiq should have 1 "event-log" job
 
   @ee
-  Scenario: Anonymous creates a user with default permissions (with override)
+  Scenario: Anonymous creates a user with custom permissions (with override)
     Given the current account is "ent1"
     And the current account has 3 "webhook-endpoints"
     And the current account has 1 "product"

--- a/features/api/v1/users/relationships/tokens.feature
+++ b/features/api/v1/users/relationships/tokens.feature
@@ -1012,19 +1012,15 @@ Feature: User tokens relationship
         }
       }
       """
-    Then the response status should be "400"
+    Then the response status should be "200"
     And the response should contain a valid signature header for "test1"
-    And the response body should be an array of 1 error
-    And the first error should have the following properties:
+    And the response body should be a "token" with the following attributes:
       """
-      {
-        "title": "Bad request",
-        "detail": "unpermitted parameter",
-        "source": {
-          "pointer": "/data/attributes/permissions"
-        }
-      }
+      { "permissions": ["license.validate"] }
       """
+    And sidekiq should have 0 "webhook" jobs
+    And sidekiq should have 1 "metric" job
+    And sidekiq should have 1 "request-log" job
 
   @ee
   Scenario: Product generates a user token with custom permissions (ent tier, EE)
@@ -1081,19 +1077,26 @@ Feature: User tokens relationship
         }
       }
       """
-    Then the response status should be "400"
+    Then the response status should be "422"
     And the response should contain a valid signature header for "test1"
-    And the response body should be an array of 1 error
+    And the response body should be an array of 1 errors
     And the first error should have the following properties:
       """
       {
-        "title": "Bad request",
-        "detail": "unpermitted parameter",
+        "title": "Unprocessable resource",
+        "detail": "unsupported permissions",
+        "code": "PERMISSIONS_NOT_ALLOWED",
         "source": {
           "pointer": "/data/attributes/permissions"
+        },
+        "links": {
+          "about": "https://keygen.sh/docs/api/tokens/#tokens-object-attrs-permissions"
         }
       }
       """
+    And sidekiq should have 0 "webhook" jobs
+    And sidekiq should have 0 "metric" jobs
+    And sidekiq should have 1 "request-log" job
 
   @ee
   Scenario: Product generates a user token with permissions that exceed the user's permissions (ent tier)
@@ -1161,19 +1164,26 @@ Feature: User tokens relationship
         }
       }
       """
-    Then the response status should be "400"
+    Then the response status should be "422"
     And the response should contain a valid signature header for "test1"
-    And the response body should be an array of 1 error
+    And the response body should be an array of 1 errors
     And the first error should have the following properties:
       """
       {
-        "title": "Bad request",
-        "detail": "unpermitted parameter",
+        "title": "Unprocessable resource",
+        "detail": "unsupported permissions",
+        "code": "PERMISSIONS_NOT_ALLOWED",
         "source": {
           "pointer": "/data/attributes/permissions"
+        },
+        "links": {
+          "about": "https://keygen.sh/docs/api/tokens/#tokens-object-attrs-permissions"
         }
       }
       """
+    And sidekiq should have 0 "webhook" jobs
+    And sidekiq should have 0 "metric" jobs
+    And sidekiq should have 1 "request-log" job
 
   @ee
   Scenario: Product generates a user token with unsupported permissions (ent tier)
@@ -1232,19 +1242,26 @@ Feature: User tokens relationship
         }
       }
       """
-    Then the response status should be "400"
+    Then the response status should be "422"
     And the response should contain a valid signature header for "test1"
-    And the response body should be an array of 1 error
+    And the response body should be an array of 1 errors
     And the first error should have the following properties:
       """
       {
-        "title": "Bad request",
-        "detail": "unpermitted parameter",
+        "title": "Unprocessable resource",
+        "detail": "unsupported permissions",
+        "code": "PERMISSIONS_NOT_ALLOWED",
         "source": {
           "pointer": "/data/attributes/permissions"
+        },
+        "links": {
+          "about": "https://keygen.sh/docs/api/tokens/#tokens-object-attrs-permissions"
         }
       }
       """
+    And sidekiq should have 0 "webhook" jobs
+    And sidekiq should have 0 "metric" jobs
+    And sidekiq should have 1 "request-log" job
 
   @ee
   Scenario: Product generates a user token with invalid permissions (ent tier)
@@ -1312,19 +1329,22 @@ Feature: User tokens relationship
         }
       }
       """
-    Then the response status should be "400"
-    And the response should contain a valid signature header for "test1"
-    And the response body should be an array of 1 error
-    And the first error should have the following properties:
+    Then the response status should be "200"
+    And the response body should be a "token" with the following attributes:
       """
       {
-        "title": "Bad request",
-        "detail": "unpermitted parameter",
-        "source": {
-          "pointer": "/data/attributes/permissions"
-        }
+        "permissions": [
+          "license.read",
+          "license.validate",
+          "machine.create",
+          "machine.delete",
+          "machine.read"
+        ]
       }
       """
+    And sidekiq should have 0 "webhook" jobs
+    And sidekiq should have 1 "metric" job
+    And sidekiq should have 1 "request-log" job
 
   @ee
   Scenario: Product generates a user token with permissions for a user with wildcard permission (ent tier)

--- a/features/api/v1/users/update.feature
+++ b/features/api/v1/users/update.feature
@@ -1107,16 +1107,12 @@ Feature: Update user
         }
       }
       """
-    Then the response status should be "400"
-    And the response body should be an array of 1 error
-    And the first error should have the following properties:
+    Then the response status should be "200"
+    And the response body should be a "user" with the following attributes:
       """
       {
-        "title": "Bad request",
-        "detail": "unpermitted parameter",
-        "source": {
-          "pointer": "/data/attributes/permissions"
-        }
+        "permissions": ["license.validate"],
+        "role": "user"
       }
       """
 
@@ -1163,16 +1159,12 @@ Feature: Update user
         }
       }
       """
-    Then the response status should be "400"
-    And the response body should be an array of 1 error
-    And the first error should have the following properties:
+     Then the response status should be "200"
+    And the response body should be a "user" with the following attributes:
       """
       {
-        "title": "Bad request",
-        "detail": "unpermitted parameter",
-        "source": {
-          "pointer": "/data/attributes/permissions"
-        }
+        "permissions": [],
+        "role": "user"
       }
       """
 
@@ -1233,6 +1225,10 @@ Feature: Update user
     Given I am an admin of account "ent1"
     And the current account is "ent1"
     And the current account has 2 "admins"
+    And the first "admin" has the following permissions:
+      """
+      ["admin.update", "admin.read", "user.update", "user.read", "license.read", "license.validate", "machine.read"]
+      """
     And I use an authentication token
     When I send a PATCH request to "/accounts/ent1/users/$1" with the following:
       """

--- a/spec/factories/account_setting.rb
+++ b/spec/factories/account_setting.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :account_setting, aliases: %i[setting] do
+    initialize_with { AccountSetting.find_by(account:, key:) || new(**attributes.reject { _2 in NIL_ACCOUNT }) }
+
+    sequence :key, %w[default_license_permissions default_user_permissions].cycle
+    value { %w[license.validate] }
+
+    account { nil }
+  end
+end

--- a/spec/models/license_spec.rb
+++ b/spec/models/license_spec.rb
@@ -256,6 +256,17 @@ describe License, type: :model do
           expect(actions).to match_array %w[license.read license.validate]
         end
       end
+
+      context 'with default license permissions override' do
+        before { create(:setting, key: :default_license_permissions, value: %w[license.validate machine.create], account:) }
+
+        it 'should set default permissions' do
+          license = create(:license, account:)
+          actions = license.permissions.actions
+
+          expect(actions).to match_array account.settings.default_license_permissions
+        end
+      end
     end
 
     context 'on update' do

--- a/spec/models/license_spec.rb
+++ b/spec/models/license_spec.rb
@@ -260,7 +260,7 @@ describe License, type: :model do
       context 'with default license permissions override' do
         before { create(:setting, key: :default_license_permissions, value: %w[license.validate machine.create], account:) }
 
-        it 'should set default permissions' do
+        it 'should override default permissions' do
           license = create(:license, account:)
           actions = license.permissions.actions
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -111,6 +111,17 @@ describe User, type: :model do
 
         expect(actions).to match_array %w[license.read license.validate]
       end
+
+      context 'with default user permissions override' do
+        before { create(:setting, key: :default_user_permissions, value: %w[license.validate license.read user.read], account:) }
+
+        it 'should set default permissions' do
+          user    = create(:user, account:)
+          actions = user.permissions.actions
+
+          expect(actions).to match_array account.settings.default_user_permissions
+        end
+      end
     end
 
     context 'on update' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -115,11 +115,18 @@ describe User, type: :model do
       context 'with default user permissions override' do
         before { create(:setting, key: :default_user_permissions, value: %w[license.validate license.read user.read], account:) }
 
-        it 'should set default permissions' do
+        it 'should override default user permissions' do
           user    = create(:user, account:)
           actions = user.permissions.actions
 
           expect(actions).to match_array account.settings.default_user_permissions
+        end
+
+        it 'should not override default admin permissions' do
+          admin   = create(:user, :admin, account:)
+          actions = admin.permissions.actions
+
+          expect(actions).to match_array Permission::ADMIN_PERMISSIONS
         end
       end
     end

--- a/spec/policies/accounts/setting_policy_spec.rb
+++ b/spec/policies/accounts/setting_policy_spec.rb
@@ -117,20 +117,14 @@ describe Accounts::SettingPolicy, type: :policy do
       with_scenarios %i[accessing_its_setting] do
         with_token_authentication do
           with_permissions %w[account.read] do
-            without_token_permissions { denies :show }
-
             denies :show
           end
 
           with_wildcard_permissions do
-            without_token_permissions { denies :show, :create, :update, :destroy }
-
             denies :show, :create, :update, :destroy
           end
 
           with_default_permissions do
-            without_token_permissions { denies :show, :create, :update, :destroy }
-
             denies :show, :create, :update, :destroy
           end
 
@@ -182,20 +176,14 @@ describe Accounts::SettingPolicy, type: :policy do
     with_scenarios %i[accessing_its_setting] do
       with_token_authentication do
         with_permissions %w[account.read] do
-          without_token_permissions { denies :show }
-
           denies :show
         end
 
         with_wildcard_permissions do
-          without_token_permissions { denies :show, :create, :update, :destroy }
-
           denies :show, :create, :update, :destroy
         end
 
         with_default_permissions do
-          without_token_permissions { denies :show, :create, :update, :destroy }
-
           denies :show, :create, :update, :destroy
         end
 
@@ -250,20 +238,14 @@ describe Accounts::SettingPolicy, type: :policy do
 
       with_token_authentication do
         with_permissions %w[account.read] do
-          without_token_permissions { denies :show }
-
           denies :show
         end
 
         with_wildcard_permissions do
-          without_token_permissions { denies :show, :create, :update, :destroy }
-
           denies :show, :create, :update, :destroy
         end
 
         with_default_permissions do
-          without_token_permissions { denies :show, :create, :update, :destroy }
-
           denies :show, :create, :update, :destroy
         end
 
@@ -290,20 +272,14 @@ describe Accounts::SettingPolicy, type: :policy do
     with_scenarios %i[accessing_its_setting] do
       with_token_authentication do
         with_permissions %w[account.read] do
-          without_token_permissions { denies :show }
-
           denies :show
         end
 
         with_wildcard_permissions do
-          without_token_permissions { denies :show, :create, :update, :destroy }
-
           denies :show, :create, :update, :destroy
         end
 
         with_default_permissions do
-          without_token_permissions { denies :show, :create, :update, :destroy }
-
           denies :show, :create, :update, :destroy
         end
 

--- a/spec/policies/accounts/setting_policy_spec.rb
+++ b/spec/policies/accounts/setting_policy_spec.rb
@@ -1,0 +1,330 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'spec_helper'
+
+describe Accounts::SettingPolicy, type: :policy do
+  subject { described_class.new(record, account:, environment:, bearer:, token:) }
+
+  with_role_authorization :admin do
+    with_scenarios %i[accessing_its_settings] do
+      with_token_authentication do
+        with_permissions %w[account.read] do
+          without_token_permissions { denies :index }
+
+          allows :index
+        end
+
+        with_wildcard_permissions do
+          without_token_permissions { denies :index }
+
+          allows :index
+        end
+
+        with_default_permissions  do
+          without_token_permissions { denies :index }
+
+          allows :index
+        end
+
+        without_permissions { denies :index }
+      end
+    end
+
+    with_scenarios %i[accessing_its_setting] do
+      with_token_authentication do
+        with_permissions %w[account.read] do
+          without_token_permissions { denies :show }
+
+          allows :show
+        end
+
+        with_permissions %w[account.update] do
+          without_token_permissions { denies :update }
+
+          allows :update
+        end
+
+        with_wildcard_permissions do
+          without_token_permissions { denies :show, :create, :update, :destroy }
+
+          allows :show, :update, :create, :destroy
+        end
+
+        with_default_permissions do
+          without_token_permissions { denies :show, :create, :update, :destroy }
+
+          allows :show, :update, :create, :destroy
+        end
+
+        without_permissions do
+          denies :show, :create, :update, :destroy
+        end
+      end
+    end
+
+    with_scenarios %i[accessing_settings] do
+      with_token_authentication do
+        with_permissions %w[account.read] do
+          denies :index
+        end
+
+        with_wildcard_permissions { denies :index }
+        with_default_permissions  { denies :index }
+        without_permissions       { denies :index }
+      end
+    end
+
+    with_scenarios %i[accessing_setting] do
+      with_token_authentication do
+        with_permissions %w[account.read] do
+          denies :show
+        end
+
+        with_permissions %w[account.update] do
+          denies :update
+        end
+
+        with_wildcard_permissions do
+          denies :show, :create, :update, :destroy
+        end
+
+        with_default_permissions do
+          denies :show, :create, :update, :destroy
+        end
+
+        without_permissions do
+          denies :show, :create, :update, :destroy
+        end
+      end
+    end
+  end
+
+  with_role_authorization :environment do
+    within_environment :self do
+      with_scenarios %i[accessing_its_settings] do
+        with_token_authentication do
+          with_permissions %w[account.read] do
+            denies :index
+          end
+
+          with_wildcard_permissions { denies :index }
+          with_default_permissions  { denies :index }
+          without_permissions       { denies :index }
+        end
+      end
+
+      with_scenarios %i[accessing_its_setting] do
+        with_token_authentication do
+          with_permissions %w[account.read] do
+            without_token_permissions { denies :show }
+
+            denies :show
+          end
+
+          with_wildcard_permissions do
+            without_token_permissions { denies :show, :create, :update, :destroy }
+
+            denies :show, :create, :update, :destroy
+          end
+
+          with_default_permissions do
+            without_token_permissions { denies :show, :create, :update, :destroy }
+
+            denies :show, :create, :update, :destroy
+          end
+
+          without_permissions do
+            denies :show, :create, :update, :destroy
+          end
+        end
+      end
+    end
+
+    with_scenarios %i[accessing_settings] do
+      with_token_authentication do
+        with_permissions %w[account.read] do
+          denies :index
+        end
+
+        with_wildcard_permissions { denies :index }
+        with_default_permissions  { denies :index }
+        without_permissions       { denies :index }
+      end
+    end
+
+    with_scenarios %i[accessing_its_setting] do
+      with_token_authentication do
+        with_permissions %w[account.read] do
+          denies :show
+        end
+
+        with_wildcard_permissions { denies :show, :create, :update, :destroy }
+        with_default_permissions  { denies :show, :create, :update, :destroy }
+        without_permissions       { denies :show, :create, :update, :destroy }
+      end
+    end
+  end
+
+  with_role_authorization :product do
+    with_scenarios %i[accessing_its_settings] do
+      with_token_authentication do
+        with_permissions %w[account.read] do
+          denies :index
+        end
+
+        with_wildcard_permissions { denies :index }
+        with_default_permissions  { denies :index }
+        without_permissions       { denies :index }
+      end
+    end
+
+    with_scenarios %i[accessing_its_setting] do
+      with_token_authentication do
+        with_permissions %w[account.read] do
+          without_token_permissions { denies :show }
+
+          denies :show
+        end
+
+        with_wildcard_permissions do
+          without_token_permissions { denies :show, :create, :update, :destroy }
+
+          denies :show, :create, :update, :destroy
+        end
+
+        with_default_permissions do
+          without_token_permissions { denies :show, :create, :update, :destroy }
+
+          denies :show, :create, :update, :destroy
+        end
+
+        without_permissions do
+          denies :show, :create, :update, :destroy
+        end
+      end
+    end
+  end
+
+  with_role_authorization :license do
+    with_scenarios %i[accessing_its_settings] do
+      with_license_authentication do
+        with_permissions %w[account.read] do
+          denies :index
+        end
+
+        with_wildcard_permissions { denies :index }
+        with_default_permissions  { denies :index }
+        without_permissions       { denies :index }
+      end
+
+      with_token_authentication do
+        with_permissions %w[account.read] do
+          denies :index
+        end
+
+        with_wildcard_permissions { denies :index }
+        with_default_permissions  { denies :index }
+        without_permissions       { denies :index }
+      end
+    end
+
+    with_scenarios %i[accessing_its_setting] do
+      with_license_authentication do
+        with_permissions %w[account.read] do
+          denies :show
+        end
+
+        with_wildcard_permissions do
+          denies :show, :create, :update, :destroy
+        end
+
+        with_default_permissions do
+          denies :show, :create, :update, :destroy
+        end
+
+        without_permissions do
+          denies :show, :create, :update, :destroy
+        end
+      end
+
+      with_token_authentication do
+        with_permissions %w[account.read] do
+          without_token_permissions { denies :show }
+
+          denies :show
+        end
+
+        with_wildcard_permissions do
+          without_token_permissions { denies :show, :create, :update, :destroy }
+
+          denies :show, :create, :update, :destroy
+        end
+
+        with_default_permissions do
+          without_token_permissions { denies :show, :create, :update, :destroy }
+
+          denies :show, :create, :update, :destroy
+        end
+
+        without_permissions do
+          denies :show, :create, :update, :destroy
+        end
+      end
+    end
+  end
+
+  with_role_authorization :user do
+    with_scenarios %i[accessing_its_settings] do
+      with_token_authentication do
+        with_permissions %w[account.read] do
+          denies :index
+        end
+
+        with_wildcard_permissions { denies :index }
+        with_default_permissions  { denies :index }
+        without_permissions       { denies :index }
+      end
+    end
+
+    with_scenarios %i[accessing_its_setting] do
+      with_token_authentication do
+        with_permissions %w[account.read] do
+          without_token_permissions { denies :show }
+
+          denies :show
+        end
+
+        with_wildcard_permissions do
+          without_token_permissions { denies :show, :create, :update, :destroy }
+
+          denies :show, :create, :update, :destroy
+        end
+
+        with_default_permissions do
+          without_token_permissions { denies :show, :create, :update, :destroy }
+
+          denies :show, :create, :update, :destroy
+        end
+
+        without_permissions do
+          denies :show, :create, :update, :destroy
+        end
+      end
+    end
+  end
+
+  without_authorization do
+    with_scenarios %i[accessing_settings] do
+      without_authentication do
+        denies :index
+      end
+    end
+
+    with_scenarios %i[accessing_setting] do
+      without_authentication do
+        denies :show, :create, :update, :destroy
+      end
+    end
+  end
+end

--- a/spec/support/helpers/authorization_helper.rb
+++ b/spec/support/helpers/authorization_helper.rb
@@ -149,6 +149,42 @@ module AuthorizationHelper
       let(:record) { account.plan }
     end
 
+    def accessing_its_settings(scenarios)
+      case scenarios
+      in [:as_admin | :as_environment | :as_product | :as_license | :as_user | :as_anonymous, *]
+        let(:settings) { create_list(:setting, 2, account:) }
+      end
+
+      let(:record) { account.settings }
+    end
+
+    def accessing_its_setting(scenarios)
+      case scenarios
+      in [:as_admin | :as_environment | :as_product | :as_license | :as_user | :as_anonymous, *]
+        let(:setting) { create(:setting, account:) }
+      end
+
+      let(:record) { setting }
+    end
+
+    def accessing_settings(scenarios)
+      case scenarios
+      in [:as_admin | :as_environment | :as_product | :as_license | :as_user | :as_anonymous, *]
+        let(:settings) { create_list(:setting, 2, account: create(:account)) }
+      end
+
+      let(:record) { settings }
+    end
+
+    def accessing_setting(scenarios)
+      case scenarios
+      in [:as_admin | :as_environment | :as_product | :as_license | :as_user | :as_anonymous, *]
+        let(:setting) { create(:setting, account: create(:account)) }
+      end
+
+      let(:record) { setting }
+    end
+
     def accessing_analytics(scenarios)
       case scenarios
       in [:as_admin | :as_environment | :as_product | :as_license | :as_user | :as_anonymous, *]


### PR DESCRIPTION
This moves custom permissions from an Ent feature to a GA feature for all Cloud tiers, but permissions are still not available in CE. Also adds a new account settings concept, which currently houses default permission overrides for licenses and users.