### PR TITLE
Add UUIDv7 as default record primary key

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,6 @@ gem 'action_policy', '~> 0.6.3'
 gem 'openssl', '~> 3.1.0'
 gem 'ed25519'
 gem 'jwt'
-gem 'uuid7'
 
 # Scopes and pagination
 gem 'has_scope'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -512,8 +512,6 @@ GEM
       rails (>= 7.0)
     uri (0.12.2)
     useragent (0.16.11)
-    uuid7 (0.2.0)
-      zeitwerk (~> 2.4)
     verbose_migrations (1.0.1)
       rails (>= 6.0)
     webmock (3.14.0)
@@ -614,7 +612,6 @@ DEPENDENCIES
   typed_params (~> 1.3.0)
   union_of
   uri (>= 0.12.2)
-  uuid7
   verbose_migrations
   webmock (~> 3.14.0)
   workos (~> 5.15)

--- a/app/controllers/concerns/current_request_attributes.rb
+++ b/app/controllers/concerns/current_request_attributes.rb
@@ -6,7 +6,7 @@ module CurrentRequestAttributes
   included do
     before_action do
       Current.api_version = RequestMigrations.config.request_version_resolver.call(request)
-      Current.request_id  = request.request_id = UUID7.generate
+      Current.request_id  = request.request_id = SecureRandom.uuid_v7
       Current.host        = request.host
       Current.ip          = request.remote_ip
     end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -48,7 +48,7 @@ class ApplicationRecord < ActiveRecord::Base
 
   private
 
-  def generate_uuid_v7_primary_key = self.id ||= UUID7.generate
+  def generate_uuid_v7_primary_key = self.id ||= SecureRandom.uuid_v7
 
   def self.uuid_primary_key? = attribute_types["id"].type == :uuid
   def uuid_primary_key?      = self.class.uuid_primary_key?

--- a/app/services/broadcast_event_service.rb
+++ b/app/services/broadcast_event_service.rb
@@ -63,7 +63,7 @@ class BroadcastEventService < BaseService
             end
 
           EventLogWorker2.perform_async(
-            'id' => UUID7.generate,
+            'id' => SecureRandom.uuid_v7,
             'event_type_id' => event_type_id,
             'account_id' => account_id,
             'environment_id' => environment_id,

--- a/app/workers/event_log_worker.rb
+++ b/app/workers/event_log_worker.rb
@@ -22,7 +22,7 @@ class EventLogWorker < BaseWorker
     metadata   = JSON.parse(metadata) if metadata.present?
     event_type = fetch_event_type_by_event(event)
     event_log  = EventLog.create!(
-      id: UUID7.generate,
+      id: SecureRandom.uuid_v7,
       event_type_id: event_type.id,
       idempotency_key:,
       account_id:,

--- a/app/workers/record_metric_worker.rb
+++ b/app/workers/record_metric_worker.rb
@@ -40,7 +40,7 @@ class RecordMetricWorker < BaseWorker
       end
 
     account.metrics.insert!({
-      id: UUID7.generate,
+      id: SecureRandom.uuid_v7,
       event_type_id: event_type.id,
       created_date: recorded_at,
       created_at: recorded_at,

--- a/config/initializers/regexp.rb
+++ b/config/initializers/regexp.rb
@@ -3,10 +3,10 @@
 Regexp.timeout = 1
 
 # used throughout the app to check if a value is a UUID
-UUID_RE = /\A[0-9A-F]{8}-?[0-9A-F]{4}-?[4][0-9A-F]{3}-?[89AB][0-9A-F]{3}-?[0-9A-F]{12}\z/i
+UUID_RE = /\A[0-9A-F]{8}-?[0-9A-F]{4}-?[0-9A-F]{4}-?[0-9A-F]{4}-?[0-9A-F]{12}\z/i
 
 # above pattern without anchors for URLs
-UUID_URL_RE = /[0-9A-F]{8}-?[0-9A-F]{4}-?[4][0-9A-F]{3}-?[89AB][0-9A-F]{3}-?[0-9A-F]{12}/i
+UUID_URL_RE = /[0-9A-F]{8}-?[0-9A-F]{4}-?[0-9A-F]{4}-?[0-9A-F]{4}-?[0-9A-F]{12}/i
 
 # used throughout the app for checking if a value is a partial UUID
 UUID_CHAR_RE = /\A[-0-9A-F]+\z/i


### PR DESCRIPTION
Should improve performance and risk in using batch operations like `find_each` using the default of sorting by primary key.

## Prereqs

- [ ] Talk to customers and make sure this won't be a breaking change, e.g. if a customer is expecting UUIDv4s, this would break that expectation — even if we have always reserved the right to change the format of new resource identifiers.