### PR TITLE
Refactor PyPI authz to return 401 when applicable

### DIFF
--- a/app/policies/release_engines/pypi/release_package_policy.rb
+++ b/app/policies/release_engines/pypi/release_package_policy.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module ReleaseEngines::Pypi
+  class ReleasePackagePolicy < ::ReleasePackagePolicy
+    scope_for :active_record_relation do |relation|
+      relation = relation.for_environment(environment)
+
+      # NOTE(ezekg) See comment in simple controller. We don't want to use our normal authz scoping
+      #             and raise a not found error for packages that do exist but aren't accessible
+      #             by the current bearer, even if that avoids leaking information. Rather, we
+      #             want to return an authz error to avoid redirecting to PyPI.
+      relation.all
+    end
+  end
+end

--- a/features/api/v1/engines/pypi/simple/show.feature
+++ b/features/api/v1/engines/pypi/simple/show.feature
@@ -408,7 +408,7 @@ Feature: PyPI simple package files
       { "distributionStrategy": "LICENSED" }
       """
     When I send a GET request to "/accounts/test1/engines/pypi/simple/foo"
-    Then the response status should be "403"
+    Then the response status should be "401"
 
   Scenario: Anonymous requests versions for a closed product
     Given the last "product" has the following attributes:
@@ -416,7 +416,7 @@ Feature: PyPI simple package files
       { "distributionStrategy": "CLOSED" }
       """
     When I send a GET request to "/accounts/test1/engines/pypi/simple/foo"
-    Then the response status should be "403"
+    Then the response status should be "401"
 
   Scenario: Anonymous requests versions for an open product
     Given the last "product" has the following attributes:


### PR DESCRIPTION
This allows `pip` to prompt the end-user for authentication when required, improving DX.