### PR TITLE
Add user delete permission to products

### DIFF
--- a/app/models/permission.rb
+++ b/app/models/permission.rb
@@ -532,6 +532,7 @@ class Permission < ApplicationRecord
 
     user.ban
     user.create
+    user.delete
     user.group.update
     user.read
     user.tokens.generate

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -87,6 +87,12 @@ class UserPolicy < ApplicationPolicy
       allow!
     in role: Role(:environment) if record.user?
       allow!
+    in role: Role(:product) if record.user?
+      deny! 'user cannot belong to another product' unless
+        record.products == [bearer] ||
+        record.products.empty?
+
+      allow!
     else
       deny!
     end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -66,6 +66,12 @@ FactoryBot.define do
       end
     end
 
+    trait :with_user_license do
+      after :create do |user|
+        create(:license_user, account: user.account, environment: user.environment, user:)
+      end
+    end
+
     trait :with_licenses do
       with_user_licenses
       with_owned_license

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -877,6 +877,10 @@ describe UserPolicy, type: :policy do
           denies :update
         end
 
+        with_permissions %w[user.delete] do
+          denies :destroy
+        end
+
         with_permissions %w[user.ban] do
           denies :ban
         end
@@ -933,6 +937,20 @@ describe UserPolicy, type: :policy do
           allows :update
         end
 
+        with_permissions %w[user.delete] do
+          without_token_permissions { denies :destroy }
+
+          with_user_traits :with_owned_license do
+            denies :destroy
+          end
+
+          with_user_traits :with_user_license do
+            denies :destroy
+          end
+
+          allows :destroy
+        end
+
         with_permissions %w[user.ban] do
           without_token_permissions { denies :ban }
 
@@ -950,8 +968,13 @@ describe UserPolicy, type: :policy do
             denies :show, :create, :update, :destroy, :invite, :ban, :unban
           end
 
-          allows :show, :create, :update, :ban, :unban
-          denies :destroy, :invite
+          with_user_traits :with_licenses do
+            allows :show, :create, :update, :ban, :unban
+            denies :destroy, :invite
+          end
+
+          allows :show, :create, :update, :destroy, :ban, :unban
+          denies :invite
         end
 
         with_default_permissions do
@@ -959,8 +982,13 @@ describe UserPolicy, type: :policy do
             denies :show, :create, :update, :destroy, :invite, :ban, :unban
           end
 
-          allows :show, :create, :update, :ban, :unban
-          denies :destroy, :invite
+          with_user_traits :with_licenses do
+            allows :show, :create, :update, :ban, :unban
+            denies :destroy, :invite
+          end
+
+          allows :show, :create, :update, :destroy, :ban, :unban
+          denies :invite
         end
 
         without_permissions do
@@ -1001,6 +1029,20 @@ describe UserPolicy, type: :policy do
           allows :update
         end
 
+        with_permissions %w[user.delete] do
+          without_token_permissions { denies :destroy }
+
+          with_user_traits :with_owned_license do
+            denies :destroy
+          end
+
+          with_user_traits :with_user_license do
+            denies :destroy
+          end
+
+          allows :destroy
+        end
+
         with_permissions %w[user.ban] do
           without_token_permissions { denies :ban }
 
@@ -1018,8 +1060,13 @@ describe UserPolicy, type: :policy do
             denies :show, :create, :update, :destroy, :invite, :ban, :unban
           end
 
-          allows :show, :create, :update, :ban, :unban
-          denies :destroy, :invite
+          with_user_traits :with_licenses do
+            allows :show, :create, :update, :ban, :unban
+            denies :destroy, :invite
+          end
+
+          allows :show, :create, :update, :destroy, :ban, :unban
+          denies :invite
         end
 
         with_default_permissions do
@@ -1027,8 +1074,13 @@ describe UserPolicy, type: :policy do
             denies :show, :create, :update, :destroy, :invite, :ban, :unban
           end
 
-          allows :show, :create, :update, :ban, :unban
-          denies :destroy, :invite
+          with_user_traits :with_licenses do
+            allows :show, :create, :update, :ban, :unban
+            denies :destroy, :invite
+          end
+
+          allows :show, :create, :update, :destroy, :ban, :unban
+          denies :invite
         end
 
         without_permissions do


### PR DESCRIPTION
Allows deletion of users if they have no products, or if their only product matches the current one.

## Prereqs

- [ ] Add permission to existing products? `rake keygen:permissions:products:add[user.delete]`

## Subreqs

- [x] Update changelog.
- [x] Update docs.