### PR TITLE
Update to allow global admins to escape environment isolation

### DIFF
--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -188,8 +188,12 @@ module Authentication
       )
     end
 
-    user = current_account.users.for_environment(current_environment)
-                                .find_by(email: email.downcase)
+    user = current_account.users.for_environment(current_environment).union(
+                                  current_account.admins.for_environment(nil), # NB(ezekg) allow global admins to authn everywhere
+                                )
+                                .find_by(
+                                  email: email.downcase,
+                                )
 
     @current_http_scheme = :password
     @current_http_token  = nil

--- a/app/models/concerns/environmental.rb
+++ b/app/models/concerns/environmental.rb
@@ -167,7 +167,10 @@ module Environmental
               when environment.nil?
                 association.environment_id.nil?
               when environment.isolated?
-                association.environment_id == environment_id
+                association.environment_id == environment_id || (
+                  # NB(ezekg) allow global admins to escape environment isolation
+                  association in User(role: Role(:admin), environment_id: nil)
+                )
               when environment.shared?
                 association.environment_id == environment_id || association.environment_id.nil?
               end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -121,9 +121,6 @@ class User < ApplicationRecord
   before_destroy :enforce_admin_minimums_on_account!
   before_update :enforce_admin_minimums_on_account!, if: -> { role.present? && role.changed? }
 
-  before_destroy :enforce_admin_minimums_on_environment!
-  before_update :enforce_admin_minimums_on_environment!, if: -> { role.present? && role.changed? }
-
   # Tokens should be revoked when role is changed
   before_update -> { revoke_tokens!(except: Current.token) },
     if: -> { role&.name_changed? }
@@ -514,8 +511,7 @@ class User < ApplicationRecord
     nil
   end
 
-  def enforce_admin_minimums_on_account!     = enforce_admin_minimums_for(:account,     abort_on_error: true)
-  def enforce_admin_minimums_on_environment! = enforce_admin_minimums_for(:environment, abort_on_error: true)
+  def enforce_admin_minimums_on_account! = enforce_admin_minimums_for(:account, abort_on_error: true)
   def enforce_admin_minimums_for(association_name, abort_on_error: false)
     association = public_send(association_name)
     return if

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -136,7 +136,10 @@ class ApplicationPolicy
         when environment.nil?
           bearer_environment_id.nil?
         when environment.isolated?
-          bearer_environment_id == environment.id
+          bearer_environment_id == environment.id || (
+            # NB(ezekg) allow global admins to escape environment isolation
+            bearer in role: Role(:admin), environment_id: nil
+          )
         when environment.shared?
           bearer_environment_id == environment.id || bearer_environment_id.nil?
         end

--- a/features/api/v1/environments/create.feature
+++ b/features/api/v1/environments/create.feature
@@ -122,21 +122,18 @@ Feature: Create environments
         }
       }
       """
-    Then the response status should be "422"
-    And the response body should be an array of 1 errors
-    And the first error should have the following properties:
+    Then the response status should be "201"
+    And the response body should be an "environment" with the following attributes:
       """
       {
-        "title": "Unprocessable resource",
-        "detail": "environment must have at least 1 admin user",
-        "code": "ADMINS_REQUIRED",
-        "source": {
-          "pointer": "/data/relationships/admins"
-        }
+        "isolationStrategy": "ISOLATED",
+        "name": "Isolated Environment",
+        "code": "ISOLATED"
       }
       """
-    And sidekiq should have 0 "webhook" jobs
-    And sidekiq should have 0 "metric" jobs
+    And the current account should have 1 "admin"
+    And sidekiq should have 1 "webhook" job
+    And sidekiq should have 1 "metric" job
     And sidekiq should have 1 "request-log" job
 
   Scenario: Admin creates a shared environment for their account (with admins)

--- a/features/api/v1/licenses/create.feature
+++ b/features/api/v1/licenses/create.feature
@@ -818,8 +818,7 @@ Feature: Create license
     And the current account has 1 "webhook-endpoint"
     And the current account has 1 "policy"
     And the current account has 1 global "user"
-    And the current account has 1 "admin"
-    And I am the last admin of account "ent1"
+    And I am an admin of account "ent1"
     And I use an authentication token
     And I send the following headers:
       """
@@ -841,7 +840,7 @@ Feature: Create license
               "data": { "type": "policies", "id": "$policies[0]" }
             },
             "user": {
-              "data": { "type": "users", "id": "$users[2]" }
+              "data": { "type": "users", "id": "$users[1]" }
             }
           }
         }

--- a/features/api/v1/users/actions/bans.feature
+++ b/features/api/v1/users/actions/bans.feature
@@ -68,7 +68,7 @@ Feature: User ban actions
       """
       { "keygen-environment": "isolated" }
       """
-    When I send a POST request to "/accounts/test1/users/$2/actions/ban"
+    When I send a POST request to "/accounts/test1/users/$1/actions/ban"
     And the response should contain a valid signature header for "test1"
     Then the response status should be "200"
     And the response body should be a "user" with the following attributes:
@@ -235,7 +235,7 @@ Feature: User ban actions
       """
       { "keygen-environment": "isolated" }
       """
-    When I send a POST request to "/accounts/test1/users/$2/actions/unban"
+    When I send a POST request to "/accounts/test1/users/$1/actions/unban"
     And the response should contain a valid signature header for "test1"
     Then the response status should be "200"
     And the response body should be a "user" with the following attributes:

--- a/features/api/v1/users/destroy.feature
+++ b/features/api/v1/users/destroy.feature
@@ -347,14 +347,13 @@ Feature: Delete user
       """
     When I send a DELETE request to "/accounts/test1/users/$2"
     Then the response status should be "204"
-    And the current account should have 3 "admins"
+    And the current account should have 2 "admins"
 
   @ee
   Scenario: Admin attempts to delete themself when they're the only admin for an isolated environment
     Given the current account is "test1"
     And the current account has 1 isolated "environment"
-    # NOTE(ezekg) Isolated environments automatically have an admin created for them,
-    #             so we're authenticating as the isolated admin here.
+    And the current account has 1 isolated "admin"
     And I am the last admin of account "test1"
     And I use an authentication token
     And I send the following headers:
@@ -362,19 +361,8 @@ Feature: Delete user
       { "Keygen-Environment": "isolated" }
       """
     When I send a DELETE request to "/accounts/test1/users/$1"
-    Then the response status should be "422"
-    And the current account should have 2 "admins"
-    And the first error should have the following properties:
-      """
-        {
-          "title": "Unprocessable resource",
-          "detail": "environment must have at least 1 admin user",
-          "code": "ENVIRONMENT_ADMINS_REQUIRED",
-          "source": {
-            "pointer": "/data/relationships/environment"
-          }
-        }
-      """
+    Then the response status should be "204"
+    And the current account should have 1 "admin"
 
   @ee
   Scenario: Admin attempts to delete themself when they're not the only admin for a shared environment

--- a/features/api/v1/users/relationships/licenses.feature
+++ b/features/api/v1/users/relationships/licenses.feature
@@ -44,7 +44,7 @@ Feature: User licenses relationship
     And the current account has 3 isolated "licenses" for the last "user" as "owner"
     And I am an environment of account "test1"
     And I use an authentication token
-    When I send a GET request to "/accounts/test1/users/$2/licenses?environment=isolated"
+    When I send a GET request to "/accounts/test1/users/$1/licenses?environment=isolated"
     Then the response status should be "200"
     And the response body should be an array with 3 "licenses"
 

--- a/features/api/v1/users/relationships/machines.feature
+++ b/features/api/v1/users/relationships/machines.feature
@@ -51,7 +51,7 @@ Feature: User machines relationship
     And the current account has 3 isolated "machines" for the last "license"
     And I am an environment of account "test1"
     And I use an authentication token
-    When I send a GET request to "/accounts/test1/users/$2/machines?environment=isolated"
+    When I send a GET request to "/accounts/test1/users/$1/machines?environment=isolated"
     Then the response status should be "200"
     And the response body should be an array with 3 "machines"
 

--- a/features/api/v1/users/relationships/products.feature
+++ b/features/api/v1/users/relationships/products.feature
@@ -45,7 +45,7 @@ Feature: User products relationship
     And the current account has 3 isolated "licenses" for the last "user" as "owner"
     And I am an environment of account "test1"
     And I use an authentication token
-    When I send a GET request to "/accounts/test1/users/$2/products?environment=isolated"
+    When I send a GET request to "/accounts/test1/users/$1/products?environment=isolated"
     Then the response status should be "200"
     And the response body should be an array with 3 "products"
 

--- a/features/api/v1/users/update.feature
+++ b/features/api/v1/users/update.feature
@@ -663,6 +663,7 @@ Feature: Update user
   Scenario: Admin attempts to demote themself to user when they're the only admin for an isolated environment
     Given the current account is "test1"
     And the current account has 1 isolated "environment"
+    And the current account has 1 isolated "admin"
     And I am the last admin of account "test1"
     And I use an authentication token
     And I send the following headers:
@@ -680,19 +681,7 @@ Feature: Update user
         }
       }
       """
-    Then the response status should be "422"
-    And the first error should have the following properties:
-      """
-      {
-        "title": "Unprocessable resource",
-        "detail": "environment must have at least 1 admin user",
-        "source": {
-          "pointer": "/data/relationships/environment"
-        },
-        "code": "ENVIRONMENT_ADMINS_REQUIRED"
-      }
-      """
-    And the current user should have 1 "token"
+    Then the response status should be "200"
 
   @ee
   Scenario: Admin attempts to demote themself to user when they're not the only admin for a shared environment
@@ -1348,6 +1337,7 @@ Feature: Update user
   Scenario: Admin updates their permissions (isolated environment, other admins without full permissions)
     Given the current account is "ent1"
     And the current account has 1 isolated "environment"
+    And the current account has 1 isolated "admin"
     And the current account has 2 isolated "admins" with the following:
       """
       { "permissions": ["license.validate"] }
@@ -1365,18 +1355,7 @@ Feature: Update user
         }
       }
       """
-    Then the response status should be "422"
-    And the first error should have the following properties:
-      """
-      {
-        "title": "Unprocessable resource",
-        "detail": "environment must have at least 1 admin user with a full permission set",
-        "source": {
-          "pointer": "/data/relationships/environment"
-        },
-        "code": "ENVIRONMENT_ADMINS_REQUIRED"
-      }
-      """
+    Then the response status should be "200"
 
   @ee
   Scenario: Admin updates their permissions (shared environment, other admins without full permissions)
@@ -1681,7 +1660,7 @@ Feature: Update user
       """
       { "keygen-environment": "isolated" }
       """
-    When I send a PATCH request to "/accounts/test1/users/$2" with the following:
+    When I send a PATCH request to "/accounts/test1/users/$1" with the following:
       """
       {
         "data": {

--- a/features/auth/sso.feature
+++ b/features/auth/sso.feature
@@ -68,6 +68,7 @@ Feature: SSO
       """
       { "id": "cb2cab2f-aec0-4102-a1ca-8abc674d6adc", "code": "isolated" }
       """
+    And the account "ecorp-example" has 1 isolated "admin"
     And the last "admin" of account "ecorp-example" has the following attributes:
       """
       { "email": "elliot+isolated@ecorp.example" }
@@ -96,6 +97,7 @@ Feature: SSO
       """
       session_id=$sessions[0]; domain=keygen.sh; path=/; expires=Mon, 28 Feb 2552 12:00:00 GMT; secure; httponly; samesite=None; partitioned;
       """
+    And the account "ecorp-example" should have 2 "admins"
     And the last "admin" of account "ecorp-example" should have the following attributes:
       """
       {
@@ -126,9 +128,9 @@ Feature: SSO
   Scenario: We receive a successful callback for an existing admin (isolated environment, global admin)
     Given the account "ecorp-example" has 1 isolated "environment" with the following attributes:
       """
-      { "id": "cb2cab2f-aec0-4102-a1ca-8abc674d6adc", "code": "sandbox" }
+      { "id": "cb2cab2f-aec0-4102-a1ca-8abc674d6adc", "code": "isolated" }
       """
-    And the first "admin" of account "ecorp-example" has the following attributes:
+    And the last "admin" of account "ecorp-example" has the following attributes:
       """
       { "email": "elliot+global@ecorp.example" }
       """
@@ -149,12 +151,39 @@ Feature: SSO
       """
     And I use user agent "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:136.0) Gecko/20100101 Firefox/136.0"
     And time is frozen at "2552-02-28T00:00:00.000Z"
-    When I send a GET request to "//auth.keygen.sh/sso?code=test_123&state=Z2I8ARocRyyaZ9RQamDy2lpyom1oUw-FcwoAh2E5G92XqjNnVI93Rm5a2_sB0PvOITPZWALiAfNKE-K72VjcKE7sefefA8IDduEinccEcpuZJ3e8XjJdvG0qSlJ_PTs.McBe_pYs7KwnytGl.xFUUPSckrxL4YkSKzqn8Kw"
+    When I send a GET request to "//auth.keygen.sh/sso?code=test_123&state=zkeKTgQw357Nek3z7aeFHDTSSIdfkSwA-7s9E6NYj5QEKJA_h0sNnKjaJ7GJDOep8R_VC_cy_H0RlP1UQavxpk7Z40Ap15xxWgcdVT5FWjR8cUlVH94bgg-MeLhejto.pHs06JgatU88k4Ud.xbT5-byycH4IraHGZsOJeA"
     Then the response status should be "303"
-    And the response headers should contain "Location" with "https://portal.keygen.sh/sso/error?code=SSO_USER_NOT_FOUND"
-    And the response headers should not contain "Set-Cookie"
-    And the account "ecorp-example" should have 2 "admins"
-    And the account "ecorp-example" should have 0 "sessions"
+    And the response headers should contain "Location" with "https://portal.keygen.sh/ecorp-example?env=isolated"
+    And the response headers should contain "Set-Cookie" with an encrypted cookie:
+      """
+      session_id=$sessions[0]; domain=keygen.sh; path=/; expires=Mon, 28 Feb 2552 12:00:00 GMT; secure; httponly; samesite=None; partitioned;
+      """
+    And the account "ecorp-example" should have 1 "admin"
+    And the last "admin" of account "ecorp-example" should have the following attributes:
+      """
+      {
+        "environment_id": null,
+        "sso_profile_id": "test_prof_61bbd8f6eedbaff8b040d1c98ba9",
+        "sso_connection_id": "test_conn_565647f76ab997ed8a62444451c6",
+        "sso_idp_id": "test_idp_332389f4fb8a9e823cb8308a2179",
+        "email": "elliot+global@ecorp.example",
+        "first_name": "Elliot",
+        "last_name": "Alderson"
+      }
+      """
+    And the account "ecorp-example" should have 1 "session"
+    And the last "session" of account "ecorp-example" should have the following attributes:
+      """
+      {
+        "environment_id": "cb2cab2f-aec0-4102-a1ca-8abc674d6adc",
+        "bearer_type": "User",
+        "bearer_id": "$users[0]",
+        "token_id": null,
+        "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:136.0) Gecko/20100101 Firefox/136.0",
+        "ip": "127.0.0.1",
+        "last_used_at": null
+      }
+      """
     And time is unfrozen
 
   Scenario: We receive a successful callback for an existing admin (shared environment, shared admin)
@@ -191,6 +220,7 @@ Feature: SSO
       """
       session_id=$sessions[0]; domain=keygen.sh; path=/; expires=Mon, 28 Feb 2552 12:00:00 GMT; secure; httponly; samesite=None; partitioned;
       """
+    And the account "ecorp-example" should have 2 "admins"
     And the last "admin" of account "ecorp-example" should have the following attributes:
       """
       {
@@ -251,6 +281,7 @@ Feature: SSO
       """
       session_id=$sessions[0]; domain=keygen.sh; path=/; expires=Mon, 28 Feb 2552 12:00:00 GMT; secure; httponly; samesite=None; partitioned;
       """
+    And the account "ecorp-example" should have 1 "admin"
     And the last "admin" of account "ecorp-example" should have the following attributes:
       """
       {
@@ -580,7 +611,7 @@ Feature: SSO
       """
       session_id=$sessions[0]; domain=keygen.sh; path=/; expires=Mon, 28 Feb 2552 08:00:00 GMT; secure; httponly; samesite=None; partitioned;
       """
-    And the account "lumon-example" should have 2 "admins"
+    And the account "lumon-example" should have 1 "admin"
     And the account "lumon-example" should have 1 "read-only" admin
     And the last "read-only" admin of account "lumon-example" should have the following attributes:
       """
@@ -599,7 +630,7 @@ Feature: SSO
       """
       {
         "bearer_type": "User",
-        "bearer_id": "$users[2]",
+        "bearer_id": "$users[1]",
         "token_id": null,
         "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:136.0) Gecko/20100101 Firefox/136.0",
         "ip": "127.0.0.1",

--- a/features/step_definitions/authentication_steps.rb
+++ b/features/step_definitions/authentication_steps.rb
@@ -129,7 +129,7 @@ end
 
 Given /^I (?:use (?:an|my) authentication|authenticate with (?:a|my)) token$/ do
   @token = if @bearer.respond_to?(:environment)
-             @bearer.tokens.first_or_create!(account: @bearer.account, environment: @bearer.environment, bearer: @bearer)
+             @bearer.tokens.first_or_create!(account: @bearer.account, environment: @environment || @bearer.environment, bearer: @bearer)
            else
              @bearer.tokens.first_or_create!(account: @bearer.account, bearer: @bearer)
            end

--- a/features/step_definitions/resource_steps.rb
+++ b/features/step_definitions/resource_steps.rb
@@ -98,7 +98,7 @@ Given /^the current account is "([^\"]*)"$/ do |id|
 end
 
 Given /^the current environment is "([^\"]*)"$/ do |id|
-  Current.environment = FindByAliasService.call(@account.environments, id:, aliases: :code)
+  Current.environment = @environment = FindByAliasService.call(@account.environments, id:, aliases: :code)
 end
 
 Given /^there exists (\d+) "([^\"]*)"$/ do |count, resource|

--- a/spec/factories/environment.rb
+++ b/spec/factories/environment.rb
@@ -21,16 +21,5 @@ FactoryBot.define do
       isolation_strategy { 'SHARED' }
       code               { 'shared' }
     end
-
-    # Add an admin to isolated environments (at least 1 is required).
-    after :build do |environment|
-      next unless
-        environment.isolated?
-
-      next if
-        environment.users.any?
-
-      environment.users << build(:admin, account: environment.account, environment:)
-    end
   end
 end

--- a/spec/models/environment_spec.rb
+++ b/spec/models/environment_spec.rb
@@ -37,7 +37,7 @@ describe Environment, type: :model do
         account:,
       )
 
-      expect { environment.save }.to change { account.admins.count }.by_at_most(+1) # for isolated admin
+      expect { environment.save }.to_not change { account.admins.count }
     end
 
     it 'should not promote isolated users to admins on update' do


### PR DESCRIPTION
Closes #870. Simple change that allows global admins to escape isolation and authenticate into any environment, fixing the subpar UX/DX around creating and managing isolated environments in Portal.