### PR TITLE
Remove default order from pruning cutoff date calculation

### DIFF
--- a/app/workers/prune_event_logs_worker.rb
+++ b/app/workers/prune_event_logs_worker.rb
@@ -46,7 +46,7 @@ class PruneEventLogsWorker < BaseWorker
 
     @hi_vol_event_type_ids = EventType.where(event: HIGH_VOLUME_EVENTS).ids
     @cutoff_end_date       = BACKLOG_DAYS.days.ago.to_date
-    @cutoff_start_date     = EventLog.where(created_date: ..cutoff_end_date).minimum(:created_date) || cutoff_end_date
+    @cutoff_start_date     = EventLog.unordered.where(created_date: ..cutoff_end_date).minimum(:created_date) || cutoff_end_date
     @start_time            = Time.parse(ts)
 
     Keygen.logger.info "[workers.prune-event-logs] Starting: start=#{start_time} cutoff_start=#{cutoff_start_date} cutoff_end=#{cutoff_end_date}"

--- a/app/workers/prune_metrics_worker.rb
+++ b/app/workers/prune_metrics_worker.rb
@@ -14,7 +14,7 @@ class PruneMetricsWorker < BaseWorker
       BACKLOG_DAYS <= 0 # never prune -- keep metrics backlog forever
 
     @cutoff_end_date   = BACKLOG_DAYS.days.ago.to_date
-    @cutoff_start_date = Metric.where(created_date: ..cutoff_end_date).minimum(:created_date) || cutoff_end_date
+    @cutoff_start_date = Metric.unordered.where(created_date: ..cutoff_end_date).minimum(:created_date) || cutoff_end_date
     @start_time        = Time.parse(ts)
 
     Keygen.logger.info "[workers.prune-metrics] Starting: start=#{start_time} cutoff_start=#{cutoff_start_date} cutoff_end=#{cutoff_end_date}"

--- a/app/workers/prune_request_logs_worker.rb
+++ b/app/workers/prune_request_logs_worker.rb
@@ -14,7 +14,7 @@ class PruneRequestLogsWorker < BaseWorker
       BACKLOG_DAYS <= 0 # never prune -- keep request backlog forever
 
     @cutoff_end_date   = BACKLOG_DAYS.days.ago.to_date
-    @cutoff_start_date = RequestLog.where(created_date: ..cutoff_end_date).minimum(:created_date) || cutoff_end_date
+    @cutoff_start_date = RequestLog.unordered.where(created_date: ..cutoff_end_date).minimum(:created_date) || cutoff_end_date
     @start_time        = Time.parse(ts)
 
     Keygen.logger.info "[workers.prune-request-logs] Starting: start=#{start_time} cutoff_start=#{cutoff_start_date} cutoff_end=#{cutoff_end_date}"


### PR DESCRIPTION
The default order was causing the query to not use the new index.