### PR TITLE
Fix upload/yank authz for legacy release endpoints

### DIFF
--- a/app/policies/releases/v1x0/upload_policy.rb
+++ b/app/policies/releases/v1x0/upload_policy.rb
@@ -7,7 +7,7 @@ module Releases::V1x0
       verify_environment!
 
       case bearer
-      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
+      in role: Role(:admin | :developer | :environment)
         allow!
       in role: Role(:product) if record.product == bearer
         allow!

--- a/app/policies/releases/v1x0/yank_policy.rb
+++ b/app/policies/releases/v1x0/yank_policy.rb
@@ -7,7 +7,7 @@ module Releases::V1x0
       verify_environment!
 
       case bearer
-      in role: Role(:admin | :developer | :sales_agent | :support_agent | :read_only | :environment)
+      in role: Role(:admin | :developer | :environment)
         allow!
       in role: Role(:product) if record.product == bearer
         allow!

--- a/features/api/v1/releases/relationships/v1x0/artifact.feature
+++ b/features/api/v1/releases/relationships/v1x0/artifact.feature
@@ -1667,6 +1667,39 @@ Feature: Release artifact relationship
     When I send a PUT request to "/accounts/test1/releases/$0/artifact"
     Then the response status should be "404"
 
+  Scenario: Sales agent uploads an artifact for a release
+    Given the current account is "test1"
+    And the current account has 1 "sales-agent"
+    And I am a sales agent of account "test1"
+    And the current account has 3 draft "releases"
+    And the current account has 1 waiting "artifact" for the first "release"
+    And I use an authentication token
+    And I use API version "1.0"
+    When I send a PUT request to "/accounts/test1/releases/$0/artifact"
+    Then the response status should be "403"
+
+  Scenario: Support agent uploads an artifact for a release
+    Given the current account is "test1"
+    And the current account has 1 "support-agent"
+    And I am a support agent of account "test1"
+    And the current account has 3 draft "releases"
+    And the current account has 1 waiting "artifact" for the first "release"
+    And I use an authentication token
+    And I use API version "1.0"
+    When I send a PUT request to "/accounts/test1/releases/$0/artifact"
+    Then the response status should be "403"
+
+  Scenario: Read-only uploads an artifact for a release
+    Given the current account is "test1"
+    And the current account has 1 "read-only"
+    And I am a read only of account "test1"
+    And the current account has 3 draft "releases"
+    And the current account has 1 waiting "artifact" for the first "release"
+    And I use an authentication token
+    And I use API version "1.0"
+    When I send a PUT request to "/accounts/test1/releases/$0/artifact"
+    Then the response status should be "403"
+
   Scenario: Admin uploads an artifact with a binary request body (binary content type)
     Given I am an admin of account "test1"
     And the current account is "test1"
@@ -1886,6 +1919,42 @@ Feature: Release artifact relationship
     And I use API version "1.0"
     When I send a DELETE request to "/accounts/test1/releases/$0/artifact"
     Then the response status should be "404"
+    And the first "release" should not be yanked
+
+  Scenario: Sales agent yanks an artifact for a release
+    Given the current account is "test1"
+    And the current account has 1 "sales-agent"
+    And I am a sales agent of account "test1"
+    And the current account has 3 "releases"
+    And the current account has 1 "artifact" for the first "release"
+    And I use an authentication token
+    And I use API version "1.0"
+    When I send a DELETE request to "/accounts/test1/releases/$0/artifact"
+    Then the response status should be "403"
+    And the first "release" should not be yanked
+
+  Scenario: Support agent yanks an artifact for a release
+    Given the current account is "test1"
+    And the current account has 1 "support-agent"
+    And I am a support agent of account "test1"
+    And the current account has 3 "releases"
+    And the current account has 1 "artifact" for the first "release"
+    And I use an authentication token
+    And I use API version "1.0"
+    When I send a DELETE request to "/accounts/test1/releases/$0/artifact"
+    Then the response status should be "403"
+    And the first "release" should not be yanked
+
+  Scenario: Read-only yanks an artifact for a release
+    Given the current account is "test1"
+    And the current account has 1 "read-only"
+    And I am a read only of account "test1"
+    And the current account has 3 "releases"
+    And the current account has 1 "artifact" for the first "release"
+    And I use an authentication token
+    And I use API version "1.0"
+    When I send a DELETE request to "/accounts/test1/releases/$0/artifact"
+    Then the response status should be "403"
     And the first "release" should not be yanked
 
   # Expiration basis


### PR DESCRIPTION
The authz of the legacy v1.0 release policies did not match each special admin role's underlying permission set, so although these branches would have been unreachable due to the prior permission assertion, it was still incorrect. This adjusts the policies to reflect the correct role <> permission sets, like other release policies.