### PR TITLE
Fix Clickhouse endpoints when disabled

### DIFF
--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -6,5 +6,15 @@ module Api::V1
     include CurrentAccountScope
     include CurrentEnvironmentScope
     include Pagination
+
+    private
+
+    # mark controller action as requiring clickhouse to be enabled
+    def self.use_clickhouse(**)
+      before_action(**) do
+        render_not_supported unless
+          Keygen.database.clickhouse_available? && Keygen.database.clickhouse_enabled?
+      end
+    end
   end
 end

--- a/app/controllers/api/v1/event_logs_controller.rb
+++ b/app/controllers/api/v1/event_logs_controller.rb
@@ -2,6 +2,8 @@
 
 module Api::V1
   class EventLogsController < Api::V1::BaseController
+    use_clickhouse
+
     has_scope(:date, type: :hash, using: [:start, :end]) { |c, s, v| s.for_date_range(*v) }
     has_scope(:whodunnit, type: :any) { |c, s, v| s.search_whodunnit(v) }
     has_scope(:resource, type: :any) { |c, s, v| s.search_resource(v) }

--- a/app/controllers/api/v1/request_logs_controller.rb
+++ b/app/controllers/api/v1/request_logs_controller.rb
@@ -2,6 +2,8 @@
 
 module Api::V1
   class RequestLogsController < Api::V1::BaseController
+    use_clickhouse
+
     has_scope(:date, type: :hash, using: [:start, :end]) { |c, s, v| s.for_date_range(*v) }
     has_scope(:requestor, type: :any) { |c, s, v| s.search_requestor(v) }
     has_scope(:resource, type: :any) { |c, s, v| s.search_resource(v) }

--- a/app/controllers/api/v1/searches_controller.rb
+++ b/app/controllers/api/v1/searches_controller.rb
@@ -3,6 +3,7 @@
 module Api::V1
   class SearchesController < Api::V1::BaseController
     use_read_replica
+    use_clickhouse if: :clickhouse_query?
 
     class UnsupportedSearchTypeError < StandardError; end
     class EmptyQueryError < StandardError; end
@@ -10,15 +11,15 @@ module Api::V1
     SEARCH_MIN_QUERY_SIZE = 3.freeze
     SEARCH_OPS            = %i[AND OR].freeze
     SEARCH_MODELS         = [
-      Entitlement.name,
-      RequestLog.name,
-      Product.name,
-      Policy.name,
-      License.name,
-      Machine.name,
-      User.name,
-      Release.name,
-      Group.name,
+      'Entitlement',
+      'RequestLog',
+      'Product',
+      'Policy',
+      'License',
+      'Machine',
+      'User',
+      'Release',
+      'Group',
     ].freeze
 
     before_action :scope_to_current_account!
@@ -123,6 +124,12 @@ module Api::V1
       render_bad_request(detail: "search type '#{type.camelize(:lower)}' is not supported", source: { pointer: "/meta/type" })
     rescue EmptyQueryError
       render_bad_request(detail: "search query is required", source: { pointer: "/meta/query" })
+    end
+
+    def clickhouse_query?
+      type = params.dig(:meta, :type)
+
+      type in 'request-log'
     end
   end
 end

--- a/app/controllers/priv/analytics/base_controller.rb
+++ b/app/controllers/priv/analytics/base_controller.rb
@@ -4,15 +4,5 @@ module Priv::Analytics
   class BaseController < Api::V1::BaseController
     before_action :scope_to_current_account!
     before_action :authenticate_with_token!
-
-    private
-
-    # mark controller action as requiring clickhouse to be enabled
-    def self.use_clickhouse(**)
-      before_action(**) do
-        render_not_supported unless
-          Keygen.database.clickhouse_available? && Keygen.database.clickhouse_enabled?
-      end
-    end
   end
 end

--- a/features/api/v1/searches/search.feature
+++ b/features/api/v1/searches/search.feature
@@ -1637,6 +1637,7 @@ Feature: Search
     And sidekiq should have 0 "event-log" jobs
     And sidekiq should have 0 "request-log" jobs
 
+  @clickhouse
   Scenario: Admin performs a search by request log type on ID (full)
     Given I am an admin of account "test1"
     And the current account is "test1"
@@ -1672,6 +1673,7 @@ Feature: Search
     And sidekiq should have 0 "event-log" jobs
     And sidekiq should have 0 "request-log" jobs
 
+  @clickhouse
   Scenario: Admin performs a search by request log type on ID (partial)
     Given I am an admin of account "test1"
     And the current account is "test1"
@@ -1707,6 +1709,7 @@ Feature: Search
     And sidekiq should have 0 "event-log" jobs
     And sidekiq should have 0 "request-log" jobs
 
+  @clickhouse
   Scenario: Admin performs a search by request log type on the url attribute (full)
     Given I am an admin of account "test1"
     And the current account is "test1"
@@ -1737,6 +1740,7 @@ Feature: Search
     And sidekiq should have 0 "event-log" jobs
     And sidekiq should have 0 "request-log" jobs
 
+  @clickhouse
   Scenario: Admin performs a search by request log type on the url attribute (partial)
     Given I am an admin of account "test1"
     And the current account is "test1"
@@ -1767,6 +1771,7 @@ Feature: Search
     And sidekiq should have 0 "event-log" jobs
     And sidekiq should have 0 "request-log" jobs
 
+  @clickhouse
   Scenario: Admin performs a search by request log type on the IP attribute (full, IPv4)
     Given I am an admin of account "test1"
     And the current account is "test1"
@@ -1798,6 +1803,7 @@ Feature: Search
     And sidekiq should have 0 "event-log" jobs
     And sidekiq should have 0 "request-log" jobs
 
+  @clickhouse
   Scenario: Admin performs a search by request log type on the IP attribute (partial, IPv4)
     Given I am an admin of account "test1"
     And the current account is "test1"
@@ -1829,6 +1835,7 @@ Feature: Search
     And sidekiq should have 0 "event-log" jobs
     And sidekiq should have 0 "request-log" jobs
 
+  @clickhouse
   Scenario: Admin performs a search by request log type on the IP attribute (full, IPv6)
     Given I am an admin of account "test1"
     And the current account is "test1"
@@ -1860,6 +1867,7 @@ Feature: Search
     And sidekiq should have 0 "event-log" jobs
     And sidekiq should have 0 "request-log" jobs
 
+  @clickhouse
   Scenario: Admin performs a search by request log type on the IP attribute (partial, IPv6)
     Given I am an admin of account "test1"
     And the current account is "test1"
@@ -1891,6 +1899,7 @@ Feature: Search
     And sidekiq should have 0 "event-log" jobs
     And sidekiq should have 0 "request-log" jobs
 
+  @clickhouse
   Scenario: Admin performs a search by request log type on resource (full)
     Given I am an admin of account "test1"
     And the current account is "test1"
@@ -1921,6 +1930,7 @@ Feature: Search
     And sidekiq should have 0 "event-log" jobs
     And sidekiq should have 0 "request-log" jobs
 
+  @clickhouse
   Scenario: Admin performs a search by request log type on resource (partial)
     Given I am an admin of account "test1"
     And the current account is "test1"
@@ -1951,6 +1961,7 @@ Feature: Search
     And sidekiq should have 0 "event-log" jobs
     And sidekiq should have 0 "request-log" jobs
 
+  @clickhouse
   Scenario: Admin performs a search by request log type on resource ID (full)
     Given I am an admin of account "test1"
     And the current account is "test1"
@@ -1981,6 +1992,7 @@ Feature: Search
     And sidekiq should have 0 "event-log" jobs
     And sidekiq should have 0 "request-log" jobs
 
+  @clickhouse
   Scenario: Admin performs a search by request log type on resource ID (partial)
     Given I am an admin of account "test1"
     And the current account is "test1"
@@ -2011,6 +2023,7 @@ Feature: Search
     And sidekiq should have 0 "event-log" jobs
     And sidekiq should have 0 "request-log" jobs
 
+  @clickhouse
   Scenario: Admin performs a search by request log type on requestor (full)
     Given I am an admin of account "test1"
     And the current account is "test1"
@@ -2041,6 +2054,7 @@ Feature: Search
     And sidekiq should have 0 "event-log" jobs
     And sidekiq should have 0 "request-log" jobs
 
+  @clickhouse
   Scenario: Admin performs a search by request log type on requestor (partial)
     Given I am an admin of account "test1"
     And the current account is "test1"
@@ -2085,6 +2099,7 @@ Feature: Search
     And sidekiq should have 0 "event-log" jobs
     And sidekiq should have 0 "request-log" jobs
 
+  @clickhouse
   Scenario: Admin performs a search by request log type on requestor ID (full)
     Given I am an admin of account "test1"
     And the current account is "test1"
@@ -2115,6 +2130,7 @@ Feature: Search
     And sidekiq should have 0 "event-log" jobs
     And sidekiq should have 0 "request-log" jobs
 
+  @clickhouse
   Scenario: Admin performs a search by request log type on requestor ID (partial)
     Given I am an admin of account "test1"
     And the current account is "test1"
@@ -2145,6 +2161,7 @@ Feature: Search
     And sidekiq should have 0 "event-log" jobs
     And sidekiq should have 0 "request-log" jobs
 
+  @clickhouse
   Scenario: Admin performs a search by request log type on requestor ID and type
     Given I am an admin of account "test1"
     And the current account is "test1"
@@ -2190,6 +2207,7 @@ Feature: Search
     And sidekiq should have 0 "event-log" jobs
     And sidekiq should have 0 "request-log" jobs
 
+  @clickhouse
   Scenario: Admin performs a search by request log type on multiple attributes
     Given I am an admin of account "test1"
     And the current account is "test1"


### PR DESCRIPTION
Some endpoints were not marked as requiring Clickhouse even when they did, which resulted in server errors instead of a 405 status code when Clickhouse is not enabled (e.g. when self-hosting).