### PR TITLE
Add product authz scopes to webhooks

### DIFF
--- a/app/controllers/api/v1/webhook_events_controller.rb
+++ b/app/controllers/api/v1/webhook_events_controller.rb
@@ -10,7 +10,7 @@ module Api::V1
     before_action :set_event, only: [:show, :destroy]
 
     def index
-      events = apply_pagination(authorized_scope(apply_scopes(current_account.webhook_events)).preload(:event_type))
+      events = apply_pagination(authorized_scope(apply_scopes(current_account.webhook_events)).preload(:event_type, :product))
       authorize! events
 
       render jsonapi: events

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -24,8 +24,10 @@ class Current < ActiveSupport::CurrentAttributes
 
   def account_id     = account&.id
   def environment_id = environment&.id
+  def bearer_type    = bearer&.class&.name
   def bearer_id      = bearer&.id
   def session_id     = session&.id
   def token_id       = token&.id
+  def resource_type  = resource&.class&.name
   def resource_id    = resource&.id
 end

--- a/app/models/license_entitlement.rb
+++ b/app/models/license_entitlement.rb
@@ -10,6 +10,8 @@ class LicenseEntitlement < ApplicationRecord
 
   belongs_to :license
   belongs_to :entitlement
+  has_one :product,
+    through: :license
   has_one :policy,
     through: :license
 

--- a/app/models/policy_entitlement.rb
+++ b/app/models/policy_entitlement.rb
@@ -10,6 +10,8 @@ class PolicyEntitlement < ApplicationRecord
 
   belongs_to :policy
   belongs_to :entitlement
+  has_one :product,
+    through: :policy
 
   has_environment default: -> { policy&.environment_id }
   has_account default: -> { policy&.account_id }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -290,8 +290,10 @@ class User < ApplicationRecord
 
   scope :accessible_by, -> accessor {
     case accessor
-    in role: Role(:admin | :product) # give products the ability to read all users
+    in role: Role(:admin)
       all
+    in role: Role(:product) # give products the ability to read all users
+      with_role(:user)
     in role: Role(:environment)
       for_environment(accessor.id)
     in role: Role(:user)

--- a/app/models/webhook_event.rb
+++ b/app/models/webhook_event.rb
@@ -9,6 +9,9 @@ class WebhookEvent < ApplicationRecord
   include Pageable
 
   belongs_to :event_type
+  belongs_to :webhook_endpoint, optional: true
+  has_one :product,
+    through: :webhook_endpoint
 
   has_environment
   has_account
@@ -24,7 +27,7 @@ class WebhookEvent < ApplicationRecord
 
   scope :with_events, -> (*events) { where(event_type_id: EventType.where(event: events).pluck(:id)) }
 
-  # FIXME(ezekg) Products should only be able to read events that are
-  #              associated with the given product
-  scope :for_product, -> id { self }
+  scope :for_product, -> id {
+    joins(:product).where(products: { id: })
+  }
 end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -14,7 +14,7 @@ class ApplicationPolicy
   authorize :account
   authorize :environment, allow_nil: true, optional: true
   authorize :bearer,      allow_nil: true
-  authorize :token,       allow_nil: true
+  authorize :token,       allow_nil: true, optional: true
 
   scope_matcher :active_record_relation, ActiveRecord::Relation
   scope_for :active_record_relation do |relation|

--- a/app/policies/webhook_endpoint_policy.rb
+++ b/app/policies/webhook_endpoint_policy.rb
@@ -8,7 +8,9 @@ class WebhookEndpointPolicy < ApplicationPolicy
     )
 
     case bearer
-    in role: Role(:admin | :developer | :read_only | :product | :environment)
+    in role: Role(:admin | :developer | :read_only | :environment)
+      allow!
+    in role: Role(:product) if record.all? { _1.product == bearer }
       allow!
     else
       deny!
@@ -22,7 +24,9 @@ class WebhookEndpointPolicy < ApplicationPolicy
     )
 
     case bearer
-    in role: Role(:admin | :developer | :read_only | :product | :environment)
+    in role: Role(:admin | :developer | :read_only | :environment)
+      allow!
+    in role: Role(:product) if record.product == bearer
       allow!
     else
       deny!
@@ -34,7 +38,9 @@ class WebhookEndpointPolicy < ApplicationPolicy
     verify_environment!
 
     case bearer
-    in role: Role(:admin | :developer | :product | :environment)
+    in role: Role(:admin | :developer | :environment)
+      allow!
+    in role: Role(:product) if record.product == bearer
       allow!
     else
       deny!
@@ -46,7 +52,9 @@ class WebhookEndpointPolicy < ApplicationPolicy
     verify_environment!
 
     case bearer
-    in role: Role(:admin | :developer | :product | :environment)
+    in role: Role(:admin | :developer | :environment)
+      allow!
+    in role: Role(:product) if record.product == bearer
       allow!
     else
       deny!
@@ -58,7 +66,9 @@ class WebhookEndpointPolicy < ApplicationPolicy
     verify_environment!
 
     case bearer
-    in role: Role(:admin | :developer | :product | :environment)
+    in role: Role(:admin | :developer | :environment)
+      allow!
+    in role: Role(:product) if record.product == bearer
       allow!
     else
       deny!

--- a/app/policies/webhook_event_policy.rb
+++ b/app/policies/webhook_event_policy.rb
@@ -8,7 +8,9 @@ class WebhookEventPolicy < ApplicationPolicy
     )
 
     case bearer
-    in role: Role(:admin | :developer | :read_only | :product | :environment)
+    in role: Role(:admin | :developer | :read_only | :environment)
+      allow!
+    in role: Role(:product) if record.all? { _1.product == bearer }
       allow!
     else
       deny!
@@ -22,7 +24,9 @@ class WebhookEventPolicy < ApplicationPolicy
     )
 
     case bearer
-    in role: Role(:admin | :developer | :read_only | :product | :environment)
+    in role: Role(:admin | :developer | :read_only | :environment)
+      allow!
+    in role: Role(:product) if record.product == bearer
       allow!
     else
       deny!

--- a/app/serializers/webhook_endpoint_serializer.rb
+++ b/app/serializers/webhook_endpoint_serializer.rb
@@ -42,6 +42,23 @@ class WebhookEndpointSerializer < BaseSerializer
     end
   end
 
+  relationship :product do
+    linkage always: true do
+      if @object.product_id?
+        { type: :products, id: @object.product_id }
+      else
+        nil
+      end
+    end
+    link :related do
+      if @object.product_id?
+        @url_helpers.v1_account_product_path @object.account_id, @object.product_id
+      else
+        nil
+      end
+    end
+  end
+
   link :self do
     @url_helpers.v1_account_webhook_endpoint_path @object.account_id, @object
   end

--- a/app/services/broadcast_webhook_service.rb
+++ b/app/services/broadcast_webhook_service.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+class BroadcastWebhookService < BaseService
+  include ActionPolicy::Behaviour
+
+  authorize :account
+  authorize :environment
+
+  def initialize(event:, account:, environment:, resource:, meta: nil)
+    @event       = event
+    @account     = account
+    @environment = environment
+    @resource    = resource
+    @meta        = meta
+  end
+
+  def call
+    selected_endpoint_ids = []
+
+    webhook_endpoints = account.webhook_endpoints.preload(product: { role: :permissions }).for_environment(
+      environment,
+      strict: true,
+    )
+
+    # skip resources that our endpoint's product aren't authorized to read (if any)
+    webhook_endpoints.find_each do |webhook_endpoint|
+      next unless
+        webhook_endpoint.subscribed?(event)
+
+      action  = resource.class < Enumerable ? :index? : :show?
+      context = {
+        bearer: webhook_endpoint.product, # s/bearer/actor/
+      }
+
+      # assert either 1) it's not a product endpoint or 2) the product is allowed
+      # to read the resource being sent in the webhook event
+      next unless
+        webhook_endpoint.product.nil? || allowed_to?(action, resource, context:)
+
+      selected_endpoint_ids << webhook_endpoint.id
+    end
+
+    # skip if there are no relevant endpoints
+    return if
+      selected_endpoint_ids.empty?
+
+    # render resource while we have it
+    renderer_options = { meta: meta&.transform_keys { _1.to_s.camelize(:lower) } }.compact
+    renderer         = Keygen::JSONAPI::Renderer.new(
+      api_version: CURRENT_API_VERSION,
+      context: :webhook,
+      account:,
+    )
+
+    resource_payload = renderer.render(resource, renderer_options)
+                               .as_json
+
+    CreateWebhookEventsWorker2.perform_async(
+      event,
+      selected_endpoint_ids,
+      resource_payload,
+      account.id,
+      environment&.id,
+    )
+  rescue => e
+    Keygen.logger.exception(e)
+
+    # FIXME(ezekg) this is for tests since jobs are run inline
+    raise if e in WebhookWorker::FailedRequestError
+  end
+
+  private
+
+  attr_reader :event,
+              :account,
+              :environment,
+              :resource,
+              :meta
+end

--- a/app/workers/webhook_worker.rb
+++ b/app/workers/webhook_worker.rb
@@ -45,7 +45,7 @@ class WebhookWorker < BaseWorker
     return unless
       endpoint.subscribed?(event_type.event)
 
-    # Migrate event payload
+    # migrate event payload in case anything has changed e.g. endpoint API version
     current_version = event.api_version || CURRENT_API_VERSION
     target_version  = endpoint.api_version || account.api_version
     migrator        = RequestMigrations::Migrator.new(

--- a/db/migrate/20250515142604_add_product_to_webhook_endpoints.rb
+++ b/db/migrate/20250515142604_add_product_to_webhook_endpoints.rb
@@ -1,0 +1,9 @@
+class AddProductToWebhookEndpoints < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    add_column :webhook_endpoints, :product_id, :uuid, null: true, if_not_exists: true
+
+    add_index :webhook_endpoints, :product_id, algorithm: :concurrently, if_not_exists: true
+  end
+end

--- a/db/migrate/20250515152010_add_webhook_endpoint_to_webhook_events.rb
+++ b/db/migrate/20250515152010_add_webhook_endpoint_to_webhook_events.rb
@@ -1,0 +1,9 @@
+class AddWebhookEndpointToWebhookEvents < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    add_column :webhook_events, :webhook_endpoint_id, :uuid, null: true # FIXME(ezekg) make not-null
+
+    add_index :webhook_events, :webhook_endpoint_id, algorithm: :concurrently
+  end
+end

--- a/db/migrate/20250515152529_seed_webhook_endpoint_for_webhook_events.rb
+++ b/db/migrate/20250515152529_seed_webhook_endpoint_for_webhook_events.rb
@@ -1,0 +1,76 @@
+class SeedWebhookEndpointForWebhookEvents < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+  verbose!
+
+  BATCH_SIZE = 1_000
+
+  def up
+    update_count = nil
+    batch_count  = 0
+
+    until update_count == 0
+      batch_count  += 1
+      update_count  = exec_update(<<~SQL.squish, batch_count:, batch_size: BATCH_SIZE)
+        WITH batch AS (
+          SELECT
+            webhook_events.id    AS webhook_event_id,
+            webhook_endpoints.id AS webhook_endpoint_id
+          FROM
+            webhook_events
+          INNER JOIN
+            webhook_endpoints ON webhook_endpoints.account_id     = webhook_events.account_id     AND
+                                 webhook_endpoints.environment_id = webhook_events.environment_id AND
+                                 webhook_endpoints.url            = webhook_events.endpoint
+          WHERE
+            webhook_events.webhook_endpoint_id IS NULL
+          LIMIT
+            :batch_size
+        )
+        UPDATE
+          webhook_events
+        SET
+          webhook_endpoint_id = batch.webhook_endpoint_id
+        FROM
+          batch
+        WHERE
+          webhook_events.id = batch.webhook_event_id
+        /* batch=:batch_count */
+      SQL
+    end
+  end
+
+  def down
+    update_count = nil
+    batch_count  = 0
+
+    until update_count == 0
+      batch_count  += 1
+      update_count  = exec_update(<<~SQL.squish, batch_count:, batch_size: BATCH_SIZE)
+        UPDATE
+          webhook_events
+        SET
+          webhook_endpoint_id = NULL
+        WHERE
+          webhook_events.id IN (
+            SELECT
+              webhook_events.id
+            FROM
+              webhook_events
+            WHERE
+              webhook_events.webhook_endpoint_id IS NOT NULL
+            LIMIT
+              :batch_size
+          )
+        /* batch=:batch_count */
+      SQL
+    end
+  end
+
+  private
+
+  def exec_update(sql, **binds)
+    ActiveRecord::Base.connection.exec_update(
+      ActiveRecord::Base.sanitize_sql([sql, **binds]),
+    )
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_05_02_170156) do
+ActiveRecord::Schema[7.2].define(version: 2025_05_15_152529) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_stat_statements"
@@ -912,10 +912,12 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_02_170156) do
     t.string "signature_algorithm", default: "ed25519"
     t.string "api_version"
     t.uuid "environment_id"
+    t.uuid "product_id"
     t.index ["account_id", "created_at"], name: "index_webhook_endpoints_on_account_id_and_created_at"
     t.index ["created_at"], name: "index_webhook_endpoints_on_created_at", order: :desc
     t.index ["environment_id"], name: "index_webhook_endpoints_on_environment_id"
     t.index ["id", "created_at", "account_id"], name: "index_webhook_endpoints_on_id_and_created_at_and_account_id", unique: true
+    t.index ["product_id"], name: "index_webhook_endpoints_on_product_id"
   end
 
   create_table "webhook_events", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
@@ -932,11 +934,13 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_02_170156) do
     t.string "status"
     t.string "api_version"
     t.uuid "environment_id"
+    t.uuid "webhook_endpoint_id"
     t.index ["account_id", "created_at"], name: "index_webhook_events_on_account_id_and_created_at", order: { created_at: :desc }
     t.index ["environment_id"], name: "index_webhook_events_on_environment_id"
     t.index ["event_type_id"], name: "index_webhook_events_on_event_type_id"
     t.index ["id", "created_at", "account_id"], name: "index_webhook_events_on_id_and_created_at_and_account_id", unique: true
     t.index ["idempotency_token"], name: "index_webhook_events_on_idempotency_token"
     t.index ["jid", "created_at", "account_id"], name: "index_webhook_events_on_jid_and_created_at_and_account_id"
+    t.index ["webhook_endpoint_id"], name: "index_webhook_events_on_webhook_endpoint_id"
   end
 end

--- a/features/api/v1/entitlements/create.feature
+++ b/features/api/v1/entitlements/create.feature
@@ -910,3 +910,28 @@ Feature: Create entitlements
     And sidekiq should have 0 "webhook" jobs
     And sidekiq should have 0 "metric" jobs
     And sidekiq should have 1 "request-log" job
+
+  # product-specific webhook smoke tests
+  Scenario: Admin creates an entitlement and generates authorized webhooks
+    Given the current account is "test1"
+    And the current account has 2 "products"
+    And the current account has 2 "webhook-endpoints" for each "product"
+    And the current account has 1 "webhook-endpoint"
+    And I am an admin of account "test1"
+    And I authenticate with a token
+    When I send a POST request to "/accounts/test1/entitlements" with the following:
+      """
+      {
+        "data": {
+          "type": "entitlement",
+          "attributes": {
+            "name": "Product Feature",
+            "code": "PRODUCT_FEATURE"
+          }
+        }
+      }
+      """
+    Then the response status should be "201"
+    And sidekiq should have 5 "webhook" job
+    And sidekiq should have 1 "metric" job
+    And sidekiq should have 1 "request-log" job

--- a/features/api/v1/environments/create.feature
+++ b/features/api/v1/environments/create.feature
@@ -455,3 +455,29 @@ Feature: Create environments
     And sidekiq should have 0 "webhook" jobs
     And sidekiq should have 0 "metric" jobs
     And sidekiq should have 1 "request-log" job
+
+  # product-specific webhook smoke tests
+  Scenario: Admin creates an environment and generates authorized webhooks
+    Given the current account is "test1"
+    And the current account has 2 "products"
+    And the current account has 2 "webhook-endpoints" for each "product"
+    And the current account has 1 "webhook-endpoint"
+    And I am an admin of account "test1"
+    And I authenticate with a token
+    When I send a POST request to "/accounts/test1/environments" with the following:
+      """
+      {
+        "data": {
+          "type": "environment",
+          "attributes": {
+            "isolationStrategy": "SHARED",
+            "name": "Staging",
+            "code": "staging"
+          }
+        }
+      }
+      """
+    Then the response status should be "201"
+    And sidekiq should have 1 "webhook" job
+    And sidekiq should have 1 "metric" job
+    And sidekiq should have 1 "request-log" job

--- a/features/api/v1/licenses/create.feature
+++ b/features/api/v1/licenses/create.feature
@@ -7389,3 +7389,29 @@ Feature: Create license
     And sidekiq should have 1 "webhook" job
     And sidekiq should have 1 "metric" job
     And sidekiq should have 1 "request-log" job
+
+  # product-specific webhook smoke tests
+  Scenario: Product creates a license and generates authorized webhooks for its product
+    Given the current account is "test1"
+    And the current account has 2 "products"
+    And the current account has 2 "webhook-endpoints" for each "product"
+    And the current account has 1 "policy" for each "product"
+    And I am the first product of account "test1"
+    And I use an authentication token
+    When I send a POST request to "/accounts/test1/licenses" with the following:
+      """
+      {
+        "data": {
+          "type": "licenses",
+          "relationships": {
+            "policy": {
+              "data": { "type": "policies", "id": "$policies[0]" }
+            }
+          }
+        }
+      }
+      """
+    Then the response status should be "201"
+    And sidekiq should have 2 "webhook" jobs
+    And sidekiq should have 1 "metric" job
+    And sidekiq should have 1 "request-log" job

--- a/features/api/v1/users/create.feature
+++ b/features/api/v1/users/create.feature
@@ -3172,3 +3172,25 @@ Feature: Create user
     And sidekiq should have 0 "webhook" jobs
     And sidekiq should have 0 "metric" jobs
     And sidekiq should have 0 "request-log" jobs
+
+  # product-specific webhook smoke tests
+  Scenario: Anonymous creates a user and generates authorized webhooks for all products
+    Given the current account is "test1"
+    And the current account has 2 "products"
+    And the current account has 2 "webhook-endpoints" for each "product"
+    When I send a POST request to "/accounts/test1/users" with the following:
+      """
+      {
+        "data": {
+          "type": "users",
+          "attributes": {
+            "email": "xkcd-936@keygen.example",
+            "password": "correcthorsebatterystaple"
+          }
+        }
+      }
+      """
+    Then the response status should be "201"
+    And sidekiq should have 4 "webhook" jobs
+    And sidekiq should have 1 "metric" job
+    And sidekiq should have 1 "request-log" job

--- a/features/api/v1/users/relationships/second_factors.feature
+++ b/features/api/v1/users/relationships/second_factors.feature
@@ -199,10 +199,7 @@ Feature: Manage second factors for user
     And I am a product of account "test1"
     And I use an authentication token
     When I send a GET request to "/accounts/test1/users/$0/second-factors"
-    Then the response status should be "403"
-    And sidekiq should have 0 "webhook" jobs
-    And sidekiq should have 0 "metric" jobs
-    And sidekiq should have 1 "request-log" job
+    Then the response status should be "404"
 
   Scenario: Product lists a user's second factors
     Given the current account is "test1"

--- a/features/api/v1/users/update.feature
+++ b/features/api/v1/users/update.feature
@@ -1543,15 +1543,7 @@ Feature: Update user
         }
       }
       """
-    Then the response status should be "403"
-    And the response body should be an array of 1 error
-    And the first error should have the following properties:
-      """
-      {
-        "title": "Access denied",
-        "detail": "You do not have permission to complete the request (product lacks permission to perform action)"
-      }
-      """
+    Then the response status should be "404"
 
   @ee
   Scenario: Product escalates a user's permissions

--- a/features/api/v1/webhook_endpoints/update.feature
+++ b/features/api/v1/webhook_endpoints/update.feature
@@ -68,6 +68,70 @@ Feature: Update webhook endpoint
       }
       """
 
+  Scenario: Admin updates a webhook endpoint's product
+    Given I am an admin of account "test1"
+    And the current account is "test1"
+    And the current account has 2 "products"
+    And the current account has 1 "webhook-endpoint" for the first "product"
+    And I use an authentication token
+    When I send a PATCH request to "/accounts/test1/webhook-endpoints/$0" with the following:
+      """
+      {
+        "data": {
+          "type": "webhook-endpoint",
+          "relationships": {
+            "product": {
+              "data": { "type": "product", "id": "$products[1]" }
+            }
+          }
+        }
+      }
+      """
+    Then the response status should be "200"
+    And the response should contain a valid signature header for "test1"
+    And the response body should be a "webhook-endpoint"
+    And the response body should be a "webhook-endpoint" with the following relationships:
+      """
+      {
+        "product": {
+          "links": { "related": "/v1/accounts/$account/products/$products[1]" },
+          "data": { "type": "products", "id": "$products[1]" }
+        }
+      }
+      """
+
+  Scenario: Admin removes a webhook endpoint's product
+    Given I am an admin of account "test1"
+    And the current account is "test1"
+    And the current account has 1 "product"
+    And the current account has 1 "webhook-endpoint" for the last "product"
+    And I use an authentication token
+    When I send a PATCH request to "/accounts/test1/webhook-endpoints/$0" with the following:
+      """
+      {
+        "data": {
+          "type": "webhook-endpoint",
+          "relationships": {
+            "product": {
+              "data": null
+            }
+          }
+        }
+      }
+      """
+    Then the response status should be "200"
+    And the response should contain a valid signature header for "test1"
+    And the response body should be a "webhook-endpoint"
+    And the response body should be a "webhook-endpoint" with the following relationships:
+      """
+      {
+        "product": {
+          "links": { "related": null },
+          "data": null
+        }
+      }
+      """
+
   Scenario: Admin updates a webhook endpoint's API version to v1.0
     Given I am an admin of account "test1"
     And the current account is "test1"

--- a/features/api/v1/webhook_events/actions/retry.feature
+++ b/features/api/v1/webhook_events/actions/retry.feature
@@ -102,6 +102,18 @@ Feature: Retry webhook events
     When I send a POST request to "/accounts/test1/webhook-events/$0/actions/retry"
     Then the response status should be "201"
 
+  Scenario: Product retries their webhook event for their account
+    Given the current account is "test1"
+    And the current account has 1 "product"
+    And the current account has 1 "webhook-endpoint" for the last "product"
+    And the current account has 3 "webhook-events" for the last "webhook-endpoint"
+    And I am a product of account "test1"
+    And I use an authentication token
+    When I send a POST request to "/accounts/test1/webhook-events/$0/actions/retry"
+    Then the response status should be "403"
+    And the response body should be an array of 1 error
+    And the current account should have 3 "webhook-events"
+
   Scenario: Product retries a webhook event for their account
     Given the current account is "test1"
     And the current account has 1 "webhook-endpoint"
@@ -110,9 +122,7 @@ Feature: Retry webhook events
     And I am a product of account "test1"
     And I use an authentication token
     When I send a POST request to "/accounts/test1/webhook-events/$0/actions/retry"
-    Then the response status should be "403"
-    And the response body should be an array of 1 error
-    And the current account should have 3 "webhook-events"
+    Then the response status should be "404"
 
   Scenario: License retries a webhook event for their account
     Given the current account is "test1"

--- a/features/api/v1/webhook_events/destroy.feature
+++ b/features/api/v1/webhook_events/destroy.feature
@@ -37,6 +37,18 @@ Feature: Delete webhook event
     When I send a DELETE request to "/accounts/test1/webhook-events/$1?environment=isolated"
     Then the response status should be "204"
 
+  Scenario: Product attempts to delete their webhook event for their account
+    Given the current account is "test1"
+    And the current account has 1 "product"
+    And the current account has 1 "webhook-endpoint" for the last "product"
+    And the current account has 3 "webhook-events" for the last "webhook-endpoint"
+    And I am a product of account "test1"
+    And I use an authentication token
+    When I send a DELETE request to "/accounts/test1/webhook-events/$1"
+    Then the response status should be "403"
+    And the response body should be an array of 1 error
+    And the current account should have 3 "webhook-events"
+
   Scenario: Product attempts to delete a webhook event for their account
     Given the current account is "test1"
     And the current account has 3 "webhook-events"
@@ -44,9 +56,7 @@ Feature: Delete webhook event
     And I am a product of account "test1"
     And I use an authentication token
     When I send a DELETE request to "/accounts/test1/webhook-events/$1"
-    Then the response status should be "403"
-    And the response body should be an array of 1 error
-    And the current account should have 3 "webhook-events"
+    Then the response status should be "404"
 
   Scenario: License attempts to delete a webhook event for their account
     Given the current account is "test1"

--- a/features/api/v1/webhook_events/index.feature
+++ b/features/api/v1/webhook_events/index.feature
@@ -55,16 +55,18 @@ Feature: List webhook events
     And the response should contain a valid signature header for "test1"
     And the response body should be an array with 6 "webhook-events"
 
-  Scenario: Product retrieves all webhook events for their account
+  Scenario: Product retrieves all their webhook events for their account
     Given the current account is "test1"
+    And the current account has 2 "products"
+    And the current account has 2 "webhook-endpoints" for each "product"
+    And the current account has 3 "webhook-events" for each "webhook-endpoint"
     And the current account has 3 "webhook-events"
-    And the current account has 1 "product"
     And I am a product of account "test1"
     And I use an authentication token
     When I send a GET request to "/accounts/test1/webhook-events"
     Then the response status should be "200"
     And the response should contain a valid signature header for "test1"
-    And the response body should be an array with 3 "webhook-events"
+    And the response body should be an array with 6 "webhook-events"
 
   Scenario: Admin retrieves a paginated list of webhook events
     Given I am an admin of account "test1"

--- a/features/api/v1/webhook_events/show.feature
+++ b/features/api/v1/webhook_events/show.feature
@@ -62,6 +62,17 @@ Feature: Show webhook event
     Then the response status should be "200"
     And the response body should be a "webhook-event"
 
+  Scenario: Product retrieves a webhook event for their product
+    Given the current account is "test1"
+    And the current account has 1 "product"
+    And the current account has 1 "webhook-endpoint" for the last "product"
+    And the current account has 3 "webhook-events" for the last "webhook-endpoint"
+    And I am a product of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/webhook-events/$0"
+    Then the response status should be "200"
+    And the response body should be a "webhook-event"
+
   Scenario: Product retrieves a webhook event for their account
     Given the current account is "test1"
     And the current account has 3 "webhook-events"
@@ -69,8 +80,7 @@ Feature: Show webhook event
     And I am a product of account "test1"
     And I use an authentication token
     When I send a GET request to "/accounts/test1/webhook-events/$0"
-    Then the response status should be "200"
-    And the response body should be a "webhook-event"
+    Then the response status should be "404"
 
   Scenario: License retrieves a webhook event for their account
     Given the current account is "test1"

--- a/features/step_definitions/worker_steps.rb
+++ b/features/step_definitions/worker_steps.rb
@@ -48,7 +48,7 @@ Then /^sidekiq should (?:have|process) (\d+) "([^\"]*)" jobs?(?: queued in ([.\d
     PerformBulk::Processor.drain # process and queue bulk jobs
     PerformBulk::Runner.drain
   when "webhook_worker"
-    CreateWebhookEventsWorker.drain
+    CreateWebhookEventsWorker2.drain
   end
 
   # Count queued jobs

--- a/spec/factories/webhook_endpoint.rb
+++ b/spec/factories/webhook_endpoint.rb
@@ -8,6 +8,7 @@ FactoryBot.define do
 
     account     { NIL_ACCOUNT }
     environment { NIL_ENVIRONMENT }
+    product     { nil }
 
     trait :in_isolated_environment do
       environment { build(:environment, :isolated, account:) }

--- a/spec/factories/webhook_event.rb
+++ b/spec/factories/webhook_event.rb
@@ -8,8 +8,9 @@ FactoryBot.define do
     payload  { '{}' }
     jid      { SecureRandom.hex }
 
-    account     { NIL_ACCOUNT }
-    environment { NIL_ENVIRONMENT }
+    account          { NIL_ACCOUNT }
+    environment      { NIL_ENVIRONMENT }
+    webhook_endpoint { build(:webhook_endpoint, url: endpoint, account:, environment:) }
     event_type
 
     trait :in_isolated_environment do

--- a/spec/policies/webhook_endpoint_policy_spec.rb
+++ b/spec/policies/webhook_endpoint_policy_spec.rb
@@ -269,12 +269,12 @@ describe WebhookEndpointPolicy, type: :policy do
   end
 
   with_role_authorization :product do
-    with_scenarios %i[accessing_webhook_endpoints] do
+    with_scenarios %i[accessing_its_webhook_endpoints] do
       with_token_authentication do
         with_permissions %w[webhook-endpoint.read] do
-          without_token_permissions { denies :show }
+          without_token_permissions { denies :index }
 
-          allows :show
+          allows :index
         end
 
         with_wildcard_permissions { allows :index }
@@ -283,7 +283,7 @@ describe WebhookEndpointPolicy, type: :policy do
       end
     end
 
-    with_scenarios %i[accessing_a_webhook_endpoint] do
+    with_scenarios %i[accessing_its_webhook_endpoint] do
       with_token_authentication do
         with_permissions %w[webhook-endpoint.read] do
           without_token_permissions { denies :show }
@@ -323,6 +323,50 @@ describe WebhookEndpointPolicy, type: :policy do
           end
 
           allows :show, :create, :update, :destroy
+        end
+
+        without_permissions do
+          denies :show, :create, :update, :destroy
+        end
+      end
+    end
+
+    with_scenarios %i[accessing_webhook_endpoints] do
+      with_token_authentication do
+        with_permissions %w[webhook-endpoint.read] do
+          denies :index
+        end
+
+        with_wildcard_permissions { denies :index }
+        with_default_permissions  { denies :index }
+        without_permissions       { denies :index }
+      end
+    end
+
+    with_scenarios %i[accessing_a_webhook_endpoint] do
+      with_token_authentication do
+        with_permissions %w[webhook-endpoint.read] do
+          denies :show
+        end
+
+        with_permissions %w[webhook-endpoint.create] do
+          denies :create
+        end
+
+        with_permissions %w[webhook-endpoint.update] do
+          denies :update
+        end
+
+        with_permissions %w[webhook-endpoint.delete] do
+          denies :destroy
+        end
+
+        with_wildcard_permissions do
+          denies :show, :create, :update, :destroy
+        end
+
+        with_default_permissions do
+          denies :show, :create, :update, :destroy
         end
 
         without_permissions do

--- a/spec/policies/webhook_event_policy_spec.rb
+++ b/spec/policies/webhook_event_policy_spec.rb
@@ -253,15 +253,21 @@ describe WebhookEventPolicy, type: :policy do
   end
 
   with_role_authorization :product do
-    with_scenarios %i[accessing_webhook_events] do
+    with_scenarios %i[accessing_its_webhook_events] do
       with_token_authentication do
+        with_permissions %w[webhook-event.read] do
+          without_token_permissions { denies :index }
+
+          allows :index
+        end
+
         with_wildcard_permissions { allows :index }
         with_default_permissions  { allows :index }
         without_permissions       { denies :index }
       end
     end
 
-    with_scenarios %i[accessing_a_webhook_event] do
+    with_scenarios %i[accessing_its_webhook_event] do
       with_token_authentication do
         with_permissions %w[webhook-event.read] do
           without_token_permissions { denies :show }
@@ -270,17 +276,53 @@ describe WebhookEventPolicy, type: :policy do
         end
 
         with_wildcard_permissions do
-          without_token_permissions { denies :show, :destroy, :retry }
+          without_token_permissions do
+            denies :show, :destroy, :retry
+          end
 
           denies :destroy, :retry
           allows :show
         end
 
         with_default_permissions do
-          without_token_permissions { denies :show, :destroy, :retry }
+          without_token_permissions do
+            denies :show, :destroy, :retry
+          end
 
           denies :destroy, :retry
           allows :show
+        end
+
+        without_permissions do
+          denies :show, :destroy, :retry
+        end
+      end
+    end
+
+    with_scenarios %i[accessing_webhook_events] do
+      with_token_authentication do
+        with_permissions %w[webhook-event.read] do
+          denies :index
+        end
+
+        with_wildcard_permissions { denies :index }
+        with_default_permissions  { denies :index }
+        without_permissions       { denies :index }
+      end
+    end
+
+    with_scenarios %i[accessing_a_webhook_event] do
+      with_token_authentication do
+        with_permissions %w[webhook-event.read] do
+          denies :show
+        end
+
+        with_wildcard_permissions do
+          denies :show, :destroy, :retry
+        end
+
+        with_default_permissions do
+          denies :show, :destroy, :retry
         end
 
         without_permissions do

--- a/spec/services/broadcast_event_service_spec.rb
+++ b/spec/services/broadcast_event_service_spec.rb
@@ -571,4 +571,31 @@ describe BroadcastEventService do
       expect(event.payload).to eq expected
     end
   end
+
+  context 'when endpoint is scoped to a product' do
+    let(:product)  { create(:product, account:)}
+    let(:endpoint) { create(:webhook_endpoint, product:, account:) }
+
+    it 'should emit events relevant to the product' do
+      policy  = create(:policy, product:, account:)
+      license = create(:license, policy:, account:)
+
+      event = create_webhook_event!(account, license,
+        event: 'license.created',
+      )
+
+      expect(event).to_not be nil
+      expect(event.product).to eq product
+    end
+
+    it 'should not emit events irrelevant to the product' do
+      license = create(:license, account:)
+
+      event = create_webhook_event!(account, license,
+        event: 'license.created',
+      )
+
+      expect(event).to be nil
+    end
+  end
 end

--- a/spec/support/helpers/authorization_helper.rb
+++ b/spec/support/helpers/authorization_helper.rb
@@ -246,6 +246,32 @@ module AuthorizationHelper
       let(:record) { event_log }
     end
 
+    def accessing_its_webhook_endpoints(scenarios)
+      case scenarios
+      in [:as_admin, *]
+        let(:webhook_endpoints) { create_list(:webhook_endpoint, 3, account:) }
+      in [:as_environment, *]
+        let(:webhook_endpoints) { create_list(:webhook_endpoint, 3, account:, environment: bearer) }
+      in [:as_product, *]
+        let(:webhook_endpoints) { create_list(:webhook_endpoint, 3, account:, product: bearer) }
+      end
+
+      let(:record) { webhook_endpoints }
+    end
+
+    def accessing_its_webhook_endpoint(scenarios)
+      case scenarios
+      in [:as_admin, *]
+        let(:webhook_endpoint) { create(:webhook_endpoint, account:) }
+      in [:as_environment, *]
+        let(:webhook_endpoint) { create(:webhook_endpoint, account:, environment: bearer) }
+      in [:as_product, *]
+        let(:webhook_endpoint) { create(:webhook_endpoint, account:, product: bearer) }
+      end
+
+      let(:record) { webhook_endpoint }
+    end
+
     def accessing_webhook_endpoints(scenarios)
       case scenarios
       in [:as_admin | :as_environment | :as_product | :as_license | :as_user | :as_anonymous, *]
@@ -262,6 +288,34 @@ module AuthorizationHelper
       end
 
       let(:record) { webhook_endpoint }
+    end
+
+    def accessing_its_webhook_events(scenarios)
+      case scenarios
+      in [:as_admin, *]
+        let(:webhook_events) { create_list(:webhook_event, 3, account:) }
+      in [:as_environment, *]
+        let(:webhook_events) { create_list(:webhook_event, 3, account:, environment: bearer) }
+      in [:as_product, *]
+        let(:webhook_endpoint) { create(:webhook_endpoint, product: bearer, account:) }
+        let(:webhook_events)   { create_list(:webhook_event, 3, account:, webhook_endpoint:) }
+      end
+
+      let(:record) { webhook_events }
+    end
+
+    def accessing_its_webhook_event(scenarios)
+      case scenarios
+      in [:as_admin, *]
+        let(:webhook_event) { create(:webhook_event, account:) }
+      in [:as_environment, *]
+        let(:webhook_event) { create(:webhook_event, account:, environment: bearer) }
+      in [:as_product, *]
+        let(:webhook_endpoint) { create(:webhook_endpoint, product: bearer, account:) }
+        let(:webhook_event)    { create(:webhook_event, account:, webhook_endpoint:) }
+      end
+
+      let(:record) { webhook_event }
     end
 
     def accessing_webhook_events(scenarios)


### PR DESCRIPTION
We've been relying on a broken authz model for webhooks i.r.t. products, where a product is allowed to create/delete endpoints and receive events that could be for resources outside of its jurisdiction — which could result in unauthorized spying if a product token is used outside of a trusted server-side environment. Though there's no signs of that occurring, this will likely become more of a risk with custom permissions recently being GA'd, so I'm tightening up the reigns preemptively.

## Prereqs

- [ ] Manually add `product_id` column to `webhook_endpoints` out-of-band. Then…
- [ ] Manually set `product_id` on all Zapier webhook endpoints, i.e. `webhook_endpoints.url like 'https://hooks.zapier.com/%`. In the case there are multiple products for a given account, we'll need to do a little bit of spelunking to determine correct product (likely looking at request logs from Zapier and peeking the requestor, which will be a specific product).

## Subreqs

- [ ] Verify Zapier integrations are still functioning as expected, i.e. events are still emitted to all Zapier endpoints, and no authz errors are occurring when Zapier handles them.