### PR TITLE
Remove implicit timestamps from dual writes replication

### DIFF
--- a/lib/dual_writes.rb
+++ b/lib/dual_writes.rb
@@ -200,7 +200,7 @@ module DualWrites
     def insert_records(records, is_deleted:, ver:)
       records = records.map { with_metadata(it, is_deleted:, ver:) }
 
-      replica_class.insert_all!(records)
+      replica_class.insert_all!(records, record_timestamps: false)
     end
 
     def with_metadata(attributes, is_deleted:, ver:)


### PR DESCRIPTION
This is currently broken, since the Clickhouse adapter uses `CURRENT_TIMESTAMP` when it should use `now64()`. This is a band-aid until I can get a patch into our fork (https://github.com/keygen-sh/clickhouse-activerecord).