### PR TITLE
feat: add dev-container for keygen + debian based-docker

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,0 +1,39 @@
+{
+    "name": "keygen-api",
+    "build": {
+        "dockerfile": "debian.dockerfile",
+        "target": "build-base",
+        "context": "."
+    },
+    "workspaceFolder": "/app",
+    "features": {
+        // https://github.com/devcontainers/features/tree/main/src/common-utils
+        "ghcr.io/devcontainers/features/common-utils:2": {
+            "nonFreePackages": true,
+            "upgradePackages": false
+        },
+        // https://github.com/devcontainers/features/tree/main/src/docker-in-docker
+        "ghcr.io/devcontainers/features/docker-in-docker:2": {
+            "moby": false
+        }
+    },
+    "mounts": [
+        {
+            "type": "bind",
+            "source": "${localWorkspaceFolder}",
+            "target": "/app"
+        }
+    ],
+    "customizations": {
+        "vscode": {
+            "settings": {
+                "terminal.integrated.shell.linux": "/bin/bash"
+            },
+            "extensions": [
+                "Shopify.ruby-extensions-pack",
+                "Shopify.ruby-lsp"
+            ]
+        }
+    },
+    "runArgs": ["--network=host"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "explorer.fileNesting.enabled": true,
+    "explorer.fileNesting.patterns": {
+        "README.md": "LICENSE.md, SECURITY.md",
+        "Dockerfile": "*.dockerfile, .devcontainer.*, .dockerignore, captain-definition, compose.*, docker-compose.*, dockerfile*, Caddyfile",
+    }
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,7 @@
 # Base image
 FROM ruby:3.3.8-alpine AS base
 
-ENV BUNDLE_WITHOUT="development:test" \
-  BUNDLE_PATH="/usr/local/bundle" \
-  BUNDLE_DEPLOYMENT="1" \
-  RAILS_ENV="production"
+ENV BUNDLE_PATH="/usr/local/bundle"
 
 # Build base
 FROM base AS build-base
@@ -33,6 +30,10 @@ RUN apk add --no-cache \
 FROM build-base AS build
 WORKDIR /app
 
+ENV BUNDLE_WITHOUT="development:test" \
+  BUNDLE_DEPLOYMENT="1" \
+  RAILS_ENV="production"
+
 COPY ./Gemfile /app/Gemfile
 COPY ./Gemfile.lock /app/Gemfile.lock  
 
@@ -52,6 +53,10 @@ RUN \
 # Final stage
 FROM base AS production
 LABEL maintainer="keygen.sh <oss@keygen.sh>"
+
+ENV BUNDLE_WITHOUT="development:test" \
+  BUNDLE_DEPLOYMENT="1" \
+  RAILS_ENV="production"
 
 RUN apk add --no-cache \
     bash \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,55 +4,61 @@
 FROM ruby:3.3.8-alpine AS base
 
 ENV BUNDLE_WITHOUT="development:test" \
-    BUNDLE_PATH="/usr/local/bundle" \
-    BUNDLE_DEPLOYMENT="1" \
-    RAILS_ENV="production"
+  BUNDLE_PATH="/usr/local/bundle" \
+  BUNDLE_DEPLOYMENT="1" \
+  RAILS_ENV="production"
 
-# Build stage
-FROM base AS build
-
+# Build base
+FROM base AS build-base
 WORKDIR /app
-COPY ./Gemfile /app/Gemfile
-COPY ./Gemfile.lock /app/Gemfile.lock
 
 RUN apk add --no-cache \
-  git \
-  bash \
-  build-base \
-  libxml2-dev \
-  libxslt-dev \
-  yaml-dev \
-  tzdata \
-  openssl \
-  postgresql-dev \
-  libc6-compat \
-  libstdc++ && \
+    git \
+    bash \
+    build-base \
+    libxml2-dev \
+    libxslt-dev \
+    yaml-dev \
+    tzdata \
+    openssl \
+    postgresql-dev \
+    libc6-compat \
+    libstdc++ && \
   bundle config --global without "${BUNDLE_WITHOUT}"  && \
   bundle config --global path "${BUNDLE_PATH}" && \
   bundle config --global deployment "${BUNDLE_DEPLOYMENT}" && \
-  bundle config --global retry 5 && \
+  bundle config --global retry 5
+
+# Build stage
+FROM build-base AS build
+WORKDIR /app
+
+COPY ./Gemfile /app/Gemfile
+COPY ./Gemfile.lock /app/Gemfile.lock  
+
+RUN \
   bundle install && \
   find /usr/local/bundle/ \
-    \( \
-      -name "*.c" -o \
-      -name "*.o" -o \
-      -name "*.a" -o \
-      -name "*.h" -o \
-      -name "Makefile" -o \
-      -name "*.md" \
-    \) -delete && \
+  \( \
+    -name "*.c" -o \
+    -name "*.o" -o \
+    -name "*.a" -o \
+    -name "*.h" -o \
+    -name "Makefile" -o \
+    -name "*.md" \
+  \) -delete && \
   chmod -R a+r "${BUNDLE_PATH}"
 
 # Final stage
-FROM base
+FROM base AS production
 LABEL maintainer="keygen.sh <oss@keygen.sh>"
 
 RUN apk add --no-cache \
-  bash \
-  postgresql-client \
-  tzdata \
-  libc6-compat \
-  libstdc++ && \
+    bash \
+    postgresql-client \
+    tzdata \
+    libc6-compat \
+    libstdc++ && \
   adduser -h /app -g keygen -u 1000 -s /bin/bash -D keygen
 
 COPY --from=build --chown=keygen:keygen \
@@ -65,10 +71,10 @@ RUN chmod +x /app/scripts/entrypoint.sh && \
   chown -R keygen:keygen /app
 
 ENV KEYGEN_EDITION="CE" \
-    KEYGEN_MODE="singleplayer" \
-    RAILS_LOG_TO_STDOUT="1" \
-    PORT="3000" \
-    BIND="0.0.0.0"
+  KEYGEN_MODE="singleplayer" \
+  RAILS_LOG_TO_STDOUT="1" \
+  PORT="3000" \
+  BIND="0.0.0.0"
 
 USER keygen
 

--- a/debian.dockerfile
+++ b/debian.dockerfile
@@ -3,10 +3,7 @@
 # Base image
 FROM ruby:3.3.8-slim AS base
 
-ENV BUNDLE_WITHOUT="development:test" \
-    BUNDLE_PATH="/usr/local/bundle" \
-    BUNDLE_DEPLOYMENT="1" \
-    RAILS_ENV="production"
+ENV BUNDLE_PATH="/usr/local/bundle"
 
 # Build base
 FROM base AS build-base
@@ -31,6 +28,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 FROM build-base AS build
 WORKDIR /app
 
+ENV BUNDLE_WITHOUT="development:test" \
+  BUNDLE_DEPLOYMENT="1" \
+  RAILS_ENV="production"
+ 
 COPY ./Gemfile /app/Gemfile
 COPY ./Gemfile.lock /app/Gemfile.lock  
 RUN \
@@ -49,6 +50,10 @@ RUN \
 # Final stage
 FROM base AS production
 LABEL maintainer="keygen.sh <oss@keygen.sh>"
+
+ENV BUNDLE_WITHOUT="development:test" \
+  BUNDLE_DEPLOYMENT="1" \
+  RAILS_ENV="production"
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     postgresql-client \

--- a/debian.dockerfile
+++ b/debian.dockerfile
@@ -1,0 +1,77 @@
+# syntax=docker/dockerfile:1
+
+# Base image
+FROM ruby:3.3.8-slim AS base
+
+ENV BUNDLE_WITHOUT="development:test" \
+    BUNDLE_PATH="/usr/local/bundle" \
+    BUNDLE_DEPLOYMENT="1" \
+    RAILS_ENV="production"
+
+# Build base
+FROM base AS build-base
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        git \
+        build-essential \
+        libxml2-dev \
+        libxslt-dev \
+        tzdata \
+        openssl \
+        libpq-dev \
+    && rm -rf /var/lib/apt/lists/* \
+    && bundle config --global without "${BUNDLE_WITHOUT}" \
+    && bundle config --global path "${BUNDLE_PATH}" \
+    && bundle config --global deployment "${BUNDLE_DEPLOYMENT}" \
+    && bundle config --global retry 5 
+
+# Build stage
+FROM build-base AS build
+WORKDIR /app
+
+COPY ./Gemfile /app/Gemfile
+COPY ./Gemfile.lock /app/Gemfile.lock  
+RUN \
+    bundle install \
+    && find /usr/local/bundle/ \
+    \( \
+        -name "*.c" -o \
+        -name "*.o" -o \
+        -name "*.a" -o \
+        -name "*.h" -o \
+        -name "Makefile" -o \
+        -name "*.md" \
+    \) -delete \
+    && chmod -R a+r "${BUNDLE_PATH}"
+
+# Final stage
+FROM base AS production
+LABEL maintainer="keygen.sh <oss@keygen.sh>"
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    postgresql-client \
+    tzdata \
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd -m -s /bin/bash -u 1000 keygen
+
+COPY --from=build --chown=keygen:keygen \
+    /usr/local/bundle/ /usr/local/bundle
+
+WORKDIR /app
+COPY . /app
+
+RUN chmod +x /app/scripts/entrypoint.sh && \
+    chown -R keygen:keygen /app
+
+ENV KEYGEN_EDITION="CE" \
+    KEYGEN_MODE="singleplayer" \
+    RAILS_LOG_TO_STDOUT="1" \
+    PORT="3000" \
+    BIND="0.0.0.0"
+
+USER keygen
+
+ENTRYPOINT ["/app/scripts/entrypoint.sh"]
+CMD ["web"]


### PR DESCRIPTION
This adds a dev-container for Keygen, providing an isolated dev environment. 
Additionally, it adds a debian Debian-based Docker image, which is needed to get a better dev container experience (e.g. for docker-in-docker support).

I also separated the build stage into a build-base and build, in which the first one is independent of the gem files, making its caching better. This stage is used as the dev-container base.