### PR TITLE
Add support for IdP-initiated SSO login

### DIFF
--- a/db/migrate/20251114033324_add_sso_idp_initiated_authn_to_accounts.rb
+++ b/db/migrate/20251114033324_add_sso_idp_initiated_authn_to_accounts.rb
@@ -1,0 +1,7 @@
+class AddSsoIdpInitiatedAuthnToAccounts < ActiveRecord::Migration[8.1]
+  verbose!
+
+  def change
+    add_column :accounts, :sso_idp_initiated_authn, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2025_11_12_213258) do
+ActiveRecord::Schema[8.1].define(version: 2025_11_14_033324) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_catalog.plpgsql"
@@ -54,6 +54,7 @@ ActiveRecord::Schema[8.1].define(version: 2025_11_12_213258) do
     t.string "slack_team_id"
     t.string "slug"
     t.boolean "sso_external_authn", default: false, null: false
+    t.boolean "sso_idp_initiated_authn", default: false, null: false
     t.boolean "sso_jit_provisioning", default: false, null: false
     t.string "sso_organization_domains", default: [], array: true
     t.string "sso_organization_id"

--- a/features/step_definitions/resource_steps.rb
+++ b/features/step_definitions/resource_steps.rb
@@ -159,14 +159,27 @@ Given /^the current account has the following attributes:$/ do |body|
   @account.update!(attributes)
 end
 
-Given /^the current account has SSO configured for "([^\"]*)"$/ do |domain|
+Given /^the current account has SSO (?:configured|stubbed) for "([^\"]*)"$/ do |domain|
   allow(WorkOS::SSO).to receive(:authorization_url).and_wrap_original do |*, domain_hint:, login_hint:, **|
     "https://api.workos.test/sso/authorize?domain_hint=#{domain_hint}&login_hint=#{login_hint}"
   end
 
   @account.update!(
-    sso_organization_id: "test_org_#{SecureRandom.hex}",
-    sso_organization_domains: [domain],
+    sso_organization_id: @account.sso_organization_id.presence || "test_org_#{SecureRandom.hex}",
+    sso_organization_domains: @account.sso_organization_domains.presence || [domain],
+  )
+end
+
+Given /^the account "([^\"]*)" has SSO (?:configured|stubbed) for "([^\"]*)"$/ do |id, domain|
+  allow(WorkOS::SSO).to receive(:authorization_url).and_wrap_original do |*, domain_hint:, login_hint:, **|
+    "https://api.workos.test/sso/authorize?domain_hint=#{domain_hint}&login_hint=#{login_hint}"
+  end
+
+  account = FindByAliasService.call(Account, id:, aliases: :slug)
+
+  account.update!(
+    sso_organization_id: account.sso_organization_id.presence || "test_org_#{SecureRandom.hex}",
+    sso_organization_domains: account.sso_organization_domains.presence || [domain],
   )
 end
 

--- a/lib/keygen/ee/sso.rb
+++ b/lib/keygen/ee/sso.rb
@@ -9,7 +9,7 @@ module Keygen
 
       extend self
 
-      def redirect_url(account:, environment:, callback_url:, email: nil, expires_in: 5.minutes)
+      def redirect_url(account:, callback_url:, environment: nil, email: nil, expires_in: 5.minutes)
         WorkOS::SSO.authorization_url(
           client_id: WORKOS_CLIENT_ID,
           organization: account.sso_organization_id,
@@ -33,7 +33,7 @@ module Keygen
 
         res.profile
       rescue WorkOS::APIError => e
-        raise Keygen::Error::InvalidSingleSignOnError.new(e.message, code: "SSO_#{e.error.upcase}")
+        raise Keygen::Error::InvalidSingleSignOnError.new("bad code: #{e.message}", code: "SSO_#{e.error.upcase}")
       end
 
       def decrypt_state(ciphertext, secret_key:)
@@ -45,11 +45,11 @@ module Keygen
                           .join('--')
 
         dec = crypt.decrypt_and_verify(enc)
-        return nil if dec.blank?
+        raise ActiveSupport::MessageEncryptor::InvalidMessage, 'invalid message' if dec.blank?
 
         State.new(**dec.symbolize_keys)
-      rescue ActiveSupport::MessageEncryptor::InvalidMessage
-        nil
+      rescue ActiveSupport::MessageEncryptor::InvalidMessage => e
+        raise Keygen::Error::InvalidSingleSignOnError.new("bad state: #{e.message}", code: 'SSO_STATE_INVALID')
       end
 
       private


### PR DESCRIPTION
Previously, we only supported SP-initiated SSO logins, i.e. those originating from us, because IdP-initiated SSO logins, i.e. those originating from the IdP, do not contain the required state to complete authentication. This adds a flag to accounts to allow [IdP-intiated SSO logins](https://workos.com/docs/sso/login-flows/sp-initiated-sso) by essentially restarting the authn dance, but with valid state.