### PR TITLE
Fix breaking change for overrides with zero value

### DIFF
--- a/app/models/license.rb
+++ b/app/models/license.rb
@@ -262,47 +262,47 @@ class License < ApplicationRecord
   validates :max_machines,
     numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 2_147_483_647 },
     allow_nil: true,
-    if: -> { max_machines_override.present? }
+    if: -> { max_machines_override? }
 
   validates :max_machines,
     numericality: { greater_than_or_equal_to: 1, message: 'must be greater than or equal to 1 for floating policy' },
     allow_nil: true,
-    if: -> { max_machines_override.present? && floating? }
+    if: -> { max_machines_override? && floating? }
 
   validates :max_machines,
     numericality: { equal_to: 1, message: 'must be equal to 1 for non-floating policy' },
     allow_nil: true,
-    if: -> { max_machines_override.present? && node_locked? }
+    if: -> { max_machines_override? && node_locked? }
 
   validates :max_cores,
     numericality: { greater_than_or_equal_to: 1, less_than_or_equal_to: 2_147_483_647 },
     allow_nil: true,
-    if: -> { max_cores_override.present? }
+    if: -> { max_cores_override? }
 
   validates :max_memory,
     numericality: { greater_than_or_equal_to: 1, less_than_or_equal_to: 9_223_372_036_854_775_807 },
     allow_nil: true,
-    if: -> { max_memory_override.present? }
+    if: -> { max_memory_override? }
 
   validates :max_disk,
     numericality: { greater_than_or_equal_to: 1, less_than_or_equal_to: 9_223_372_036_854_775_807 },
     allow_nil: true,
-    if: -> { max_disk_override.present? }
+    if: -> { max_disk_override? }
 
   validates :max_uses,
     numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 2_147_483_647 },
     allow_nil: true,
-    if: -> { max_uses_override.present? }
+    if: -> { max_uses_override? }
 
   validates :max_processes,
     numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 2_147_483_647 },
     allow_nil: true,
-    if: -> { max_processes_override.present? }
+    if: -> { max_processes_override? }
 
   validates :max_users,
     numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 2_147_483_647 },
     allow_nil: true,
-    if: -> { max_users_override.present? }
+    if: -> { max_users_override? }
 
   scope :search_id, -> (term) {
     identifier = term.to_s
@@ -780,43 +780,43 @@ class License < ApplicationRecord
     end
   end
 
-  def max_machines  = max_machines_override.presence || policy_max_machines
+  def max_machines  = max_machines_override? ? max_machines_override : policy_max_machines
   def max_machines? = max_machines.present?
   def max_machines=(value)
     self.max_machines_override = value
   end
 
-  def max_cores  = max_cores_override.presence || policy_max_cores
+  def max_cores  = max_cores_override? ? max_cores_override : policy_max_cores
   def max_cores? = max_cores.present?
   def max_cores=(value)
     self.max_cores_override = value
   end
 
-  def max_memory  = max_memory_override.presence || policy_max_memory
+  def max_memory  = max_memory_override? ? max_memory_override : policy_max_memory
   def max_memory? = max_memory.present?
   def max_memory=(value)
     self.max_memory_override = value
   end
 
-  def max_disk  = max_disk_override.presence || policy_max_disk
+  def max_disk  = max_disk_override? ? max_disk_override : policy_max_disk
   def max_disk? = max_disk.present?
   def max_disk=(value)
     self.max_disk_override = value
   end
 
-  def max_uses  = max_uses_override.presence || policy_max_uses
+  def max_uses  = max_uses_override? ? max_uses_override : policy_max_uses
   def max_uses? = max_uses.present?
   def max_uses=(value)
     self.max_uses_override = value
   end
 
-  def max_processes  = max_processes_override.presence || policy_max_processes
+  def max_processes  = max_processes_override? ? max_processes_override : policy_max_processes
   def max_processes? = max_processes.present?
   def max_processes=(value)
     self.max_processes_override = value
   end
 
-  def max_users  = max_users_override.presence || policy_max_users
+  def max_users  = max_users_override? ? max_users_override : policy_max_users
   def max_users? = max_users.present?
   def max_users=(value)
     self.max_users_override = value

--- a/app/models/machine.rb
+++ b/app/models/machine.rb
@@ -114,7 +114,7 @@ class Machine < ApplicationRecord
 
   validates :max_processes,
     numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 2_147_483_647 },
-    if: -> { max_processes_override.present? },
+    if: -> { max_processes_override? },
     allow_nil: true
 
   validates :ip,       length: { maximum: 255 }
@@ -677,7 +677,7 @@ class Machine < ApplicationRecord
     group
   end
 
-  def max_processes  = max_processes_override.presence || license_max_processes
+  def max_processes  = max_processes_override? ? max_processes_override : license_max_processes
   def max_processes? = max_processes.present?
   def max_processes=(value)
     self.max_processes_override = value

--- a/features/api/v1/licenses/create.feature
+++ b/features/api/v1/licenses/create.feature
@@ -6812,7 +6812,7 @@ Feature: Create license
         "data": {
           "type": "licenses",
           "attributes": {
-            "maxMemory": 0
+            "maxMemory": -1
           },
           "relationships": {
             "policy": {


### PR DESCRIPTION
Some languages, notably Go, treat zero as a "blank" integer value, and existing users have relied upon [previous behavior](https://github.com/keygen-sh/keygen-api/pull/988/commits/19bd175c007fbffce644fbf5674e532244603586) where zero was not significant. I'm reverting those changes made in #988 even though they're technically correct.

In practice, nobody is actually setting these to a significant zero (and in many cases, it's not even allowed to be significant zero according to the various model validations), so this revert in behavior is relatively safe.