### PR TITLE
Use --group-by=scenarios for parallel features

### DIFF
--- a/lib/tasks/test.rake
+++ b/lib/tasks/test.rake
@@ -56,7 +56,7 @@ begin
     desc 'run rspec test suite'
     task :rspec, %i[pattern] => %i[test:environment log:clear] do |_, args|
       pattern = args[:pattern]&.delete_prefix('./') # parallel_tests doesn't support this prefix
-      options = ENV['PARALLEL_TEST_OPTIONS']
+      options = ['--group-by=filesize', ENV['PARALLEL_TEST_OPTIONS']].compact.join(" ")
 
       if pattern&.match?(/((\[\d+(:\d+)*\])|(:\d+))$/) # parallel_tests doesn't support line numbers/example IDs
         RSpec::Core::RakeTask.new(:spec) unless Rake::Task.task_defined?('spec') # make sure task always exists
@@ -86,7 +86,7 @@ begin
     desc 'run cucumber test suite'
     task :cucumber, %i[pattern] => %i[test:environment log:clear] do |_, args|
       pattern = args[:pattern]&.delete_prefix('./') # parallel_tests doesn't support this prefix
-      options = ENV['PARALLEL_TEST_OPTIONS']
+      options = ['--group-by=scenarios', ENV['PARALLEL_TEST_OPTIONS']].compact.join(" ")
 
       if pattern&.match?(/:\d+$/) # parallel_tests doesn't support line numbers
         cucumber = Rake::Task['cucumber']


### PR DESCRIPTION
This should reduce the likelihood of a large feature, i.e. `validations.feature`, slowing down the entire test suite. In addition, this should theoretically allow us to increase CPUs to reduce CI time, e.g. 16 CPUs to 32 CPUs should cut time in half.