### PR TITLE
Add monkey patch for Clickhouse adapter current timestamp

### DIFF
--- a/config/initializers/clickhouse.rb
+++ b/config/initializers/clickhouse.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# FIXME(ezekg) clickhouse adapter tries to use CURRENT_TIMESTAMP which results in an UNKNOWN_IDENTIFIER error
+class ActiveRecord::ConnectionAdapters::ClickhouseAdapter
+  module DatabaseStatements
+    HIGH_PRECISION_CURRENT_TIMESTAMP = Arel.sql('now64(6)', retryable: true).freeze
+    private_constant :HIGH_PRECISION_CURRENT_TIMESTAMP
+
+    def high_precision_current_timestamp = HIGH_PRECISION_CURRENT_TIMESTAMP
+  end
+
+  include DatabaseStatements
+end

--- a/spec/models/request_log_spec.rb
+++ b/spec/models/request_log_spec.rb
@@ -229,8 +229,9 @@ describe RequestLog, type: :model do
                 'url' => '/v1/licenses',
                 'status' => '201',
                 'ip' => '127.0.0.1',
-                'created_at' => now,
-                'updated_at' => now,
+                # NB(ezekg) testing missing timestamps
+                # 'created_at' => now,
+                # 'updated_at' => now,
                 'created_date' => now.to_date,
               },
             ]


### PR DESCRIPTION
Right now, the Clickhouse adapter uses `CURRENT_TIMESTAMP` when it should use `now64()`. Will upstream later.