### PR TITLE
Fix dual writes polynomial job retries

### DIFF
--- a/lib/dual_writes.rb
+++ b/lib/dual_writes.rb
@@ -409,7 +409,7 @@ module DualWrites
     discard_on ActiveJob::DeserializationError
     rescue_from StandardError do |error| # FIXME(ezekg) rails doesn't support dynamic attempts proc
       if executions < DualWrites.configuration.retry_attempts
-        retry_job(wait: :polynomially_longer)
+        retry_job(wait: determine_delay(seconds_or_duration_or_algorithm: :polynomially_longer, executions:))
       else
         raise error
       end
@@ -452,7 +452,7 @@ module DualWrites
     discard_on ActiveJob::DeserializationError
     rescue_from StandardError do |error|
       if executions < DualWrites.configuration.retry_attempts
-        retry_job(wait: :polynomially_longer)
+        retry_job(wait: determine_delay(seconds_or_duration_or_algorithm: :polynomially_longer, executions:))
       else
         raise error
       end


### PR DESCRIPTION
Evidently, `retry_job` has different `wait:` behavior than `retry_on`.