### PR TITLE
Remove argument logging from async jobs

### DIFF
--- a/app/models/concerns/async_creatable.rb
+++ b/app/models/concerns/async_creatable.rb
@@ -13,6 +13,8 @@ module AsyncCreatable
   end
 
   class CreateAsyncJob < ActiveJob::Base
+    self.log_arguments = Rails.env.local?
+
     queue_as { ActiveRecord.queues[:default] }
 
     discard_on ActiveJob::DeserializationError

--- a/app/models/concerns/async_destroyable.rb
+++ b/app/models/concerns/async_destroyable.rb
@@ -11,6 +11,8 @@ module AsyncDestroyable
   end
 
   class DestroyAsyncJob < ActiveJob::Base
+    self.log_arguments = Rails.env.local?
+
     queue_as { ActiveRecord.queues[:default] }
 
     discard_on ActiveJob::DeserializationError

--- a/app/models/concerns/async_touchable.rb
+++ b/app/models/concerns/async_touchable.rb
@@ -27,6 +27,8 @@ module AsyncTouchable
   end
 
   class TouchAsyncJob < ActiveJob::Base
+    self.log_arguments = Rails.env.local?
+
     queue_as { ActiveRecord.queues[:default] }
 
     discard_on ActiveJob::DeserializationError

--- a/app/models/concerns/async_updatable.rb
+++ b/app/models/concerns/async_updatable.rb
@@ -27,6 +27,8 @@ module AsyncUpdatable
   end
 
   class UpdateAsyncJob < ActiveJob::Base
+    self.log_arguments = Rails.env.local?
+
     queue_as { ActiveRecord.queues[:default] }
 
     discard_on ActiveJob::DeserializationError


### PR DESCRIPTION
Way too verbose, and since filtering args isn't supported (https://github.com/rails/rails/pull/34438), better to opt out entirely.