### PR TITLE
Update verbiage for managed user password resets

### DIFF
--- a/app/models/concerns/password_resettable.rb
+++ b/app/models/concerns/password_resettable.rb
@@ -15,6 +15,9 @@ module PasswordResettable
   end
 
   def send_password_reset_email(token:)
+    return if
+      managed? # managed users aren't allowed to reset password
+
     UserMailer.password_reset(user: self, token: token).deliver_later
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -456,9 +456,11 @@ class User < ApplicationRecord
   def single_sign_on_enabled? = !role.user? && account.sso?
   alias :sso_enabled? :single_sign_on_enabled?
 
-  def password?
-    password_digest?
-  end
+  def password?     = password_digest?
+  def passwordless? = !password?
+
+  # NOTE(ezekg) a "managed user" is a passwordless user with the "user" role
+  def managed? = has_role?(:user) && passwordless? && account.protected?
 
   def active?(t = 90.days.ago)
     created_at >= t || any_active_licenses.any?

--- a/app/policies/users/password_policy.rb
+++ b/app/policies/users/password_policy.rb
@@ -17,9 +17,9 @@ module Users
       verify_permissions!('user.password.reset')
       verify_environment!
 
-      # User's without a password set cannot reset their password if account is protected
+      # users without a password set cannot reset their password
       deny! if
-        user.has_role?(:user) && account.protected? && !user.password?
+        user.managed?
 
       bearer.nil? || user == bearer
     end

--- a/app/views/user_mailer/password_reset.html.haml
+++ b/app/views/user_mailer/password_reset.html.haml
@@ -1,5 +1,5 @@
 -# frozen_string_literal: true
-- if @user.user? || @user.password?
+- if @user.managed? || @user.password?
   %p
     A password reset request was issued for a user profile signed up under this
     email address for <strong>#{@account.name}</strong>. To reset your password,

--- a/app/views/user_mailer/password_reset.html.haml
+++ b/app/views/user_mailer/password_reset.html.haml
@@ -1,5 +1,5 @@
 -# frozen_string_literal: true
-- if @user.password?
+- if @user.user? || @user.password?
   %p
     A password reset request was issued for a user profile signed up under this
     email address for <strong>#{@account.name}</strong>. To reset your password,


### PR DESCRIPTION
We only want to use "invite" verbiage for passwordless admins and teammates, not for managed users.