### PR TITLE
Fix warning for ignored batch order

### DIFF
--- a/app/services/broadcast_webhook_service.rb
+++ b/app/services/broadcast_webhook_service.rb
@@ -23,7 +23,7 @@ class BroadcastWebhookService < BaseService
     )
 
     # skip resources that our endpoint's product aren't authorized to read (if any)
-    webhook_endpoints.find_each do |webhook_endpoint|
+    webhook_endpoints.unordered.find_each do |webhook_endpoint|
       next unless
         webhook_endpoint.subscribed?(event)
 

--- a/app/workers/create_webhook_events_worker.rb
+++ b/app/workers/create_webhook_events_worker.rb
@@ -18,7 +18,7 @@ class CreateWebhookEventsWorker < BaseWorker
       strict: true,
     )
 
-    webhook_endpoints.find_each do |webhook_endpoint|
+    webhook_endpoints.unordered.find_each do |webhook_endpoint|
       next unless
         webhook_endpoint.subscribed?(event)
 

--- a/app/workers/create_webhook_events_worker2.rb
+++ b/app/workers/create_webhook_events_worker2.rb
@@ -24,7 +24,7 @@ class CreateWebhookEventsWorker2 < BaseWorker
       strict: true,
     )
 
-    webhook_endpoints.find_each do |webhook_endpoint|
+    webhook_endpoints.unordered.find_each do |webhook_endpoint|
       next unless
         webhook_endpoint.subscribed?(event)
 

--- a/app/workers/cull_dead_machines_worker.rb
+++ b/app/workers/cull_dead_machines_worker.rb
@@ -10,7 +10,7 @@ class CullDeadMachinesWorker < BaseWorker
                       .where(heartbeat_jid: nil)
                       .dead
 
-    machines.find_each do |machine|
+    machines.unordered.find_each do |machine|
       jid = SecureRandom.hex(12) # precalc jid so we can set it on machine beforehand
       job = MachineHeartbeatWorker.set(jid:)
 

--- a/app/workers/cull_dead_processes_worker.rb
+++ b/app/workers/cull_dead_processes_worker.rb
@@ -10,7 +10,7 @@ class CullDeadProcessesWorker < BaseWorker
                               .where(heartbeat_jid: nil)
                               .dead
 
-    processes.find_each do |process|
+    processes.unordered.find_each do |process|
       jid = SecureRandom.hex(12) # precalc jid so we can set it on process beforehand
       job = ProcessHeartbeatWorker.set(jid:)
 

--- a/app/workers/license_expirations_worker.rb
+++ b/app/workers/license_expirations_worker.rb
@@ -11,7 +11,7 @@ class LicenseExpirationsWorker < BaseWorker
                       .reorder(nil)
                       .distinct
 
-    licenses.find_each do |license|
+    licenses.unordered.find_each do |license|
       next if license.account.nil? || license.policy.nil?
 
       case

--- a/app/workers/license_overdue_check_ins_worker.rb
+++ b/app/workers/license_overdue_check_ins_worker.rb
@@ -22,7 +22,7 @@ class LicenseOverdueCheckInsWorker < BaseWorker
                           :end_date
                       SQL
 
-    licenses.find_each do |license|
+    licenses.unordered.find_each do |license|
       next if license.expired? || license.account.nil? || license.policy.nil?
 
       case

--- a/app/workers/prune_event_logs_worker.rb
+++ b/app/workers/prune_event_logs_worker.rb
@@ -54,7 +54,7 @@ class PruneEventLogsWorker < BaseWorker
 
     Keygen.logger.info "[workers.prune-event-logs] Starting: accounts=#{accounts.count} start=#{start_time} cutoff=#{cutoff_date}"
 
-    accounts.find_each do |account|
+    accounts.unordered.find_each do |account|
       account_id = account.id
       event_logs = account.event_logs.where(created_date: ...cutoff_date)
       plan       = account.plan

--- a/app/workers/prune_metrics_worker.rb
+++ b/app/workers/prune_metrics_worker.rb
@@ -22,7 +22,7 @@ class PruneMetricsWorker < BaseWorker
 
     Keygen.logger.info "[workers.prune-metrics] Starting: accounts=#{accounts.count} start=#{start_time} cutoff=#{cutoff_date}"
 
-    accounts.find_each do |account|
+    accounts.unordered.find_each do |account|
       account_id = account.id
       metrics    = account.metrics.where(created_date: ...cutoff_date)
 

--- a/app/workers/prune_release_download_links_worker.rb
+++ b/app/workers/prune_release_download_links_worker.rb
@@ -15,7 +15,7 @@ class PruneReleaseDownloadLinksWorker < BaseWorker
 
     Keygen.logger.info "[workers.prune-release-download-links] Starting: accounts=#{accounts.count} time=#{cutoff_time}"
 
-    accounts.find_each do |account|
+    accounts.unordered.find_each do |account|
       account_id = account.id
       downloads  = account.release_download_links.where('created_at < ?', cutoff_time)
 

--- a/app/workers/prune_release_upgrade_links_worker.rb
+++ b/app/workers/prune_release_upgrade_links_worker.rb
@@ -15,7 +15,7 @@ class PruneReleaseUpgradeLinksWorker < BaseWorker
 
     Keygen.logger.info "[workers.prune-release-upgrade-links] Starting: accounts=#{accounts.count} time=#{cutoff_time}"
 
-    accounts.find_each do |account|
+    accounts.unordered.find_each do |account|
       account_id = account.id
       upgrades   = account.release_upgrade_links.where('created_at < ?', cutoff_time)
 

--- a/app/workers/prune_request_logs_worker.rb
+++ b/app/workers/prune_request_logs_worker.rb
@@ -22,7 +22,7 @@ class PruneRequestLogsWorker < BaseWorker
 
     Keygen.logger.info "[workers.prune-request-logs] Starting: accounts=#{accounts.count} start=#{start_time} cutoff=#{cutoff_date}"
 
-    accounts.find_each do |account|
+    accounts.unordered.find_each do |account|
       account_id   = account.id
       request_logs = account.request_logs.where(created_date: ...cutoff_date)
       plan         = account.plan

--- a/app/workers/prune_webhook_events_worker.rb
+++ b/app/workers/prune_webhook_events_worker.rb
@@ -22,7 +22,7 @@ class PruneWebhookEventsWorker < BaseWorker
 
     Keygen.logger.info "[workers.prune-webhook-events] Starting: accounts=#{accounts.count} start=#{start_time} cutoff=#{cutoff_time}"
 
-    accounts.find_each do |account|
+    accounts.unordered.find_each do |account|
       account_id = account.id
       events     = account.webhook_events.where(created_at: ...cutoff_time)
 

--- a/app/workers/request_limits_report_worker.rb
+++ b/app/workers/request_limits_report_worker.rb
@@ -11,7 +11,7 @@ class RequestLimitsReportWorker < BaseWorker
     start_date = date.beginning_of_day
     end_date = date.end_of_day
 
-    Account.includes(:billing, :plan).where(billings: { state: active_states }).find_each do |account|
+    Account.includes(:billing, :plan).where(billings: { state: active_states }).unordered.find_each do |account|
       request_count = account.request_logs.where(created_at: (start_date..end_date)).count
       if request_count == 0
         next unless account.trialing_or_free? &&

--- a/app/workers/slack_invite_worker.rb
+++ b/app/workers/slack_invite_worker.rb
@@ -19,7 +19,7 @@ class SlackInviteWorker < BaseWorker
     )
 
     # send a connect invite
-    account.admins.find_each do |admin|
+    account.admins.unordered.find_each do |admin|
       next if
         admin.free_or_disposable_email?
 

--- a/lib/keygen/exporter/v1/exporter.rb
+++ b/lib/keygen/exporter/v1/exporter.rb
@@ -97,7 +97,7 @@ module Keygen
             association = owner.association(reflection.name)
             scope       = association.scope
 
-            scope.in_batches(of: BATCH_SIZE) do |records|
+            scope.unordered.in_batches(of: BATCH_SIZE) do |records|
               attributes = records.map(&:attributes_for_export)
 
               export_records(reflection.klass.name, attributes, writer:)

--- a/lib/tasks/keygen/permissions.rake
+++ b/lib/tasks/keygen/permissions.rake
@@ -64,7 +64,7 @@ namespace :keygen do
 
         Keygen.logger.info { "Adding #{permissions.join(',')} permissions to #{admins.count} admins..." }
 
-        admins.in_batches(of: batch_size).each do |batch|
+        admins.unordered.in_batches(of: batch_size).each do |batch|
           task.invoke(User.name, *batch.ids, *permissions)
 
           # FIXME(ezekg) By default, tasks can only be invoked once. So we
@@ -90,7 +90,7 @@ namespace :keygen do
 
         Keygen.logger.info { "Adding #{permissions.join(',')} permissions to #{environments.count} environments..." }
 
-        environments.in_batches(of: batch_size).each do |batch|
+        environments.unordered.in_batches(of: batch_size).each do |batch|
           task.invoke(Environment.name, *batch.ids, *permissions)
           task.reenable
         end
@@ -111,7 +111,7 @@ namespace :keygen do
 
         Keygen.logger.info { "Adding #{permissions.join(',')} permissions to #{products.count} products..." }
 
-        products.in_batches(of: batch_size).each do |batch|
+        products.unordered.in_batches(of: batch_size).each do |batch|
           task.invoke(Product.name, *batch.ids, *permissions)
           task.reenable
         end
@@ -132,7 +132,7 @@ namespace :keygen do
 
         Keygen.logger.info { "Adding #{permissions.join(',')} permissions to #{licenses.count} licenses..." }
 
-        licenses.in_batches(of: batch_size).each do |batch|
+        licenses.unordered.in_batches(of: batch_size).each do |batch|
           task.invoke(License.name, *batch.ids, *permissions)
           task.reenable
         end
@@ -153,7 +153,7 @@ namespace :keygen do
 
         Keygen.logger.info { "Adding #{permissions.join(',')} permissions to #{users.count} users..." }
 
-        users.in_batches(of: batch_size).each do |batch|
+        users.unordered.in_batches(of: batch_size).each do |batch|
           task.invoke(User.name, *batch.ids, *permissions)
           task.reenable
         end


### PR DESCRIPTION
Our default scope emits [a warning](https://api.rubyonrails.org/v8.0.3/classes/ActiveRecord/Batches.html) for `find_each` and `in_batches`. This removes the default order before batching.