### PR TITLE
Fix PgBouncer statement timeouts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,7 +59,7 @@ gem 'ar_lazy_preload', '~> 2.0'
 gem 'strong_migrations'
 gem 'verbose_migrations'
 gem 'temporary_tables'
-gem 'statement_timeout'
+gem 'statement_timeout', '~> 1.1'
 gem 'union_of'
 gem 'order_as_specified'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -494,7 +494,7 @@ GEM
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
     stackprof (0.2.26)
-    statement_timeout (1.0.0)
+    statement_timeout (1.1.0)
       rails (>= 6.0)
     statsd-ruby (1.5.0)
     stringio (3.1.7)
@@ -617,7 +617,7 @@ DEPENDENCIES
   sidekiq-cronitor (~> 3.6.0)
   sprockets (~> 3.0)
   stackprof
-  statement_timeout
+  statement_timeout (~> 1.1)
   stripe (~> 5.43)
   stripe-ruby-mock!
   strong_migrations

--- a/app/workers/vacuum_analyze_event_logs_worker.rb
+++ b/app/workers/vacuum_analyze_event_logs_worker.rb
@@ -5,7 +5,7 @@ class VacuumAnalyzeEventLogsWorker < BaseWorker
                   cronitor_disabled: false
 
   def perform
-    EventLog.statement_timeout(STATEMENT_TIMEOUT) do |conn|
+    EventLog.statement_timeout(STATEMENT_TIMEOUT, mode: :session) do |conn|
       conn.execute 'VACUUM ANALYZE event_logs'
     end
   end

--- a/app/workers/vacuum_analyze_metrics_worker.rb
+++ b/app/workers/vacuum_analyze_metrics_worker.rb
@@ -5,7 +5,7 @@ class VacuumAnalyzeMetricsWorker < BaseWorker
                   cronitor_disabled: false
 
   def perform
-    Metric.statement_timeout(STATEMENT_TIMEOUT) do |conn|
+    Metric.statement_timeout(STATEMENT_TIMEOUT, mode: :session) do |conn|
       conn.execute 'VACUUM ANALYZE metrics'
     end
   end

--- a/app/workers/vacuum_analyze_request_logs_worker.rb
+++ b/app/workers/vacuum_analyze_request_logs_worker.rb
@@ -5,7 +5,7 @@ class VacuumAnalyzeRequestLogsWorker < BaseWorker
                   cronitor_disabled: false
 
   def perform
-    RequestLog.statement_timeout(STATEMENT_TIMEOUT) do |conn|
+    RequestLog.statement_timeout(STATEMENT_TIMEOUT, mode: :session) do |conn|
       conn.execute 'VACUUM ANALYZE request_logs'
     end
   end

--- a/app/workers/vacuum_analyze_webhook_events_worker.rb
+++ b/app/workers/vacuum_analyze_webhook_events_worker.rb
@@ -5,7 +5,7 @@ class VacuumAnalyzeWebhookEventsWorker < BaseWorker
                   cronitor_disabled: false
 
   def perform
-    WebhookEvent.statement_timeout(STATEMENT_TIMEOUT) do |conn|
+    WebhookEvent.statement_timeout(STATEMENT_TIMEOUT, mode: :session) do |conn|
       conn.execute 'VACUUM ANALYZE webhook_events'
     end
   end

--- a/config/initializers/statement_timeout.rb
+++ b/config/initializers/statement_timeout.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+StatementTimeout.configure do |config|
+  config.default_mode = :transaction # for pgbouncer
+end


### PR DESCRIPTION
Resolves an issue when using PgBouncer in transaction mode while using `SET SESSION` to set statement timeouts, essentially making them a noop (i.e. because the `SET` is not necessarily being executed on the right connection).

See: https://github.com/keygen-sh/statement_timeout/commit/51566da7cab9dc1ec8862238dfd373da31460738