### PR TITLE
Disable support for unencrypted data

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -97,8 +97,8 @@ module Keygen
     config.active_record.encryption.hash_digest_class                             = OpenSSL::Digest::SHA256
     config.active_record.encryption.support_sha1_for_non_deterministic_encryption = true
 
-    config.active_record.encryption.support_unencrypted_data = true
-    config.active_record.encryption.extend_queries           = true
+    config.active_record.encryption.support_unencrypted_data = ENV.true?('ENCRYPTION_SUPPORT_UNENCRYPTED_DATA')
+    config.active_record.encryption.extend_queries           = ENV.true?('ENCRYPTION_SUPPORT_UNENCRYPTED_DATA')
 
     # FIXME(ezekg) Remove after we upgrade to Rails 7.1.4.
     # See: https://github.com/rails/rails/issues/50604

--- a/features/api/v1/licenses/create.feature
+++ b/features/api/v1/licenses/create.feature
@@ -1832,7 +1832,7 @@ Feature: Create license
     And sidekiq should have 0 "event-log" jobs
     And sidekiq should have 1 "request-log" job
 
-  Scenario: Admin creates a license for a user of their account with a key that contains a null byte
+  Scenario: Admin creates a license for a user of their account with a name that contains a null byte
     Given I am an admin of account "test1"
     And the current account is "test1"
     And the current account has 1 "webhook-endpoint"
@@ -1845,7 +1845,7 @@ Feature: Create license
         "data": {
           "type": "licenses",
           "attributes": {
-            "key": "$null_byte"
+            "name": "Foo$null_byte"
           },
           "relationships": {
             "policy": {


### PR DESCRIPTION
We already did the migration a long time ago, so this should've been disabled awhile ago. Bonus is that this will improve performance by avoiding `encrypted_column IN (encrypted_value, unencrypted_value)` queries.

Added an env flag for self-hosting in case others still need to migrate data.