### PR TITLE
Fix order for event/log pruning jobs

### DIFF
--- a/app/workers/prune_event_logs_worker.rb
+++ b/app/workers/prune_event_logs_worker.rb
@@ -57,6 +57,7 @@ class PruneEventLogsWorker < BaseWorker
     accounts.unordered.find_each do |account|
       account_id = account.id
       event_logs = account.event_logs.where(created_date: ...cutoff_date)
+                                     .reorder(created_date: :asc)
       plan       = account.plan
 
       total = event_logs.count
@@ -75,7 +76,7 @@ class PruneEventLogsWorker < BaseWorker
         end
 
         count = event_logs.statement_timeout(STATEMENT_TIMEOUT) do
-          prune = account.event_logs.where(id: event_logs.limit(BATCH_SIZE).reorder(nil).ids)
+          prune = account.event_logs.where(id: event_logs.limit(BATCH_SIZE).ids)
 
           # for ent accounts, we keep the event backlog for the retention period except dup high-volume events.
           # for std accounts, we prune everything in the event backlog.

--- a/app/workers/prune_metrics_worker.rb
+++ b/app/workers/prune_metrics_worker.rb
@@ -25,6 +25,7 @@ class PruneMetricsWorker < BaseWorker
     accounts.unordered.find_each do |account|
       account_id = account.id
       metrics    = account.metrics.where(created_date: ...cutoff_date)
+                                  .reorder(created_date: :asc)
 
       total = metrics.count
       sum   = 0
@@ -42,7 +43,7 @@ class PruneMetricsWorker < BaseWorker
         end
 
         count = metrics.statement_timeout(STATEMENT_TIMEOUT) do
-          account.metrics.where(id: metrics.limit(BATCH_SIZE).reorder(nil).ids)
+          account.metrics.where(id: metrics.limit(BATCH_SIZE).ids)
                          .delete_all
         end
 

--- a/app/workers/prune_release_download_links_worker.rb
+++ b/app/workers/prune_release_download_links_worker.rb
@@ -18,6 +18,7 @@ class PruneReleaseDownloadLinksWorker < BaseWorker
     accounts.unordered.find_each do |account|
       account_id = account.id
       downloads  = account.release_download_links.where('created_at < ?', cutoff_time)
+                                                 .reorder(created_at: :asc)
 
       total = downloads.count
       sum   = 0

--- a/app/workers/prune_release_upgrade_links_worker.rb
+++ b/app/workers/prune_release_upgrade_links_worker.rb
@@ -18,6 +18,7 @@ class PruneReleaseUpgradeLinksWorker < BaseWorker
     accounts.unordered.find_each do |account|
       account_id = account.id
       upgrades   = account.release_upgrade_links.where('created_at < ?', cutoff_time)
+                                                .reorder(created_at: :asc)
 
       total = upgrades.count
       sum   = 0

--- a/app/workers/prune_request_logs_worker.rb
+++ b/app/workers/prune_request_logs_worker.rb
@@ -25,6 +25,7 @@ class PruneRequestLogsWorker < BaseWorker
     accounts.unordered.find_each do |account|
       account_id   = account.id
       request_logs = account.request_logs.where(created_date: ...cutoff_date)
+                                         .reorder(created_date: :asc)
       plan         = account.plan
 
       total = request_logs.count
@@ -43,7 +44,7 @@ class PruneRequestLogsWorker < BaseWorker
         end
 
         count = request_logs.statement_timeout(STATEMENT_TIMEOUT) do
-          prune = account.request_logs.where(id: request_logs.limit(BATCH_SIZE).reorder(nil).ids)
+          prune = account.request_logs.where(id: request_logs.limit(BATCH_SIZE).ids)
 
           # apply the account's log retention policy if there is one
           if plan.ent? && plan.request_log_retention_duration?


### PR DESCRIPTION
Prioritizes older rows for pruning to eventually clear the backlog.