### PR TITLE
Update PostgreSQL to 17.5 in docker-compose.yml

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -42,7 +42,7 @@ services:
     depends_on: [ postgres ]
 
   postgres:
-    image: postgres:9.6
+    image: postgres:17.5
     ports:
       - "5432:5432"
     environment:


### PR DESCRIPTION
This PR updates the PostgreSQL version in `docker-compose.yml` from 9.6 to 17.5. PostgreSQL 9.6 is past its End of Life, and I’ve tested 17.5 locally with Keygen CE, confirming it works as expected. 