### PR TITLE
Update product token authz to be more consistent

### DIFF
--- a/app/models/token.rb
+++ b/app/models/token.rb
@@ -356,11 +356,12 @@ class Token < ApplicationRecord
     bearer.has_role? :user
   end
 
-  def activation_token?
+  def license_token?
     return false if orphaned_token?
 
     bearer.has_role? :license
   end
+  alias :activation_token? :license_token?
 
   def kind
     case

--- a/app/policies/environments/token_policy.rb
+++ b/app/policies/environments/token_policy.rb
@@ -11,8 +11,8 @@ module Environments
       case bearer
       in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only)
         allow!
-      in role: Role(:environment) if environment == bearer
-        record.all? { _1 in bearer_type: ^(Environment.name), bearer_id: ^(bearer.id) }
+      in role: Role(:environment), id: bearer_id if environment == bearer
+        record.all? { _1 in bearer_type: 'Environment', bearer_id: ^bearer_id }
       else
         deny!
       end

--- a/app/policies/products/token_policy.rb
+++ b/app/policies/products/token_policy.rb
@@ -13,8 +13,8 @@ module Products
       case bearer
       in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
         allow!
-      in role: Role(:product) if product == bearer
-        record.all? { _1 in bearer_type: ^(Product.name), bearer_id: ^(bearer.id) }
+      in role: Role(:product), id: bearer_id if product == bearer
+        record.all? { _1 in bearer_type: 'Product', bearer_id: ^bearer_id }
       else
         deny!
       end

--- a/features/api/v1/tokens/regenerate.feature
+++ b/features/api/v1/tokens/regenerate.feature
@@ -245,3 +245,56 @@ Feature: Regenerate authentication token
     And I authenticate with my license key
     When I send a PUT request to "/accounts/test1/tokens"
     Then the response status should be "404"
+
+  Scenario: Product resets a token for an admin
+    Given the current account is "test1"
+    And the current account has 1 "product"
+    And the current account has 1 "admin"
+    And the current account has 1 "token" for the last "admin"
+    And I am a product of account "test1"
+    And I use an authentication token
+    When I send a PUT request to "/accounts/test1/tokens/$0"
+    Then the response status should be "404"
+
+  Scenario: Product resets a token for their user
+    Given the current account is "test1"
+    And the current account has 1 "user"
+    And the current account has 1 "license" for the last "user" as "owner"
+    And the current account has 1 "token" for the last "user"
+    And I am a product of account "test1"
+    And I use an authentication token
+    When I send a PUT request to "/accounts/test1/tokens/$0"
+    Then the response status should be "200"
+    And the response body should be a "token" with a token
+
+  Scenario: Product resets a token for a user
+    Given the current account is "test1"
+    And the current account has 1 "product"
+    And the current account has 1 "user"
+    And the current account has 1 "token" for the last "user"
+    And I am a product of account "test1"
+    And I use an authentication token
+    When I send a PUT request to "/accounts/test1/tokens/$0"
+    Then the response status should be "404"
+
+  Scenario: Product resets a token for their license
+    Given the current account is "test1"
+    And the current account has 1 "product"
+    And the current account has 1 "policy" for the last "product"
+    And the current account has 1 "license" for the last "policy"
+    And the current account has 1 "token" for the last "license"
+    And I am a product of account "test1"
+    And I use an authentication token
+    When I send a PUT request to "/accounts/test1/tokens/$0"
+    Then the response status should be "200"
+    And the response body should be a "token" with a token
+
+  Scenario: Product resets a token for a license
+    Given the current account is "test1"
+    And the current account has 1 "product"
+    And the current account has 1 "license"
+    And the current account has 1 "token" for the last "license"
+    And I am a product of account "test1"
+    And I use an authentication token
+    When I send a PUT request to "/accounts/test1/tokens/$0"
+    Then the response status should be "404"

--- a/features/api/v1/tokens/revoke.feature
+++ b/features/api/v1/tokens/revoke.feature
@@ -73,11 +73,53 @@ Feature: Revoke authentication token
     When I send a DELETE request to "/accounts/test1/tokens/$3"
     Then the response status should be "404"
 
-  Scenario: Product attempts to revoke a user's token
+  Scenario: Product revokes a token for an admin
     Given the current account is "test1"
-    And the current account has 5 "users"
-    And the current account has 1 "token" for each "user"
-    And I am a user of account "test1"
+    And the current account has 1 "product"
+    And the current account has 1 "admin"
+    And the current account has 1 "token" for the last "admin"
+    And I am a product of account "test1"
     And I use an authentication token
-    When I send a DELETE request to "/accounts/test1/tokens/$4"
+    When I send a DELETE request to "/accounts/test1/tokens/$0"
+    Then the response status should be "404"
+
+  Scenario: Product revokes a token for their user
+    Given the current account is "test1"
+    And the current account has 1 "user"
+    And the current account has 1 "license" for the last "user" as "owner"
+    And the current account has 1 "token" for the last "user"
+    And I am a product of account "test1"
+    And I use an authentication token
+    When I send a DELETE request to "/accounts/test1/tokens/$0"
+    Then the response status should be "204"
+
+  Scenario: Product revokes a token for a user
+    Given the current account is "test1"
+    And the current account has 1 "product"
+    And the current account has 1 "user"
+    And the current account has 1 "token" for the last "user"
+    And I am a product of account "test1"
+    And I use an authentication token
+    When I send a DELETE request to "/accounts/test1/tokens/$0"
+    Then the response status should be "404"
+
+  Scenario: Product revokes a token for their license
+    Given the current account is "test1"
+    And the current account has 1 "product"
+    And the current account has 1 "policy" for the last "product"
+    And the current account has 1 "license" for the last "policy"
+    And the current account has 1 "token" for the last "license"
+    And I am a product of account "test1"
+    And I use an authentication token
+    When I send a DELETE request to "/accounts/test1/tokens/$0"
+    Then the response status should be "204"
+
+  Scenario: Product revokes a token for a license
+    Given the current account is "test1"
+    And the current account has 1 "product"
+    And the current account has 1 "license"
+    And the current account has 1 "token" for the last "license"
+    And I am a product of account "test1"
+    And I use an authentication token
+    When I send a DELETE request to "/accounts/test1/tokens/$0"
     Then the response status should be "404"

--- a/features/api/v1/tokens/show.feature
+++ b/features/api/v1/tokens/show.feature
@@ -58,6 +58,71 @@ Feature: Show authentication token
     Then the response status should be "200"
     And the response body should be a "token"
 
+  Scenario: Product requests a token for their license
+    Given the current account is "test1"
+    And the current account has 1 "product"
+    And the current account has 1 "policy" for the last "product"
+    And the current account has 1 "license" for the last "policy"
+    And the current account has 1 "token" for the last "license"
+    And I am a product of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/tokens/$0"
+    Then the response status should be "200"
+    And the response body should be a "token"
+
+  Scenario: Product requests a token for a license
+    Given the current account is "test1"
+    And the current account has 1 "product"
+    And the current account has 1 "license"
+    And the current account has 1 "token" for the last "license"
+    And I am a product of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/tokens/$0"
+    Then the response status should be "404"
+
+  Scenario: Product requests a token for an environment
+    Given the current account is "test1"
+    And the current account has 1 "product"
+    And the current account has 1 "environment"
+    And the current account has 1 "token" for the last "environment"
+    And I am a product of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/tokens/$0"
+    Then the response status should be "404"
+
+  Scenario: Product requests a token for an admin
+    Given the current account is "test1"
+    And the current account has 1 "product"
+    And the current account has 1 "admin"
+    And the current account has 1 "token" for the last "admin"
+    And I am a product of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/tokens/$0"
+    Then the response status should be "404"
+
+  Scenario: Product requests a token for their user
+    Given the current account is "test1"
+    And the current account has 1 "product"
+    And the current account has 1 "user"
+    And the current account has 1 "policy" for the last "product"
+    And the current account has 1 "license" for the last "policy" and the last "user" as "owner"
+    And the current account has 1 "token" for the last "user"
+    And I am a product of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/tokens/$0"
+    Then the response status should be "200"
+    And the response body should be a "token"
+
+  Scenario: Product requests a token for a user
+    Given the current account is "test1"
+    And the current account has 1 "product"
+    And the current account has 1 "user"
+    And the current account has 1 "token" for the last "user"
+    And I am a product of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/tokens/$0"
+    Then the response status should be "404"
+
   Scenario: User requests a token while authenticated
     Given the current account is "test1"
     And the current account has 1 "user"

--- a/spec/factories/token.rb
+++ b/spec/factories/token.rb
@@ -10,6 +10,26 @@ FactoryBot.define do
     environment { NIL_ENVIRONMENT }
     bearer      { build(:user, account:, environment:) }
 
+    trait :environment do
+      bearer { build(:environment, account:) }
+    end
+
+    trait :product do
+      bearer { build(:product, account:, environment:) }
+    end
+
+    trait :license do
+      bearer { build(:license, account:, environment:) }
+    end
+
+    trait :admin do
+      bearer { build(:admin, account:, environment:) }
+    end
+
+    trait :user do
+      bearer { build(:user, account:, environment:) }
+    end
+
     trait :in_isolated_environment do
       environment { build(:environment, :isolated, account:) }
     end

--- a/spec/policies/token_policy_spec.rb
+++ b/spec/policies/token_policy_spec.rb
@@ -621,6 +621,70 @@ describe TokenPolicy, type: :policy do
       end
     end
 
+    with_scenarios %i[accessing_its_license accessing_its_token] do
+      with_token_authentication do
+        with_permissions %w[token.read] do
+          allows :show
+        end
+
+        with_permissions %w[token.generate] do
+          allows :generate
+        end
+
+        with_permissions %w[token.regenerate] do
+          allows :regenerate
+        end
+
+        with_permissions %w[token.revoke] do
+          allows :revoke
+        end
+
+        with_wildcard_permissions do
+          allows :show, :generate, :regenerate, :revoke
+        end
+
+        with_default_permissions do
+          allows :show, :generate, :regenerate, :revoke
+        end
+
+        without_permissions do
+          denies :show, :generate, :regenerate, :revoke
+        end
+      end
+    end
+
+    with_scenarios %i[accessing_its_user accessing_its_token] do
+      with_token_authentication do
+        with_permissions %w[token.read] do
+          allows :show
+        end
+
+        with_permissions %w[token.generate] do
+          allows :generate
+        end
+
+        with_permissions %w[token.regenerate] do
+          allows :regenerate
+        end
+
+        with_permissions %w[token.revoke] do
+          allows :revoke
+        end
+
+        with_wildcard_permissions do
+          allows :show, :generate, :regenerate, :revoke
+        end
+
+        with_default_permissions do
+          allows :show, :generate, :regenerate, :revoke
+        end
+
+        without_permissions do
+          denies :show, :generate, :regenerate, :revoke
+        end
+      end
+    end
+
     with_scenarios %i[accessing_tokens] do
       with_token_authentication do
         with_permissions %w[token.read] do
@@ -634,33 +698,67 @@ describe TokenPolicy, type: :policy do
     end
 
     with_scenarios %i[accessing_a_token] do
-      with_token_authentication do
-        with_permissions %w[token.read] do
-          denies :show
-        end
+      with_token_trait :license do
+        with_token_authentication do
+          with_permissions %w[token.read] do
+            denies :show
+          end
 
-        with_permissions %w[token.generate] do
-          denies :generate
-        end
+          with_permissions %w[token.generate] do
+            denies :generate
+          end
 
-        with_permissions %w[token.regenerate] do
-          denies :regenerate
-        end
+          with_permissions %w[token.regenerate] do
+            denies :regenerate
+          end
 
-        with_permissions %w[token.revoke] do
-          denies :revoke
-        end
+          with_permissions %w[token.revoke] do
+            denies :revoke
+          end
 
-        with_wildcard_permissions do
-          denies :show, :generate, :regenerate, :revoke
-        end
+          with_wildcard_permissions do
+            denies :show, :generate, :regenerate, :revoke
+          end
 
-        with_default_permissions do
-          denies :show, :generate, :regenerate, :revoke
-        end
+          with_default_permissions do
+            denies :show, :generate, :regenerate, :revoke
+          end
 
-        without_permissions do
-          denies :show, :generate, :regenerate, :revoke
+          without_permissions do
+            denies :show, :generate, :regenerate, :revoke
+          end
+        end
+      end
+
+      with_token_trait :user do
+        with_token_authentication do
+          with_permissions %w[token.read] do
+            denies :show
+          end
+
+          with_permissions %w[token.generate] do
+            denies :generate
+          end
+
+          with_permissions %w[token.regenerate] do
+            denies :regenerate
+          end
+
+          with_permissions %w[token.revoke] do
+            denies :revoke
+          end
+
+          with_wildcard_permissions do
+            denies :show, :generate, :regenerate, :revoke
+          end
+
+          with_default_permissions do
+            denies :show, :generate, :regenerate, :revoke
+          end
+
+          without_permissions do
+            denies :show, :generate, :regenerate, :revoke
+          end
         end
       end
     end

--- a/spec/support/helpers/authorization_helper.rb
+++ b/spec/support/helpers/authorization_helper.rb
@@ -16,7 +16,7 @@ module AuthorizationHelper
       in []
         let(:account)     { create(:account, *account_traits) }
         let(:environment) { nil }
-        let(:bearer)      { create(:admin, *bearer_traits, account:, permissions: bearer_permissions) }
+        let(:bearer)      { create(:admin, *authn_traits, account:, permissions: bearer_permissions) }
       end
     end
 
@@ -25,7 +25,7 @@ module AuthorizationHelper
       in []
         let(:account)     { create(:account, *account_traits) }
         let(:environment) { nil }
-        let(:bearer)      { create(:environment, *bearer_traits, account:, permissions: bearer_permissions) }
+        let(:bearer)      { create(:environment, *authn_traits, account:, permissions: bearer_permissions) }
       end
     end
 
@@ -34,7 +34,7 @@ module AuthorizationHelper
       in []
         let(:account)     { create(:account, *account_traits) }
         let(:environment) { nil }
-        let(:bearer)      { create(:product, *bearer_traits, account:, permissions: bearer_permissions) }
+        let(:bearer)      { create(:product, *authn_traits, account:, permissions: bearer_permissions) }
       end
     end
 
@@ -43,7 +43,7 @@ module AuthorizationHelper
       in []
         let(:account)     { create(:account, *account_traits) }
         let(:environment) { nil }
-        let(:bearer)      { create(:license, *license_traits, *bearer_traits, account:, permissions: bearer_permissions) }
+        let(:bearer)      { create(:license, *license_traits, *authn_traits, account:, permissions: bearer_permissions) }
       end
     end
 
@@ -52,7 +52,7 @@ module AuthorizationHelper
       in []
         let(:account)     { create(:account, *account_traits) }
         let(:environment) { nil }
-        let(:bearer)      { create(:user, *bearer_traits, account:, permissions: bearer_permissions) }
+        let(:bearer)      { create(:user, *authn_traits, account:, permissions: bearer_permissions) }
       end
     end
 
@@ -501,13 +501,13 @@ module AuthorizationHelper
     def accessing_tokens(scenarios)
       case scenarios
       in [*, :accessing_another_account, *]
-        let(:tokens) { create_list(:token, 3, account: other_account) }
+        let(:tokens) { create_list(:token, 3, *token_traits, account: other_account) }
       else
         let(:tokens) {
           [
-            create(:token, account:, bearer: create(:product, *product_traits, account:)),
-            create(:token, account:, bearer: create(:license, *license_traits, account:)),
-            create(:token, account:, bearer: create(:user, *user_traits, account:)),
+            create(:token, account:, bearer: create(:product, *product_traits, *token_traits, account:)),
+            create(:token, account:, bearer: create(:license, *license_traits, *token_traits, account:)),
+            create(:token, account:, bearer: create(:user, *user_traits, *token_traits, account:)),
           ]
         }
       end
@@ -518,9 +518,9 @@ module AuthorizationHelper
     def accessing_a_token(scenarios)
       case scenarios
       in [*, :accessing_another_account, *]
-        let(:_token) { create(:token, account: other_account) }
+        let(:_token) { create(:token, *token_traits, account: other_account) }
       else
-        let(:_token) { create(:token, account:) }
+        let(:_token) { create(:token, *token_traits, account:) }
       end
 
       let(:record) { _token }
@@ -529,17 +529,17 @@ module AuthorizationHelper
     def accessing_its_tokens(scenarios)
       case scenarios
       in [*, :accessing_its_product | :accessing_a_product, *]
-        let(:tokens)   { create_list(:token, 3, account: product.account, bearer: product) }
+        let(:tokens)   { create_list(:token, 3, *token_traits, account: product.account, bearer: product) }
       in [*, :accessing_its_license | :accessing_a_license, *]
-        let(:tokens)   { create_list(:token, 3, account: license.account, bearer: license) }
+        let(:tokens)   { create_list(:token, 3, *token_traits, account: license.account, bearer: license) }
       in [*, :accessing_its_user | :accessing_a_user, *]
-        let(:tokens)   { create_list(:token, 3, account: user.account, bearer: user) }
+        let(:tokens)   { create_list(:token, 3, *token_traits, account: user.account, bearer: user) }
       in [*, :accessing_its_owner, *]
-        let(:tokens)   { create_list(:token, 3, account: user.account, bearer: owner) }
+        let(:tokens)   { create_list(:token, 3, *token_traits, account: user.account, bearer: owner) }
       in [*, :accessing_itself, *]
-        let(:tokens)   { create_list(:token, 3, account: bearer.account, bearer:) }
+        let(:tokens)   { create_list(:token, 3, *token_traits, account: bearer.account, bearer:) }
       in [:as_admin | :as_environment | :as_product | :as_license | :as_user, *]
-        let(:tokens)   { create_list(:token, 3, account: bearer.account, bearer:) }
+        let(:tokens)   { create_list(:token, 3, *token_traits, account: bearer.account, bearer:) }
       end
 
       let(:record) { tokens }
@@ -548,17 +548,17 @@ module AuthorizationHelper
     def accessing_its_token(scenarios)
       case scenarios
       in [*, :accessing_its_product | :accessing_a_product, *]
-        let(:_token) { create(:token, account: product.account, bearer: product) }
+        let(:_token) { create(:token, *token_traits, account: product.account, bearer: product) }
       in [*, :accessing_its_license | :accessing_a_license, *]
-        let(:_token) { create(:token, account: license.account, bearer: license) }
+        let(:_token) { create(:token, *token_traits, account: license.account, bearer: license) }
       in [*, :accessing_its_user | :accessing_a_user, *]
-        let(:_token) { create(:token, account: user.account, bearer: user) }
+        let(:_token) { create(:token, *token_traits, account: user.account, bearer: user) }
       in [*, :accessing_its_owner, *]
-        let(:_token) { create(:token, account: user.account, bearer: owner) }
+        let(:_token) { create(:token, *token_traits, account: user.account, bearer: owner) }
       in [*, :accessing_itself, *]
-        let(:_token) { create(:token, account: bearer.account, bearer:) }
+        let(:_token) { create(:token, *token_traits, account: bearer.account, bearer:) }
       in [:as_admin | :as_environment | :as_product | :as_license | :as_user, *]
-        let(:_token) { create(:token, account: bearer.account, bearer:) }
+        let(:_token) { create(:token, *token_traits, account: bearer.account, bearer:) }
       end
 
       let(:record) { _token }
@@ -2125,7 +2125,8 @@ module AuthorizationHelper
         let(:bearer_permissions) { nil }
         let(:token_permissions)  { nil }
         let(:account_traits)     { [] }
-        let(:bearer_traits)      { [] }
+        let(:authn_traits)       { [] }
+        let(:authz_traits)       { [] }
         let(:token_traits)       { [] }
         let(:release_traits)     { [] }
         let(:artifact_traits)    { [] }
@@ -2151,7 +2152,8 @@ module AuthorizationHelper
         using_scenario :as_anonymous
 
         let(:account_traits)    { [] }
-        let(:bearer_traits)     { [] }
+        let(:authn_traits)      { [] }
+        let(:authz_traits)      { [] }
         let(:token_traits)      { [] }
         let(:release_traits)    { [] }
         let(:artifact_traits)   { [] }
@@ -2238,7 +2240,7 @@ module AuthorizationHelper
                           env
                         end
 
-          create(:token, *token_traits, account:, bearer:, environment:, permissions: token_permissions)
+          create(:token, *authz_traits, account:, bearer:, environment:, permissions: token_permissions)
         }
 
         instance_exec(&)
@@ -2354,18 +2356,57 @@ module AuthorizationHelper
     def with_account_trait(trait, &) = with_account_traits(*trait, &)
 
     ##
-    # with_bearer_traits defines traits on the bearer context.
-    def with_bearer_traits(traits, &)
-      context "with bearer #{traits} traits" do
-        let(:bearer_traits) { traits }
+    # with_authn_traits defines traits on the authn context.
+    def with_authn_traits(traits, &)
+      context "with authn #{traits} traits" do
+        let(:authn_traits) { traits }
 
         instance_exec(&)
       end
     end
 
     ##
-    # with_bearer_trait defines a trait on the bearer context.
-    def with_bearer_trait(trait, &) = with_bearer_traits(*trait, &)
+    # with_authn_trait defines a trait on the authn context.
+    def with_authn_trait(trait, &) = with_authn_traits(*trait, &)
+
+    ##
+    # FIXME(ezekg) aliases for backwards compatibility to reduce code churn
+    alias :with_bearer_traits :with_authn_traits
+    alias :with_bearer_trait :with_authn_trait
+
+    ##
+    # with_authz_traits defines traits on the authz context.
+    def with_authz_traits(traits, &)
+      context "with authz #{traits} traits" do
+        let(:authz_traits) { traits }
+
+        instance_exec(&)
+      end
+    end
+
+    ##
+    # with_authz_trait defines a trait on the authz context.
+    def with_authz_trait(trait, &) = with_token_traits(*trait, &)
+
+    ##
+    # with_auth_traits defines traits on the authn and authz contexts.
+    def with_auth_traits(traits, &)
+      context "with auth #{traits} traits" do
+        let(:authn_traits) { traits }
+        let(:authz_traits) { traits }
+
+        instance_exec(&)
+      end
+    end
+
+    ##
+    # with_auth_trait defines a trait on the authn and authz contexts.
+    def with_auth_trait(trait, &) = with_bearer_and_token_traits(*trait, &)
+
+    ##
+    # FIXME(ezekg) aliases for backwards compatibility to reduce code churn
+    alias :with_bearer_and_token_traits :with_auth_traits
+    alias :with_bearer_and_token_trait :with_auth_trait
 
     ##
     # with_token_traits defines traits on the token context.
@@ -2380,21 +2421,6 @@ module AuthorizationHelper
     ##
     # with_token_trait defines a trait on the token context.
     def with_token_trait(trait, &) = with_token_traits(*trait, &)
-
-    ##
-    # with_bearer_and_token_traits defines traits on the bearer and token contexts.
-    def with_bearer_and_token_traits(traits, &)
-      context "with token and bearer #{traits} traits" do
-        let(:bearer_traits) { traits }
-        let(:token_traits)  { traits }
-
-        instance_exec(&)
-      end
-    end
-
-    ##
-    # with_bearer_and_token_trait defines a trait on the bearer and token contexts.
-    def with_bearer_and_token_trait(trait, &) = with_bearer_and_token_traits(*trait, &)
 
     ##
     # with_release_traits defines traits on the release context.


### PR DESCRIPTION
Over the years, as our authz model has evolved, a product's ability to manage tokens belonging to licenses and users has become a bit inconsistent, e.g. a product can generate a license token via the license's tokens relationship endpoint, but not via the main tokens endpoint, or a product could generate a token, but could not regenerate or revoke the token, which didn't make sense either. This has resulted in confusion more than a few times, so this PR makes authz more consistent.