### PR TITLE
Decrease cache max-age to 10 minutes

### DIFF
--- a/app/controllers/api/v1/release_engines/npm/package_metadata_controller.rb
+++ b/app/controllers/api/v1/release_engines/npm/package_metadata_controller.rb
@@ -54,7 +54,7 @@ module Api::V1::ReleaseEngines
 
       # for etag support
       return unless
-        stale?(metadata, last_modified:, cache_control: { max_age: 1.day, private: true })
+        stale?(metadata, last_modified:, cache_control: { max_age: 10.minutes, private: true })
 
       render json: metadata
     end

--- a/app/controllers/api/v1/release_engines/oci/manifests_controller.rb
+++ b/app/controllers/api/v1/release_engines/oci/manifests_controller.rb
@@ -30,7 +30,7 @@ module Api::V1::ReleaseEngines
 
       # for etag support
       return unless
-        stale?(manifest, cache_control: { max_age: 1.day, private: true })
+        stale?(manifest, cache_control: { max_age: 10.minutes, private: true })
 
       # oci spec is very particular about content length and media types
       response.headers['Content-Length'] = manifest.content_length

--- a/app/controllers/api/v1/release_engines/pypi/simple_controller.rb
+++ b/app/controllers/api/v1/release_engines/pypi/simple_controller.rb
@@ -15,7 +15,7 @@ module Api::V1::ReleaseEngines
 
       # for etag support
       return unless
-        stale?(packages, cache_control: { max_age: 1.day, private: true })
+        stale?(packages, cache_control: { max_age: 10.minutes, private: true })
 
       render 'api/v1/release_engines/pypi/simple/index',
         layout: 'layouts/simple',
@@ -35,7 +35,7 @@ module Api::V1::ReleaseEngines
       # FIXME(ezekg) https://github.com/brianhempel/active_record_union/issues/35
       last_modified = artifacts.collect(&:updated_at).max
       return unless
-        stale?(etag: artifacts, last_modified:, cache_control: { max_age: 1.day, private: true })
+        stale?(etag: artifacts, last_modified:, cache_control: { max_age: 10.minutes, private: true })
 
       render 'api/v1/release_engines/pypi/simple/show',
         layout: 'layouts/simple',

--- a/app/controllers/api/v1/release_engines/rubygems/compact_index_controller.rb
+++ b/app/controllers/api/v1/release_engines/rubygems/compact_index_controller.rb
@@ -40,7 +40,7 @@ module Api::V1::ReleaseEngines
 
       # for etag support
       return unless
-        stale?(versions, cache_control: { max_age: 1.day, private: true })
+        stale?(versions, cache_control: { max_age: 10.minutes, private: true })
 
       render plain: versions
     end
@@ -63,7 +63,7 @@ module Api::V1::ReleaseEngines
       )
 
       return unless
-        stale?(info, cache_control: { max_age: 1.day, private: true })
+        stale?(info, cache_control: { max_age: 10.minutes, private: true })
 
       render plain: info
     end
@@ -81,7 +81,7 @@ module Api::V1::ReleaseEngines
       )
 
       return unless
-        stale?(names, cache_control: { max_age: 1.day, private: true })
+        stale?(names, cache_control: { max_age: 10.minutes, private: true })
 
       render plain: names
     end

--- a/app/controllers/api/v1/release_engines/rubygems/specs_controller.rb
+++ b/app/controllers/api/v1/release_engines/rubygems/specs_controller.rb
@@ -22,7 +22,7 @@ module Api::V1::ReleaseEngines
       zipped  = deflate(dumped)
 
       return unless
-        stale?(zipped, cache_control: { max_age: 1.day, private: true })
+        stale?(zipped, cache_control: { max_age: 10.minutes, private: true })
 
       send_data zipped, filename: "#{params[:gem]}.gemspec.rz"
     end
@@ -41,7 +41,7 @@ module Api::V1::ReleaseEngines
       zipped = gzip(dumped)
 
       return unless
-        stale?(zipped, cache_control: { max_age: 1.day, private: true })
+        stale?(zipped, cache_control: { max_age: 10.minutes, private: true })
 
       send_data zipped
     end
@@ -74,7 +74,7 @@ module Api::V1::ReleaseEngines
       zipped = gzip(dumped)
 
       return unless
-        stale?(zipped, cache_control: { max_age: 1.day, private: true })
+        stale?(zipped, cache_control: { max_age: 10.minutes, private: true })
 
       send_data zipped
     end
@@ -96,7 +96,7 @@ module Api::V1::ReleaseEngines
       zipped = gzip(dumped)
 
       return unless
-        stale?(zipped, cache_control: { max_age: 1.day, private: true })
+        stale?(zipped, cache_control: { max_age: 10.minutes, private: true })
 
       send_data zipped
     end

--- a/features/api/v1/engines/npm/show.feature
+++ b/features/api/v1/engines/npm/show.feature
@@ -332,7 +332,7 @@ Feature: npm package metadata
     And the response should contain the following raw headers:
       """
       Etag: W/"68fca08fa381b6979de4b675868cf283"
-      Cache-Control: max-age=86400, private, no-transform
+      Cache-Control: max-age=600, private, no-transform
       """
 
   Scenario: Endpoint should return an error for a package without any versions

--- a/features/api/v1/engines/oci/manifests.feature
+++ b/features/api/v1/engines/oci/manifests.feature
@@ -1073,7 +1073,7 @@ Feature: OCI image manifests
     And the response should contain the following raw headers:
       """
       Etag: W/"c2eab43acb840126ba7a214819e2c71a"
-      Cache-Control: max-age=86400, private, no-transform
+      Cache-Control: max-age=600, private, no-transform
       """
 
   Scenario: Product retrieves their licensed manifest

--- a/features/api/v1/engines/pypi/simple/index.feature
+++ b/features/api/v1/engines/pypi/simple/index.feature
@@ -174,7 +174,7 @@ Feature: PyPI simple package index
     And the response should contain the following raw headers:
       """
       Etag: W/"397755b058e59854428836c292bdfaed"
-      Cache-Control: max-age=86400, private, no-transform
+      Cache-Control: max-age=600, private, no-transform
       """
 
   Scenario: License requests an index for a licensed product

--- a/features/api/v1/engines/pypi/simple/show.feature
+++ b/features/api/v1/engines/pypi/simple/show.feature
@@ -309,7 +309,7 @@ Feature: PyPI simple package files
     And the response should contain the following raw headers:
       """
       Etag: W/"6d7793913c7e76a1b8964e1798c316ae"
-      Cache-Control: max-age=86400, private, no-transform
+      Cache-Control: max-age=600, private, no-transform
       """
 
   Scenario: License requests versions for a licensed product

--- a/features/api/v1/engines/rubygems/compact_index.feature
+++ b/features/api/v1/engines/rubygems/compact_index.feature
@@ -152,7 +152,7 @@ Feature: Rubygems compact index
     And the response should contain the following raw headers:
       """
       Etag: W/"a870c6d351550439c697733e94fae5a0"
-      Cache-Control: max-age=86400, private, no-transform
+      Cache-Control: max-age=600, private, no-transform
       """
     And the response body should be a text document with the following content:
       """
@@ -231,7 +231,7 @@ Feature: Rubygems compact index
     And the response should contain the following raw headers:
       """
       Etag: W/"38afb98cc89d213319ac2cb928069b66"
-      Cache-Control: max-age=86400, private, no-transform
+      Cache-Control: max-age=600, private, no-transform
       """
     And the response body should be a text document with the following content:
       """
@@ -277,7 +277,7 @@ Feature: Rubygems compact index
     And the response should contain the following raw headers:
       """
       Etag: W/"2d63ca76663b18e649dee3c55bb0e0d9"
-      Cache-Control: max-age=86400, private, no-transform
+      Cache-Control: max-age=600, private, no-transform
       """
     And the response body should be a text document with the following content:
       """

--- a/features/api/v1/engines/rubygems/specs.feature
+++ b/features/api/v1/engines/rubygems/specs.feature
@@ -159,7 +159,7 @@ Feature: Rubygems legacy specs index
     And the response should contain the following raw headers:
       """
       Etag: W/"7881fff6707156380bdc9236e286cf83"
-      Cache-Control: max-age=86400, private, no-transform
+      Cache-Control: max-age=600, private, no-transform
       """
     And the response body should be a gemspec with the following content:
       """
@@ -565,7 +565,7 @@ Feature: Rubygems legacy specs index
     And the response should contain the following raw headers:
       """
       Etag: W/"697c5c065808ab67076f865ec7d72853"
-      Cache-Control: max-age=86400, private, no-transform
+      Cache-Control: max-age=600, private, no-transform
       """
     And the response body should be gemspecs with the following content:
       """
@@ -783,7 +783,7 @@ Feature: Rubygems legacy specs index
     And the response should contain the following raw headers:
       """
       Etag: W/"bb875b8be35a27c3ad8692476c094c79"
-      Cache-Control: max-age=86400, private, no-transform
+      Cache-Control: max-age=600, private, no-transform
       """
     And the response body should be gemspecs with the following content:
       """
@@ -1001,7 +1001,7 @@ Feature: Rubygems legacy specs index
     And the response should contain the following raw headers:
       """
       Etag: W/"7e47b8d18320b47af2f1a03d2f75983b"
-      Cache-Control: max-age=86400, private, no-transform
+      Cache-Control: max-age=600, private, no-transform
       """
     And the response body should be gemspecs with the following content:
       """


### PR DESCRIPTION
This is a caching change across the board for the distribution engine. Our `Etag` header will still be respected, but caches will be refreshed more often via the `If-None-Match` dance, which is what we want. Hopefully this results in less stale package indexes for accounts that release more frequently than daily (have had reports of this especially with `pip`).