### PR TITLE
Fix privilege escalation for misconfigured admins

### DIFF
--- a/app/models/concerns/roleable.rb
+++ b/app/models/concerns/roleable.rb
@@ -82,7 +82,7 @@ module Roleable
 
   class_methods do
     def has_default_role(name)
-      define_roleable_association_and_delgate
+      define_roleable_association_and_delegate
 
       # Set default role for new objects unless already set
       after_initialize -> { assign_role(name) },
@@ -90,7 +90,7 @@ module Roleable
     end
 
     def has_role(name)
-      define_roleable_association_and_delgate
+      define_roleable_association_and_delegate
 
       # Set role for new objects
       after_initialize -> { assign_role(name) },
@@ -99,7 +99,7 @@ module Roleable
 
     private
 
-    def define_roleable_association_and_delgate
+    def define_roleable_association_and_delegate
       include Permissible
       include Dirtyable
 

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -108,7 +108,7 @@ class Role < ApplicationRecord
   # permissions overrides association reader to include pending permission changes
   def permissions
     return pending_permissions if
-      role_permissions_attributes_assigned?
+      role_permissions_attributes_assigned? || new_record?
 
     super
   end
@@ -117,8 +117,12 @@ class Role < ApplicationRecord
   # pending_permissions permissions returns the role's pending permissions,
   # via the :role_permissions nested attributes.
   def pending_permissions
-    return Permission.none unless
-      role_permissions_attributes_assigned?
+    unless role_permissions_attributes_assigned?
+      return Permission.where(id: default_permission_ids) if
+        new_record?
+
+      return Permission.none
+    end
 
     Permission.where(
       id: role_permissions_attributes.collect { it[:permission_id] },

--- a/features/api/v1/users/create.feature
+++ b/features/api/v1/users/create.feature
@@ -1336,15 +1336,14 @@ Feature: Create user
       """
     Then the response status should be "403"
 
-  Scenario: Admin creates an admin for their account (default permissions)
+  Scenario: Admin creates an admin for their account (for default permissions, with default permissions)
     Given the current account is "test1"
-    And the current account has 3 "webhook-endpoints"
-    And all "webhook-endpoints" have the following attributes:
+    And the current account has 3 "webhook-endpoints" with the following attributes:
       """
       { "subscriptions": ["user.created"] }
       """
     And the current account has 2 "admins"
-    And I am an admin of account "test1"
+    And I am the last admin of account "test1"
     And I use an authentication token
     When I send a POST request to "/accounts/test1/users" with the following:
       """
@@ -1365,19 +1364,90 @@ Feature: Create user
     And sidekiq should have 1 "event-log" job
     And sidekiq should have 1 "request-log" job
 
-  Scenario: Admin creates an admin for their account (has permissions)
+  @ee
+  Scenario: Admin creates an admin for their account (for wildcard permissions, with default permissions)
     Given the current account is "test1"
-    And the current account has 3 "webhook-endpoints"
-    And all "webhook-endpoints" have the following attributes:
+    And the current account has 3 "webhook-endpoints" with the following attributes:
       """
       { "subscriptions": ["user.created"] }
       """
     And the current account has 2 "admins"
-    And the first "admin" has the following permissions:
+    And I am the last admin of account "test1"
+    And I use an authentication token
+    When I send a POST request to "/accounts/test1/users" with the following:
       """
-      ["admin.create", "user.create"]
+      {
+        "data": {
+          "type": "users",
+          "attributes": {
+            "email": "ironman@keygen.sh",
+            "password": "secret123",
+            "permissions": ["*"],
+            "role": "admin"
+          }
+        }
+      }
       """
-    And I am an admin of account "test1"
+    Then the response status should be "201"
+    And the response body should be a "user" with the role "admin"
+    And sidekiq should have 3 "webhook" jobs
+    And sidekiq should have 1 "event-log" job
+    And sidekiq should have 1 "request-log" job
+
+  @ee
+  Scenario: Admin creates an admin for their account (for limited permissions, with default permissions)
+    Given the current account is "test1"
+    And the current account has 3 "webhook-endpoints" with the following:
+      """
+      { "subscriptions": ["user.created"] }
+      """
+    And the current account has 2 "admins"
+    And I am the last admin of account "test1"
+    And I use an authentication token
+    When I send a POST request to "/accounts/test1/users" with the following:
+      """
+      {
+        "data": {
+          "type": "users",
+          "attributes": {
+            "email": "ironman@keygen.sh",
+            "password": "secret123",
+            "permissions": [
+              "admin.read",
+              "user.read",
+              "license.read",
+              "license.validate"
+            ],
+            "role": "admin"
+          }
+        }
+      }
+      """
+    Then the response status should be "201"
+    And the response body should be a "user" with the following attributes:
+      """
+      {
+        "permissions": ["admin.read", "license.read", "license.validate", "user.read"],
+        "role": "admin"
+      }
+      """
+    And sidekiq should have 3 "webhook" jobs
+    And sidekiq should have 1 "event-log" job
+    And sidekiq should have 1 "request-log" job
+
+  @ee
+  Scenario: Admin creates an admin for their account (for default permissions, with limited permissions)
+    Given the current account is "test1"
+    And the current account has 3 "webhook-endpoints" with the following attributes:
+      """
+      { "subscriptions": ["user.created"] }
+      """
+    And the current account has 2 "admins"
+    And the last "admin" has the following permissions:
+      """
+      ["admin.create", "admin.read", "user.create", "user.read"]
+      """
+    And I am the last admin of account "test1"
     And I use an authentication token
     When I send a POST request to "/accounts/test1/users" with the following:
       """
@@ -1392,16 +1462,54 @@ Feature: Create user
         }
       }
       """
+    Then the response status should be "403"
+    And sidekiq should have 0 "webhook" jobs
+    And sidekiq should have 0 "event-log" job
+    And sidekiq should have 1 "request-log" job
+
+  @ee
+  Scenario: Admin creates an admin for their account (for limited permissions, with limited permissions)
+    Given the current account is "test1"
+    And the current account has 3 "webhook-endpoints" with the following attributes:
+      """
+      { "subscriptions": ["user.created"] }
+      """
+    And the current account has 2 "admins"
+    And the last "admin" has the following permissions:
+      """
+      ["admin.create", "admin.read", "user.create", "user.read"]
+      """
+    And I am the last admin of account "test1"
+    And I use an authentication token
+    When I send a POST request to "/accounts/test1/users" with the following:
+      """
+      {
+        "data": {
+          "type": "users",
+          "attributes": {
+            "email": "ironman@keygen.sh",
+            "password": "secret123",
+            "permissions": ["user.create", "user.read"],
+            "role": "admin"
+          }
+        }
+      }
+      """
     Then the response status should be "201"
-    And the response body should be a "user" with the role "admin"
+    And the response body should be a "user" with the following attributes:
+      """
+      {
+        "permissions": ["user.create", "user.read"],
+        "role": "admin"
+      }
+      """
     And sidekiq should have 3 "webhook" jobs
     And sidekiq should have 1 "event-log" job
     And sidekiq should have 1 "request-log" job
 
   Scenario: Admin creates an admin for their account (no permissions)
     Given the current account is "test1"
-    And the current account has 3 "webhook-endpoints"
-    And all "webhook-endpoints" have the following attributes:
+    And the current account has 3 "webhook-endpoints" with the following attributes:
       """
       { "subscriptions": ["user.created"] }
       """


### PR DESCRIPTION
For admins with a limited permission set and the `admin.create` permission (i.e. likely misconfigured), said admin could create a new admin and obtain root access via the default permission set. Moving forward, the limited admin must provide explicit permissions, intersecting with their own permissions, instead of being able to use the default permission set.