### PR TITLE
Add support for ECDSA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@
 
 # Other
 .DS_Store
+.vscode

--- a/README.md
+++ b/README.md
@@ -245,10 +245,9 @@ The CLA is available [here](https://keygen.sh/cla/).
 
 ## Security
 
-We take security at Keygen very seriously. We perform annual pen-tests on our
-code base and infrastructure. In addition, we regularly perform code audits.
-Our most recent pen-test was performed by [Greg Molnar](https://greg.molnar.io/security-consultancy/),
-an OSCP-certified security researcher in the Ruby and Rails community.
+We take security at Keygen very seriously. We try to perform annual pen-tests
+on our code base and infrastructure. In addition, we regularly perform both
+internal and external code audits.
 
 If you believe you've found a vulnerability, please see our [`SECURITY.md`](https://github.com/keygen-sh/keygen-api/blob/master/SECURITY.md)
 file.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@ Thanks for helping make Keygen safe for everyone.
 
 We take the security of Keygen seriously. We perform annual internal penetration tests of Keygen's code base and infrastructure. In addition, we perform regular internal and external code audits and external pen-tests.
 
-Our most recent external pen-test was performed in May, 2023 by [Greg Molnar](https://greg.molnar.io/security-consultancy/), an OSCP-certified security researcher in the Ruby and Rails community.
+Our most recent external pen-test was performed in September, 2025 by [Casco](https://casco.com).
 
 ## Reporting Security Issues
 

--- a/app/models/license.rb
+++ b/app/models/license.rb
@@ -1047,6 +1047,8 @@ class License < ApplicationRecord
       generate_pkcs1_pss_signed_key! version: 2
     when "ED25519_SIGN"
       generate_ed25519_signed_key!
+    when "ECDSA_P256_SIGN"
+      generate_ecdsa_p256_signed_key!
     end
 
     raise ActiveRecord::RecordInvalid if key.nil?
@@ -1163,6 +1165,16 @@ class License < ApplicationRecord
     signing_data = "key/#{encoded_license_key}"
     sig = signing_key.sign signing_data
     encoded_sig = Base64.urlsafe_encode64 sig
+
+    self.key = "#{signing_data}.#{encoded_sig}"
+  end
+
+  def generate_ecdsa_p256_signed_key!
+    signing_key = OpenSSL::PKey::EC.new(account.ecdsa_private_key)
+    encoded_license_key = Base64.urlsafe_encode64(seed_key)
+    signing_data = "key/#{encoded_license_key}"
+    sig = signing_key.sign(OpenSSL::Digest::SHA256.new, signing_data)
+    encoded_sig = Base64.urlsafe_encode64(sig)
 
     self.key = "#{signing_data}.#{encoded_sig}"
   end

--- a/app/models/license_file.rb
+++ b/app/models/license_file.rb
@@ -8,9 +8,11 @@ class LicenseFile
     aes-256-gcm+ed25519
     aes-256-gcm+rsa-pss-sha256
     aes-256-gcm+rsa-sha256
+    aes-256-gcm+ecdsa-p256
     base64+ed25519
     base64+rsa-pss-sha256
     base64+rsa-sha256
+    base64+ecdsa-p256
   ].freeze
 
   attribute :account_id,     :uuid

--- a/app/models/machine_file.rb
+++ b/app/models/machine_file.rb
@@ -8,9 +8,11 @@ class MachineFile
     aes-256-gcm+ed25519
     aes-256-gcm+rsa-pss-sha256
     aes-256-gcm+rsa-sha256
+    aes-256-gcm+ecdsa-p256
     base64+ed25519
     base64+rsa-pss-sha256
     base64+rsa-sha256
+    base64+ecdsa-p256
   ].freeze
 
   attribute :account_id,     :uuid

--- a/app/models/policy.rb
+++ b/app/models/policy.rb
@@ -24,6 +24,7 @@ class Policy < ApplicationRecord
     RSA_2048_PKCS1_SIGN_V2
     RSA_2048_PKCS1_PSS_SIGN_V2
     ED25519_SIGN
+    ECDSA_P256_SIGN
   ].freeze
 
   MACHINE_UNIQUENESS_STRATEGIES = %w[
@@ -193,7 +194,7 @@ class Policy < ApplicationRecord
   validates :check_in_interval, inclusion: { in: %w[day week month year], message: "must be one of: day, week, month, year" }, if: :requires_check_in?
   validates :check_in_interval_count, inclusion: { in: 1..365, message: "must be a number between 1 and 365 inclusive" }, if: :requires_check_in?
   validates :scheme, inclusion: { in: %w[LEGACY_ENCRYPT], message: "unsupported encryption scheme (scheme must be LEGACY_ENCRYPT for legacy encrypted policies)" }, if: :encrypted?
-  validates :scheme, inclusion: { in: CRYPTO_SCHEMES, message: "unsupported encryption scheme" }, if: :scheme?
+  validates :scheme, inclusion: { in: CRYPTO_SCHEMES, message: "unsupported signing scheme" }, if: :scheme?
   validates :machine_uniqueness_strategy, inclusion: { in: MACHINE_UNIQUENESS_STRATEGIES, message: "unsupported machine uniqueness strategy" }, allow_nil: true
   validates :machine_matching_strategy, inclusion: { in: MACHINE_MATCHING_STRATEGIES, message: "unsupported machine matching strategy" }, allow_nil: true
   validates :component_uniqueness_strategy, inclusion: { in: COMPONENT_UNIQUENESS_STRATEGIES, message: "unsupported component uniqueness strategy" }, allow_nil: true

--- a/app/models/webhook_endpoint.rb
+++ b/app/models/webhook_endpoint.rb
@@ -19,7 +19,7 @@ class WebhookEndpoint < ApplicationRecord
   validates :subscriptions, length: { minimum: 1, message: 'must have at least 1 webhook event subscription' }
   validates :url, url: { protocols: %w[https] }, length: { maximum: 4.kilobytes }, presence: true
   validates :signature_algorithm,
-    inclusion: { in: %w[ed25519 rsa-pss-sha256 rsa-sha256], message: 'unsupported signature algorithm' },
+    inclusion: { in: %w[ed25519 rsa-pss-sha256 rsa-sha256 ecdsa-p256], message: 'unsupported signature algorithm' },
     allow_nil: true
 
   validates :api_version,

--- a/app/serializers/account_serializer.rb
+++ b/app/serializers/account_serializer.rb
@@ -129,12 +129,14 @@ class AccountSerializer < BaseSerializer
   meta do
     ed25519_key = Base64.strict_encode64(@object.ed25519_public_key)
     rsa2048_key = Base64.strict_encode64(@object.public_key)
+    ecdsa_key   = Base64.strict_encode64(@object.ecdsa_public_key)
 
     meta = {
       public_key: rsa2048_key,
       keys: {
         ed25519: ed25519_key,
         rsa2048: rsa2048_key,
+        ecdsa: ecdsa_key,
       }
     }
 

--- a/app/services/license_checkout_service.rb
+++ b/app/services/license_checkout_service.rb
@@ -36,6 +36,8 @@ class LicenseCheckoutService < AbstractCheckoutService
              'rsa-sha256'
            when 'ED25519_SIGN'
              'ed25519'
+           when 'ECDSA_P256_SIGN'
+             'ecdsa-p256'
            else
              true
            end

--- a/app/services/machine_checkout_service.rb
+++ b/app/services/machine_checkout_service.rb
@@ -44,6 +44,8 @@ class MachineCheckoutService < AbstractCheckoutService
              'rsa-sha256'
            when 'ED25519_SIGN'
              'ed25519'
+           when 'ECDSA_P256_SIGN'
+             'ecdsa-p256'
            else
              true
            end

--- a/features/api/v1/accounts/create.feature
+++ b/features/api/v1/accounts/create.feature
@@ -48,7 +48,8 @@ Feature: Create account
         "publicKey": "$~accounts[0].public_key",
         "keys": {
           "ed25519": "$~accounts[0].ed25519_public_key",
-          "rsa2048": "$~accounts[0].public_key"
+          "rsa2048": "$~accounts[0].public_key",
+          "ecdsa": "$~accounts[0].ecdsa_public_key"
         }
       }
       """
@@ -105,7 +106,8 @@ Feature: Create account
         "publicKey": "$~accounts[0].public_key",
         "keys": {
           "ed25519": "$~accounts[0].ed25519_public_key",
-          "rsa2048": "$~accounts[0].public_key"
+          "rsa2048": "$~accounts[0].public_key",
+          "ecdsa": "$~accounts[0].ecdsa_public_key"
         }
       }
       """

--- a/features/api/v1/accounts/show.feature
+++ b/features/api/v1/accounts/show.feature
@@ -25,7 +25,8 @@ Feature: Show account
         "publicKey": "$~accounts[0].public_key",
         "keys": {
           "ed25519": "$~accounts[0].ed25519_public_key",
-          "rsa2048": "$~accounts[0].public_key"
+          "rsa2048": "$~accounts[0].public_key",
+          "ecdsa": "$~accounts[0].ecdsa_public_key"
         }
       }
       """
@@ -360,6 +361,17 @@ Feature: Show account
       """
     When I send a GET request to "/accounts/test1"
     And the response should contain a valid "rsa-sha256" signature header for "test1"
+    Then the response status should be "200"
+
+  Scenario: Admin retrieves their account, accepting an ecdsa-p256 signature algorithm
+    Given I am an admin of account "test1"
+    And I use an authentication token
+    And I send the following headers:
+      """
+      { "Keygen-Accept-Signature": "algorithm=\"ecdsa-p256\"" }
+      """
+    When I send a GET request to "/accounts/test1"
+    And the response should contain a valid "ecdsa-p256" signature header for "test1"
     Then the response status should be "200"
 
   Scenario: Admin retrieves their account, accepting an invalid signature algorithm

--- a/features/api/v1/accounts/update.feature
+++ b/features/api/v1/accounts/update.feature
@@ -36,7 +36,8 @@ Feature: Update account
         "publicKey": "$~accounts[0].public_key",
         "keys": {
           "ed25519": "$~accounts[0].ed25519_public_key",
-          "rsa2048": "$~accounts[0].public_key"
+          "rsa2048": "$~accounts[0].public_key",
+          "ecdsa": "$~accounts[0].ecdsa_public_key"
         }
       }
       """

--- a/features/api/v1/licenses/actions/checkouts.feature
+++ b/features/api/v1/licenses/actions/checkouts.feature
@@ -368,6 +368,42 @@ Feature: License checkout actions
     And sidekiq should have 1 "metric" job
     And sidekiq should have 1 "request-log" job
 
+  Scenario: Admin performs a license checkout using ECDSA (POST)
+    Given the current account is "test1"
+    And the current account has 1 "webhook-endpoint"
+    And the current account has 1 "policy"
+    And the last "policy" has the following attributes:
+      """
+      { "scheme": "ECDSA_P256_SIGN" }
+      """
+    And the current account has 1 "license" for the last "policy"
+    And I am an admin of account "test1"
+    And I use an authentication token
+    When I send a POST request to "/accounts/test1/licenses/$0/actions/check-out"
+    Then the response status should be "200"
+    And the response body should be a "license-file" with a certificate signed using "ecdsa-p256"
+    And sidekiq should have 1 "webhook" job
+    And sidekiq should have 1 "metric" job
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: Admin performs a license checkout using ECDSA (GET)
+    Given the current account is "test1"
+    And the current account has 1 "webhook-endpoint"
+    And the current account has 1 "policy"
+    And the last "policy" has the following attributes:
+      """
+      { "scheme": "ECDSA_P256_SIGN" }
+      """
+    And the current account has 1 "license" for the last "policy"
+    And I am an admin of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/licenses/$0/actions/check-out"
+    Then the response status should be "200"
+    And the response should be a "LICENSE" certificate signed using "ecdsa-p256"
+    And sidekiq should have 1 "webhook" job
+    And sidekiq should have 1 "metric" job
+    And sidekiq should have 1 "request-log" job
+
   Scenario: Admin performs a license checkout with a custom algorithm (POST)
     Given time is frozen at "2022-10-16T14:52:48.000Z"
     And the current account is "test1"

--- a/features/api/v1/licenses/actions/validations.feature
+++ b/features/api/v1/licenses/actions/validations.feature
@@ -5105,6 +5105,24 @@ Feature: License validation actions
     And sidekiq should have 1 "metric" job
     And sidekiq should have 1 "request-log" job
 
+  Scenario: An admin validates a license using scheme ECDSA_P256_SIGN
+    Given I am an admin of account "test1"
+    And the current account is "test1"
+    And the current account has 1 "webhook-endpoint"
+    And the current account has 1 "license" using "ECDSA_P256_SIGN"
+    And I use an authentication token
+    When I send a POST request to "/accounts/test1/licenses/$0/actions/validate"
+    Then the response status should be "200"
+    And the response should contain a valid signature header for "test1"
+    And the response body should contain a "license"
+    And the response body should contain meta which includes the following:
+      """
+      { "valid": true, "detail": "is valid", "code": "VALID" }
+      """
+    And sidekiq should have 1 "webhook" job
+    And sidekiq should have 1 "metric" job
+    And sidekiq should have 1 "request-log" job
+
   Scenario: A user validates a license scoped to their own ID
     Given the current account is "test1"
     And the current account has 1 "webhook-endpoint"

--- a/features/api/v1/licenses/create.feature
+++ b/features/api/v1/licenses/create.feature
@@ -4019,6 +4019,147 @@ Feature: Create license
     And sidekiq should have 1 "metric" job
     And sidekiq should have 1 "request-log" job
 
+  Scenario: Admin creates a license using scheme ECDSA_P256_SIGN for a user of their account
+    Given I am an admin of account "test1"
+    And the current account is "test1"
+    And the current account has 1 "webhook-endpoint"
+    And the current account has 1 "product"
+    And the current account has 1 "policy"
+    And the first "policy" has the following attributes:
+      """
+      { "productId": "$products[0].id", "scheme": "ECDSA_P256_SIGN" }
+      """
+    And the current account has 1 "user"
+    And I use an authentication token
+    When I send a POST request to "/accounts/test1/licenses" with the following:
+      """
+      {
+        "data": {
+          "type": "licenses",
+          "relationships": {
+            "policy": {
+              "data": {
+                "type": "policies",
+                "id": "$policies[0]"
+              }
+            }
+          }
+        }
+      }
+      """
+    Then the response status should be "201"
+    And the current account should have 1 "license"
+    And the response body should a "license" that contains a valid "ECDSA_P256_SIGN" key with the following dataset:
+      """
+      {
+        "account": { "id": "$accounts[0].id" },
+        "product": { "id": "$products[0].id" },
+        "policy": {
+          "id": "$policies[0].id",
+          "duration": $policies[0].duration
+        },
+        "user": null,
+        "license": {
+          "id": "$licenses[0].id",
+          "created": "$licenses[0].created_at",
+          "expiry": "$licenses[0].expiry"
+        }
+      }
+      """
+    And sidekiq should have 1 "webhook" job
+    And sidekiq should have 1 "metric" job
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: Admin creates a license using scheme ECDSA_P256_SIGN with a pre-determined key
+    Given I am an admin of account "test1"
+    And the current account is "test1"
+    And the current account has 1 "webhook-endpoint"
+    And the current account has 1 "policies"
+    And the first "policy" has the following attributes:
+      """
+      { "scheme": "ECDSA_P256_SIGN" }
+      """
+    And the current account has 1 "user"
+    And I use an authentication token
+    When I send a POST request to "/accounts/test1/licenses" with the following:
+      """
+      {
+        "data": {
+          "type": "licenses",
+          "attributes": {
+            "key": "ecdsa-signed-payload"
+          },
+          "relationships": {
+            "policy": {
+              "data": {
+                "type": "policies",
+                "id": "$policies[0]"
+              }
+            },
+            "user": {
+              "data": {
+                "type": "users",
+                "id": "$users[1]"
+              }
+            }
+          }
+        }
+      }
+      """
+    Then the response status should be "201"
+    And the current account should have 1 "license"
+    And the response body should be a "license" with the signed key of "ecdsa-signed-payload" using "ECDSA_P256_SIGN"
+    And the response body should be a "license" with the scheme "ECDSA_P256_SIGN"
+    And the response body should be a "license" that is not encrypted
+    And sidekiq should have 1 "webhook" job
+    And sidekiq should have 1 "metric" job
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: Admin creates a license using scheme ECDSA_P256_SIGN with a short key
+    Given I am an admin of account "test1"
+    And the current account is "test1"
+    And the current account has 1 "webhook-endpoint"
+    And the current account has 1 "policies"
+    And the first "policy" has the following attributes:
+      """
+      { "scheme": "ECDSA_P256_SIGN" }
+      """
+    And the current account has 1 "user"
+    And I use an authentication token
+    When I send a POST request to "/accounts/test1/licenses" with the following:
+      """
+      {
+        "data": {
+          "type": "licenses",
+          "attributes": {
+            "key": "short"
+          },
+          "relationships": {
+            "policy": {
+              "data": {
+                "type": "policies",
+                "id": "$policies[0]"
+              }
+            },
+            "user": {
+              "data": {
+                "type": "users",
+                "id": "$users[1]"
+              }
+            }
+          }
+        }
+      }
+      """
+    Then the response status should be "201"
+    And the current account should have 1 "license"
+    And the response body should be a "license" with the signed key of "short" using "ECDSA_P256_SIGN"
+    And the response body should be a "license" with the scheme "ECDSA_P256_SIGN"
+    And the response body should be a "license" that is not encrypted
+    And sidekiq should have 1 "webhook" job
+    And sidekiq should have 1 "metric" job
+    And sidekiq should have 1 "request-log" job
+
   Scenario: Admin creates a license without a user
     Given I am an admin of account "test1"
     And the current account is "test1"
@@ -7084,6 +7225,46 @@ Feature: Create license
         "issued": "$licenses[0].created_at",
         "expires": "$licenses[0].expiry"
       }
+      """
+    And sidekiq should have 1 "webhook" job
+    And sidekiq should have 1 "metric" job
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: Admin creates a license using scheme ECDSA_P256_SIGN using template variables
+    Given I am an admin of account "test1"
+    And the current account is "test1"
+    And the current account has 1 "webhook-endpoint"
+    And the current account has 1 "policies"
+    And the first "policy" has the following attributes:
+      """
+      { "scheme": "ECDSA_P256_SIGN" }
+      """
+    And the current account has 1 "user"
+    And I use an authentication token
+    When I send a POST request to "/accounts/test1/licenses" with the following:
+      """
+      {
+        "data": {
+          "type": "licenses",
+          "attributes": {
+            "key": "{\"id\":\"{{id}}\",\"alg\":\"nist-p256\",\"iss\":\"{{created}}\",\"exp\":\"{{expiry}}\"}"
+          },
+          "relationships": {
+            "policy": {
+              "data": {
+                "type": "policies",
+                "id": "$policies[0]"
+              }
+            }
+          }
+        }
+      }
+      """
+    Then the response status should be "201"
+    And the current account should have 1 "license"
+    And the response body should a "license" that contains a valid "ECDSA_P256_SIGN" key with the following dataset:
+      """
+      {"id":"$licenses[0].id","alg":"nist-p256","iss":"$licenses[0].created_at","exp":"$licenses[0].expiry"}
       """
     And sidekiq should have 1 "webhook" job
     And sidekiq should have 1 "metric" job

--- a/features/api/v1/licenses/show.feature
+++ b/features/api/v1/licenses/show.feature
@@ -499,6 +499,14 @@ Feature: Show license
     When I send a GET request to "/accounts/test1/licenses/$0"
     Then the response status should be "200"
 
+  Scenario: Admin attempts to retrieve a license for their account by key using scheme ECDSA_P256_SIGN
+    Given I am an admin of account "test1"
+    And the current account is "test1"
+    And the current account has 1 "license" using "ECDSA_P256_SIGN"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/licenses/$0"
+    Then the response status should be "200"
+
   Scenario: Admin attempts to retrieves an active license for their account (new license)
     Given I am an admin of account "test1"
     And the current account is "test1"

--- a/features/api/v1/machines/actions/checkouts.feature
+++ b/features/api/v1/machines/actions/checkouts.feature
@@ -374,6 +374,44 @@ Feature: Machine checkout actions
     And sidekiq should have 1 "metric" job
     And sidekiq should have 1 "request-log" job
 
+  Scenario: Admin performs a machine checkout using ECDSA (POST)
+    Given the current account is "test1"
+    And the current account has 1 "webhook-endpoint"
+    And the current account has 1 "policy"
+    And the last "policy" has the following attributes:
+      """
+      { "scheme": "ECDSA_P256_SIGN" }
+      """
+    And the current account has 1 "license" for the last "policy"
+    And the current account has 1 "machine" for the last "license"
+    And I am an admin of account "test1"
+    And I use an authentication token
+    When I send a POST request to "/accounts/test1/machines/$0/actions/check-out"
+    Then the response status should be "200"
+    And the response body should be a "machine-file" with a certificate signed using "ecdsa-p256"
+    And sidekiq should have 1 "webhook" job
+    And sidekiq should have 1 "metric" job
+    And sidekiq should have 1 "request-log" job
+
+  Scenario: Admin performs a machine checkout using ECDSA (GET)
+    Given the current account is "test1"
+    And the current account has 1 "webhook-endpoint"
+    And the current account has 1 "policy"
+    And the last "policy" has the following attributes:
+      """
+      { "scheme": "ECDSA_P256_SIGN" }
+      """
+    And the current account has 1 "license" for the last "policy"
+    And the current account has 1 "machine" for the last "license"
+    And I am an admin of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/machines/$0/actions/check-out"
+    Then the response status should be "200"
+    And the response should be a "MACHINE" certificate signed using "ecdsa-p256"
+    And sidekiq should have 1 "webhook" job
+    And sidekiq should have 1 "metric" job
+    And sidekiq should have 1 "request-log" job
+
   Scenario: Admin performs a machine checkout with a custom algorithm (POST)
     Given time is frozen at "2022-10-16T14:52:48.000Z"
     And the current account is "test1"
@@ -383,10 +421,10 @@ Feature: Machine checkout actions
     And I use an authentication token
     When I send a POST request to "/accounts/test1/machines/$0/actions/check-out" with the following:
       """
-      { "meta": { "algorithm": "aes-256-gcm+rsa-pss-sha256" } }
+      { "meta": { "algorithm": "aes-256-gcm+ecdsa-p256" } }
       """
     Then the response status should be "200"
-    And the response body should be a "machine-file" with a certificate signed using "rsa-pss-sha256"
+    And the response body should be a "machine-file" with a certificate signed using "ecdsa-p256"
     And the response body should be a "machine-file" with the following encrypted certificate data:
       """
       {
@@ -413,9 +451,9 @@ Feature: Machine checkout actions
     And the current account has 1 "machine" for the last "license"
     And I am an admin of account "test1"
     And I use an authentication token
-    When I send a GET request to "/accounts/test1/machines/$0/actions/check-out?algorithm=base64%2Brsa-sha256"
+    When I send a GET request to "/accounts/test1/machines/$0/actions/check-out?algorithm=base64%2Brsa-pss-sha256"
     Then the response status should be "200"
-    And the response should be a "MACHINE" certificate signed using "rsa-sha256"
+    And the response should be a "MACHINE" certificate signed using "rsa-pss-sha256"
     And the response should be a "MACHINE" certificate with the following encoded data:
       """
       {

--- a/features/api/v1/policies/create.feature
+++ b/features/api/v1/policies/create.feature
@@ -3857,6 +3857,37 @@ Feature: Create policy
     And sidekiq should have 1 "metric" job
     And sidekiq should have 1 "request-log" job
 
+  Scenario: Admin creates a policy using scheme ED25519_SIGN for their account
+    Given I am an admin of account "test1"
+    And the current account is "test1"
+    And the current account has 2 "webhook-endpoints"
+    And the current account has 1 "product"
+    And I use an authentication token
+    When I send a POST request to "/accounts/test1/policies" with the following:
+      """
+      {
+        "data": {
+          "type": "policies",
+          "attributes": { "name": "ECDSA", "scheme": "ECDSA_P256_SIGN" },
+          "relationships": {
+            "product": {
+              "data": {
+                "type": "products",
+                "id": "$products[0]"
+              }
+            }
+          }
+        }
+      }
+      """
+    Then the response status should be "201"
+    And the response body should be a "policy" with the scheme "ECDSA_P256_SIGN"
+    And the response body should be a "policy" that is not encrypted
+    And the response body should be a "policy" with the name "ECDSA"
+    And sidekiq should have 2 "webhook" jobs
+    And sidekiq should have 1 "metric" job
+    And sidekiq should have 1 "request-log" job
+
   Scenario: Admin creates a legacy encrypted policy without a scheme for their account
     Given I am an admin of account "test1"
     And the current account is "test1"
@@ -4007,7 +4038,7 @@ Feature: Create policy
       """
       {
         "title": "Unprocessable resource",
-        "detail": "unsupported encryption scheme",
+        "detail": "unsupported signing scheme",
         "source": {
           "pointer": "/data/attributes/scheme"
         },

--- a/features/step_definitions/resource_steps.rb
+++ b/features/step_definitions/resource_steps.rb
@@ -469,6 +469,8 @@ Given /^the current account has (\d+) "([^\"]*)" using "([^\"]*)"$/ do |count, r
       @crypt << create(resource.singularize.underscore, :rsa_2048_pkcs1_pss_sign_v2, account: @account, key: SecureRandom.hex)
     when 'ED25519_SIGN'
       @crypt << create(resource.singularize.underscore, :ed25519_sign, account: @account, key: SecureRandom.hex)
+    when 'ECDSA_P256_SIGN'
+      @crypt << create(resource.singularize.underscore, :ecdsa_p256_sign, account: @account, key: SecureRandom.hex)
     end
   end
 end

--- a/spec/factories/license.rb
+++ b/spec/factories/license.rb
@@ -41,6 +41,10 @@ FactoryBot.define do
       policy { build(:policy, :ed25519_sign, account:, environment:) }
     end
 
+    trait :ecdsa_p256_sign do
+      policy { build(:policy, :ecdsa_p256_sign, account:, environment:) }
+    end
+
     trait :day_check_in do
       policy { build(:policy, :day_check_in, account:, environment:) }
     end

--- a/spec/factories/policy.rb
+++ b/spec/factories/policy.rb
@@ -66,6 +66,11 @@ FactoryBot.define do
       encrypted { false }
     end
 
+    trait :ecdsa_p256_sign do
+      scheme    { 'ECDSA_P256_SIGN' }
+      encrypted { false }
+    end
+
     trait :day_check_in do
       require_check_in        { true }
       check_in_interval       { 'day' }

--- a/spec/support/helpers/signature_helper.rb
+++ b/spec/support/helpers/signature_helper.rb
@@ -71,6 +71,9 @@ class SignatureHelper
     when 'rsa-sha256'
       pub = OpenSSL::PKey::RSA.new(account.public_key)
       ok  = pub.verify(sha256, sig_bytes, signing_data) rescue false
+    when 'ecdsa-p256'
+      pub = OpenSSL::PKey::EC.new(account.ecdsa_public_key)
+      ok  = pub.verify(sha256, sig_bytes, signing_data) rescue false
     end
 
     ok


### PR DESCRIPTION
Adds support for ECDSA over secp256r1 (NIST P-256) signing scheme, mainly to ease compliance with [FIPS 140-3](https://csrc.nist.gov/pubs/fips/140-3/final).

## Prereqs

- [x] #986
- [x] #987

## Subreqs

- [ ] https://github.com/keygen-sh/keygen-go/pull/26