### PR TITLE
Fix request log retention on Std tiers

### DIFF
--- a/app/workers/prune_event_logs_worker.rb
+++ b/app/workers/prune_event_logs_worker.rb
@@ -136,14 +136,14 @@ class PruneEventLogsWorker < BaseWorker
       sum   += count
       batch += 1
 
-      Keygen.logger.info "[workers.prune-event-logs] Deduped #{count} rows: account_id=#{account.id} date=#{date} batch=#{batch}/#{batches} progress=#{sum}/#{total}"
+      Keygen.logger.info "[workers.prune-event-logs] Deduped #{count} rows: account_id=#{account.id} date=#{date} batch=#{batch}/#{batches} count=#{sum}/#{total}"
 
       sleep BATCH_WAIT
 
       break if count < BATCH_SIZE
     end
 
-    Keygen.logger.info "[workers.prune-event-logs] Deduping done: account_id=#{account.id} date=#{date} progress=#{sum}/#{total}"
+    Keygen.logger.info "[workers.prune-event-logs] Deduping done: account_id=#{account.id} date=#{date} count=#{sum}/#{total}"
   end
 
   def prune_event_logs_for_date(account, date:)

--- a/app/workers/prune_request_logs_worker.rb
+++ b/app/workers/prune_request_logs_worker.rb
@@ -92,7 +92,7 @@ class PruneRequestLogsWorker < BaseWorker
     plan = account.plan
 
     return false unless
-      plan.present? && plan.ent? && plan.request_log_retention_duration?
+      plan.present? && plan.request_log_retention_duration?
 
     cutoff_date = plan.request_log_retention_duration.seconds
                                                      .ago

--- a/spec/workers/prune_request_logs_worker_spec.rb
+++ b/spec/workers/prune_request_logs_worker_spec.rb
@@ -22,17 +22,36 @@ describe PruneRequestLogsWorker do
       )
     end
 
-    context 'with a request log retention policy' do
-      let(:account) { create(:account, plan: build(:plan, :ent, request_log_retention_duration: (worker::BACKLOG_DAYS + 30).days)) }
+    context 'without a request log retention policy' do
+      let(:account) { create(:account, plan: build(:plan, :ent, request_log_retention_duration: nil)) }
 
-      it 'should prune according to retention policy' do
+      it 'should prune backlog' do
+        create_list(:request_log, 50, account:, created_at: (worker::BACKLOG_DAYS + 91).days.ago)
+        create_list(:request_log, 50, account:, created_at: (worker::BACKLOG_DAYS + 90).days.ago)
         create_list(:request_log, 50, account:, created_at: (worker::BACKLOG_DAYS + 31).days.ago)
-        create_list(:request_log, 50, account:, created_at: (worker::BACKLOG_DAYS + 29).days.ago)
+        create_list(:request_log, 50, account:, created_at: (worker::BACKLOG_DAYS + 30).days.ago)
         create_list(:request_log, 50, account:, created_at: (worker::BACKLOG_DAYS + 1).days.ago)
         create_list(:request_log, 50, account:, created_at: (worker::BACKLOG_DAYS - 1).days.ago)
 
         expect { worker.perform_async }.to(
-          change { account.request_logs.count }.from(200).to(150),
+          change { account.request_logs.count }.from(300).to(50),
+        )
+      end
+    end
+
+    context 'with a request log retention policy' do
+      let(:account) { create(:account, plan: build(:plan, :ent, request_log_retention_duration: (worker::BACKLOG_DAYS + 90).days)) }
+
+      it 'should prune according to retention policy' do
+        create_list(:request_log, 50, account:, created_at: (worker::BACKLOG_DAYS + 91).days.ago)
+        create_list(:request_log, 50, account:, created_at: (worker::BACKLOG_DAYS + 90).days.ago)
+        create_list(:request_log, 50, account:, created_at: (worker::BACKLOG_DAYS + 31).days.ago)
+        create_list(:request_log, 50, account:, created_at: (worker::BACKLOG_DAYS + 30).days.ago)
+        create_list(:request_log, 50, account:, created_at: (worker::BACKLOG_DAYS + 1).days.ago)
+        create_list(:request_log, 50, account:, created_at: (worker::BACKLOG_DAYS - 1).days.ago)
+
+        expect { worker.perform_async }.to(
+          change { account.request_logs.count }.from(300).to(250),
         )
       end
     end
@@ -51,17 +70,36 @@ describe PruneRequestLogsWorker do
       )
     end
 
-    context 'with a request log retention policy' do
-      let(:account) { create(:account, plan: build(:plan, :std, request_log_retention_duration: (worker::BACKLOG_DAYS + 3).days)) }
+    context 'without a request log retention policy' do
+      let(:account) { create(:account, plan: build(:plan, :std, request_log_retention_duration: nil)) }
 
-      it 'should prune according to retention policy' do
-        create_list(:request_log, 50, account:, created_at: (worker::BACKLOG_DAYS + 4).days.ago)
-        create_list(:request_log, 50, account:, created_at: (worker::BACKLOG_DAYS + 3).days.ago)
+      it 'should prune backlog' do
+        create_list(:request_log, 50, account:, created_at: (worker::BACKLOG_DAYS + 91).days.ago)
+        create_list(:request_log, 50, account:, created_at: (worker::BACKLOG_DAYS + 90).days.ago)
+        create_list(:request_log, 50, account:, created_at: (worker::BACKLOG_DAYS + 31).days.ago)
+        create_list(:request_log, 50, account:, created_at: (worker::BACKLOG_DAYS + 29).days.ago)
         create_list(:request_log, 50, account:, created_at: (worker::BACKLOG_DAYS + 1).days.ago)
         create_list(:request_log, 50, account:, created_at: (worker::BACKLOG_DAYS - 1).days.ago)
 
         expect { worker.perform_async }.to(
-          change { account.request_logs.count }.from(200).to(50),
+          change { account.request_logs.count }.from(300).to(50),
+        )
+      end
+    end
+
+    context 'with a request log retention policy' do
+      let(:account) { create(:account, plan: build(:plan, :std, request_log_retention_duration: (worker::BACKLOG_DAYS + 30).days)) }
+
+      it 'should prune according to retention policy' do
+        create_list(:request_log, 50, account:, created_at: (worker::BACKLOG_DAYS + 91).days.ago)
+        create_list(:request_log, 50, account:, created_at: (worker::BACKLOG_DAYS + 90).days.ago)
+        create_list(:request_log, 50, account:, created_at: (worker::BACKLOG_DAYS + 31).days.ago)
+        create_list(:request_log, 50, account:, created_at: (worker::BACKLOG_DAYS + 29).days.ago)
+        create_list(:request_log, 50, account:, created_at: (worker::BACKLOG_DAYS + 1).days.ago)
+        create_list(:request_log, 50, account:, created_at: (worker::BACKLOG_DAYS - 1).days.ago)
+
+        expect { worker.perform_async }.to(
+          change { account.request_logs.count }.from(300).to(150),
         )
       end
     end


### PR DESCRIPTION
Request log retention was only being applied to Ent tiers, but should be applied to all.