### PR TITLE
Add environment-scoped child sessions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@
 # Ignore LLM configs
 /.claude/*
 !/.claude/CLAUDE.md
+/.codex
 
 # Ignore Redis/DB dumps
 /*.dump

--- a/app/controllers/api/v1/tokens_controller.rb
+++ b/app/controllers/api/v1/tokens_controller.rb
@@ -77,7 +77,9 @@ module Api::V1
       session = if request.origin == Keygen::Portal::ORIGIN
                   # TODO(ezekg) make default session expiry configurable
                   token.sessions.build(
-                    expiry: token.expiry.presence || 1.week.from_now,
+                    environment: token.environment,
+                    parent: current_session,
+                    expiry: token.expiry.presence || current_session&.expiry || 1.week.from_now,
                     user_agent: request.user_agent,
                     ip: request.remote_ip,
                   )
@@ -146,8 +148,10 @@ module Api::V1
       )
 
       # expire current session if we're revoking its token
-      unless current_session.nil?
-        reset_session_id_cookie if current_session.token == token
+      if current_session.present? && current_session.token == token
+        unset_session_cookie(
+          session_id_cookie_for(current_session.environment),
+        )
       end
 
       token.destroy

--- a/app/controllers/api/v1/tokens_controller.rb
+++ b/app/controllers/api/v1/tokens_controller.rb
@@ -75,10 +75,10 @@ module Api::V1
 
       # NOTE(ezekg) we only support session/cookie authn from portal origin
       session = if request.origin == Keygen::Portal::ORIGIN && token.bearer == current_bearer
-                  # TODO(ezekg) make default session expiry configurable
                   token.sessions.build(
                     environment: token.environment,
                     parent: current_session,
+                    # TODO(ezekg) make default session expiry configurable
                     expiry: token.expiry.presence || current_session&.expiry || 1.week.from_now,
                     user_agent: request.user_agent,
                     ip: request.remote_ip,

--- a/app/controllers/api/v1/tokens_controller.rb
+++ b/app/controllers/api/v1/tokens_controller.rb
@@ -74,7 +74,7 @@ module Api::V1
         with: TokenPolicy
 
       # NOTE(ezekg) we only support session/cookie authn from portal origin
-      session = if request.origin == Keygen::Portal::ORIGIN
+      session = if request.origin == Keygen::Portal::ORIGIN && token.bearer == current_bearer
                   # TODO(ezekg) make default session expiry configurable
                   token.sessions.build(
                     environment: token.environment,
@@ -86,7 +86,7 @@ module Api::V1
                 end
 
       if token.save
-        set_session_id_cookie(session) if session in Session # lol nice
+        set_session_cookie(session) if session in Session # lol nice
 
         BroadcastEventService.call(
           event: 'token.generated',
@@ -109,7 +109,7 @@ module Api::V1
         to: :regenerate?
 
       if session = current_token.regenerate!(session: current_session)
-        set_session_id_cookie(session)
+        set_session_cookie(session)
       end
 
       BroadcastEventService.call(
@@ -126,7 +126,7 @@ module Api::V1
 
       # expire current session and generate a new one if we're revoking its token
       if session = token.regenerate!(session: current_session)
-        set_session_id_cookie(session)
+        set_session_cookie(session) if session.bearer == current_bearer
       end
 
       BroadcastEventService.call(
@@ -147,11 +147,9 @@ module Api::V1
         resource: token,
       )
 
-      # expire current session if we're revoking its token
+      # expire current session cookies if we're revoking its token
       if current_session.present? && current_session.token == token
-        unset_session_cookie(
-          session_id_cookie_for(current_session.environment),
-        )
+        unset_session_cookies(current_session)
       end
 
       token.destroy

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -103,7 +103,7 @@ class ApplicationController < ActionController::API
 
     # expire session cookie on certain terminal authz error codes
     if error in code: 'SESSION_NOT_ALLOWED' | 'USER_BANNED'
-      reset_session_id_cookie
+      unset_session_id_cookies
     end
 
     respond_to do |format|
@@ -141,7 +141,7 @@ class ApplicationController < ActionController::API
     response.headers['WWW-Authenticate'] = challenge
 
     # expire session cookie on invalid authn
-    reset_session_id_cookie
+    unset_session_id_cookies
 
     respond_to do |format|
       format.any {

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -101,9 +101,9 @@ class ApplicationController < ActionController::API
   def render_forbidden(*errors, **error)
     skip_verify_authorized!
 
-    # expire session cookie on certain terminal authz error codes
+    # expire session cookies on certain terminal authz error codes
     if error in code: 'SESSION_NOT_ALLOWED' | 'USER_BANNED'
-      unset_session_id_cookies
+      unset_session_cookies(current_session)
     end
 
     respond_to do |format|
@@ -140,8 +140,11 @@ class ApplicationController < ActionController::API
 
     response.headers['WWW-Authenticate'] = challenge
 
-    # expire session cookie on invalid authn
-    unset_session_id_cookies
+    # expire session cookies on invalid authn
+    unset_session_cookies(current_session)
+    unset_session_cookie(
+      session_cookie_name_for(current_environment),
+    )
 
     respond_to do |format|
       format.any {

--- a/app/controllers/auth/sso_controller.rb
+++ b/app/controllers/auth/sso_controller.rb
@@ -162,7 +162,7 @@ module Auth
         raise Keygen::Error::InvalidSingleSignOnError.new('session is not valid', code: 'SSO_SESSION_INVALID')
       end
 
-      set_session_id_cookie(session,
+      set_session_cookie(session,
         skip_verify_origin: true, # i.e. allow cookie to be set from outside Portal origin
       )
 

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -67,7 +67,7 @@ module Authentication
   end
 
   def authenticate_with_http_cookie(&auth_procedure)
-    session_id = cookies.encrypted[:session_id]
+    session_id = cookies.encrypted[session_id_cookie_for(current_environment)]
 
     auth_procedure.call(session_id)
   end
@@ -416,7 +416,7 @@ module Authentication
   #
   #             see: https://scotthelme.co.uk/csrf-is-dead/
   def has_cookie_credentials?
-    request.origin == Keygen::Portal::ORIGIN && cookies.key?(:session_id)
+    request.origin == Keygen::Portal::ORIGIN && cookies.key?(session_id_cookie_for(current_environment))
   end
 
   def has_bearer_credentials?

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -67,7 +67,7 @@ module Authentication
   end
 
   def authenticate_with_http_cookie(&auth_procedure)
-    session_id = cookies.encrypted[session_id_cookie_for(current_environment)]
+    session_id = cookies.encrypted[session_cookie_name_for(current_environment)]
 
     auth_procedure.call(session_id)
   end
@@ -148,7 +148,7 @@ module Authentication
         ip: request.remote_ip,
       )
 
-      set_session_id_cookie(session) if session.expiry_changed?
+      set_session_cookie(session) if session.expiry_changed?
     end
 
     # FIXME(ezekg) use Current everywhere instead of current ivars
@@ -416,7 +416,7 @@ module Authentication
   #
   #             see: https://scotthelme.co.uk/csrf-is-dead/
   def has_cookie_credentials?
-    request.origin == Keygen::Portal::ORIGIN && cookies.key?(session_id_cookie_for(current_environment))
+    request.origin == Keygen::Portal::ORIGIN && cookies.key?(session_cookie_name_for(current_environment))
   end
 
   def has_bearer_credentials?

--- a/app/controllers/concerns/cookies.rb
+++ b/app/controllers/concerns/cookies.rb
@@ -5,28 +5,11 @@ module Cookies
 
   include ActionController::Cookies
 
-  def set_session_id_cookie(session, **)
-    set_session_cookie(session_id_cookie_for(session.environment), session:, **)
-  end
-
-  def unset_session_id_cookies(**)
-    unset_session_cookie(session_id_cookie_for(nil), **)
-    unset_session_cookie(session_id_cookie_for(current_environment), **)
-  end
-
-  private
-
-  def session_id_cookie_for(environment)
-    if environment.present?
-      :"session_id.#{environment.id}"
-    else
-      :session_id
-    end
-  end
-
-  def set_session_cookie(name, session:, skip_verify_origin: false)
+  def set_session_cookie(session, skip_verify_origin: false)
     return unless
       skip_verify_origin || request.origin == Keygen::Portal::ORIGIN
+
+    name = session_cookie_name_for(session.environment)
 
     cookies.encrypted[name] = {
       value: session.id,
@@ -39,6 +22,20 @@ module Cookies
     }
   end
 
+  def unset_session_cookies(session, skip_verify_origin: false)
+    return unless
+      skip_verify_origin || request.origin == Keygen::Portal::ORIGIN
+
+    names = [
+      session_cookie_name_for(session&.environment),
+      *child_cookie_names_for(session),
+    ].uniq
+
+    names.map do |name|
+      unset_session_cookie(name, skip_verify_origin:)
+    end
+  end
+
   def unset_session_cookie(name, skip_verify_origin: false)
     return unless
       skip_verify_origin || request.origin == Keygen::Portal::ORIGIN
@@ -49,5 +46,21 @@ module Cookies
       partitioned: true,
       secure: true,
     )
+  end
+
+  private
+
+  def session_cookie_name_for(environment)
+    if environment.present?
+      :"session_id.#{environment.id}"
+    else
+      :session_id
+    end
+  end
+
+  def child_cookie_names_for(session)
+    return [] if session.nil?
+
+    session.children.map { session_cookie_name_for(it.environment) }
   end
 end

--- a/app/controllers/concerns/cookies.rb
+++ b/app/controllers/concerns/cookies.rb
@@ -5,11 +5,30 @@ module Cookies
 
   include ActionController::Cookies
 
-  def set_session_id_cookie(session, skip_verify_origin: false)
+  def set_session_id_cookie(session, **)
+    set_session_cookie(session_id_cookie_for(session.environment), session:, **)
+  end
+
+  def unset_session_id_cookies(**)
+    unset_session_cookie(session_id_cookie_for(nil), **)
+    unset_session_cookie(session_id_cookie_for(current_environment), **)
+  end
+
+  private
+
+  def session_id_cookie_for(environment)
+    if environment.present?
+      :"session_id.#{environment.id}"
+    else
+      :session_id
+    end
+  end
+
+  def set_session_cookie(name, session:, skip_verify_origin: false)
     return unless
       skip_verify_origin || request.origin == Keygen::Portal::ORIGIN
 
-    cookies.encrypted[:session_id] = {
+    cookies.encrypted[name] = {
       value: session.id,
       expires: session.expiry,
       domain: Keygen::DOMAIN,
@@ -20,14 +39,15 @@ module Cookies
     }
   end
 
-  def reset_session_id_cookie(skip_verify_origin: false)
+  def unset_session_cookie(name, skip_verify_origin: false)
     return unless
       skip_verify_origin || request.origin == Keygen::Portal::ORIGIN
 
-    cookies.delete(:session_id,
+    cookies.delete(name,
       domain: Keygen::DOMAIN,
       same_site: :none,
       partitioned: true,
+      secure: true,
     )
   end
 end

--- a/app/models/concerns/environmental.rb
+++ b/app/models/concerns/environmental.rb
@@ -61,7 +61,10 @@ module Environmental
     #
     # Use :default to automatically configure a default environment for the model.
     # Accepts a proc that resolves into an Environment or environment ID.
-    def has_environment(default: nil, **kwargs)
+    #
+    # Use :skip_verify_associations to skip asserting environment compatibility
+    # for particular associations that are allowed to be e.g. cross-env.
+    def has_environment(default: nil, skip_verify_associations: nil, **kwargs)
       belongs_to :environment, optional: true, **kwargs
 
       tracks_attributes :environment_id,
@@ -145,6 +148,9 @@ module Environmental
           # assert the :belongs_to has an :environment association to assert against.
           next unless
             (reflection.options in polymorphic: true) || reflection.klass < Environmental
+
+          next if
+            skip_verify_associations&.include?(reflection.name)
 
           # Perform asserts on create and update.
           validate on: %i[create update] do

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -3,7 +3,7 @@
 class Session < ApplicationRecord
   MAX_AGE = 2.weeks
 
-  include AsyncUpdatable
+  include AsyncUpdatable, AsyncDestroyable
   include Denormalizable
   include Environmental
   include Accountable
@@ -11,9 +11,27 @@ class Session < ApplicationRecord
   belongs_to :token, optional: true
   belongs_to :bearer,
     polymorphic: true
+  belongs_to :parent,
+    class_name: Session.name,
+    optional: true
 
-  has_environment default: -> { bearer&.environment_id }
+  has_environment skip_verify_associations: %i[parent], default: -> {
+    case bearer
+    in Environment(id: environment_id)
+      environment_id
+    in environment_id:
+      environment_id
+    else
+      nil
+    end
+  }
   has_account default: -> { bearer&.account_id }, inverse_of: :sessions
+
+  has_many :children,
+    class_name: Session.name,
+    foreign_key: :parent_id,
+    dependent: :destroy_async,
+    inverse_of: :parent
 
   denormalizes :bearer_type, :bearer_id,
     from: :token
@@ -41,6 +59,27 @@ class Session < ApplicationRecord
     end
   end
 
+  # assert that bearer matches the parent's bearer
+  validate on: %i[create update] do
+    next unless
+      parent_id_changed? || bearer_type_changed? || bearer_id_changed?
+
+    unless parent.nil? || bearer_type == parent.bearer_type && bearer_id == parent.bearer_id
+      errors.add :bearer, :not_allowed, message: 'bearer must match parent bearer'
+    end
+  end
+
+  # assert that a child session cannot outlive its parent
+  validate on: %i[create update] do
+    next unless
+      parent.present? && parent.expiry? # anything goes if parent doesn't expire
+
+    if expiry.nil? || parent.expiry < expiry
+      errors.add :expiry, :invalid, message: 'cannot outlive parent session'
+    end
+  end
+
   def expires_in?(dt) = expiry - dt < Time.current
   def expired?        = expiry < Time.current || created_at < MAX_AGE.ago
+  def expires?        = expiry?
 end

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -69,16 +69,6 @@ class Session < ApplicationRecord
     end
   end
 
-  # assert that a child session cannot outlive its parent
-  validate on: %i[create update] do
-    next unless
-      parent.present? && parent.expiry? # anything goes if parent doesn't expire
-
-    if expiry.nil? || parent.expiry < expiry
-      errors.add :expiry, :invalid, message: 'cannot outlive parent session'
-    end
-  end
-
   def expires_in?(dt) = expiry - dt < Time.current
   def expired?        = expiry < Time.current || created_at < MAX_AGE.ago
   def expires?        = expiry?

--- a/app/models/token.rb
+++ b/app/models/token.rb
@@ -282,7 +282,8 @@ class Token < ApplicationRecord
     self.expiry = Time.current + TOKEN_DURATION if expiry.present?
 
     transaction do
-      sessions.destroy_all # expire all of the token's sessions
+      # FIXME(ezekg) quirk: https://stackoverflow.com/a/78727914/3247081
+      sessions.delete_all(:delete_all) # expire all of the token's sessions
 
       # rebuild the session if its token matches the regenerated token
       new_session = if session.present? && session.token == self

--- a/app/models/token.rb
+++ b/app/models/token.rb
@@ -5,6 +5,7 @@ class Token < ApplicationRecord
 
   TOKEN_DURATION = 2.weeks
 
+  include AsyncDestroyable
   include Environmental
   include Accountable
   include Tokenable
@@ -19,7 +20,7 @@ class Token < ApplicationRecord
 
   # FIXME(ezekg) sessions must come before permissions otherwise autosave breaks
   has_many :sessions,
-    dependent: :delete_all,
+    dependent: :destroy_async,
     autosave: true
 
   has_many :token_permissions,
@@ -281,20 +282,22 @@ class Token < ApplicationRecord
     self.expiry = Time.current + TOKEN_DURATION if expiry.present?
 
     transaction do
-      sessions.delete_all # expire all of the token's sessions
+      sessions.destroy_all # expire all of the token's sessions
 
       # rebuild the session if its token matches the regenerated token
-      sesh = if session.present? && session.token == self
-               sessions.build(
-                 expiry: session.expiry, # don't implicitly extend session
-                 user_agent: session.user_agent,
-                 ip: session.ip,
-               )
-             end
+      new_session = if session.present? && session.token == self
+                      sessions.build(
+                        environment: session.environment,
+                        parent: session,
+                        expiry: session.expiry, # don't implicitly extend session
+                        user_agent: session.user_agent,
+                        ip: session.ip,
+                      )
+                    end
 
-      generate!(**)
+      generate!(**) # implicit save!
 
-      sesh
+      new_session
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -504,13 +504,14 @@ class User < ApplicationRecord
   end
 
   def revoke_tokens!(except: nil)
-    s = if except.present?
-          tokens.where.not(id: except)
-        else
-          tokens
-        end
+    scope = if except.present?
+              tokens.where.not(id: except)
+            else
+              tokens
+            end
 
-    s.destroy_all
+    scope.preload(:sessions)
+         .destroy_all
   end
 
   def revoke_tokens(...)

--- a/app/policies/environment_policy.rb
+++ b/app/policies/environment_policy.rb
@@ -69,15 +69,7 @@ class EnvironmentPolicy < ApplicationPolicy
 
   def me?
     verify_permissions!('environment.read')
-    verify_environment!(
-      strict: false,
-    )
 
-    case bearer
-    in role: Role(:environment) if record == bearer
-      allow!
-    else
-      deny!
-    end
+    record == bearer
   end
 end

--- a/app/policies/license_policy.rb
+++ b/app/policies/license_policy.rb
@@ -215,15 +215,7 @@ class LicensePolicy < ApplicationPolicy
 
   def me?
     verify_permissions!('license.read')
-    verify_environment!(
-      strict: false,
-    )
 
-    case bearer
-    in role: Role(:license) if record == bearer
-      allow!
-    else
-      deny!
-    end
+    record == bearer
   end
 end

--- a/app/policies/product_policy.rb
+++ b/app/policies/product_policy.rb
@@ -99,15 +99,7 @@ class ProductPolicy < ApplicationPolicy
 
   def me?
     verify_permissions!('product.read')
-    verify_environment!(
-      strict: false,
-    )
 
-    case bearer
-    in role: Role(:product) if record == bearer
-      allow!
-    else
-      deny!
-    end
+    record == bearer
   end
 end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -144,9 +144,6 @@ class UserPolicy < ApplicationPolicy
 
   def me?
     verify_permissions!('user.read')
-    verify_environment!(
-      strict: false,
-    )
 
     record == bearer
   end

--- a/db/migrate/20260501131644_add_parent_id_to_sessions.rb
+++ b/db/migrate/20260501131644_add_parent_id_to_sessions.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddParentIdToSessions < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+  verbose!
+
+  def change
+    add_column :sessions, :parent_id, :uuid
+    add_index :sessions, :parent_id, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2025_11_14_033324) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_01_131644) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_catalog.plpgsql"
@@ -853,6 +853,7 @@ ActiveRecord::Schema[8.1].define(version: 2025_11_14_033324) do
     t.datetime "expiry", null: false
     t.string "ip", null: false
     t.datetime "last_used_at"
+    t.uuid "parent_id"
     t.uuid "token_id"
     t.datetime "updated_at", null: false
     t.string "user_agent"
@@ -860,6 +861,7 @@ ActiveRecord::Schema[8.1].define(version: 2025_11_14_033324) do
     t.index ["bearer_id", "bearer_type"], name: "index_sessions_on_bearer_id_and_bearer_type"
     t.index ["created_at", "expiry", "last_used_at"], name: "index_sessions_on_created_at_and_expiry_and_last_used_at"
     t.index ["environment_id"], name: "index_sessions_on_environment_id"
+    t.index ["parent_id"], name: "index_sessions_on_parent_id"
     t.index ["token_id"], name: "index_sessions_on_token_id"
   end
 

--- a/features/api/v1/tokens/sessions.feature
+++ b/features/api/v1/tokens/sessions.feature
@@ -173,7 +173,7 @@ Feature: Token sessions
     And the response body should be a "token"
     And the response headers should contain "Set-Cookie" with an encrypted cookie:
       """
-      session_id=$sessions[0];
+      session_id.$environments[0]=$sessions[0];
       """
     And the response headers should contain the following:
       """
@@ -184,6 +184,50 @@ Feature: Token sessions
       {
         "bearerType": "Environment",
         "bearerId": "$environments[0]",
+        "tokenId": "$tokens[1]"
+      }
+      """
+
+  @ee
+  Scenario: Environment generates a new session token with environment-scoped session authentication
+    Given the current account is "test1"
+    And the current account has 1 isolated "environment"
+    And I am an environment of account "test1"
+    And I authenticate with a session for "isolated"
+    And I send the following headers:
+      """
+      { "Keygen-Environment": "isolated" }
+      """
+    When I send a POST request to "/accounts/test1/tokens"
+    Then the response status should be "201"
+    And the response body should be a "token"
+    And the response headers should contain "Set-Cookie" with an encrypted cookie:
+      """
+      session_id.$environments[0]=$sessions[1];
+      """
+    And the response headers should contain the following:
+      """
+      { "Keygen-Environment": "isolated" }
+      """
+    And the current account should have 2 "sessions"
+    And the first "session" should have the following attributes:
+      """
+      {
+        "bearerType": "Environment",
+        "bearerId": "$environments[0]",
+        "environmentId": "$environments[0]",
+        "parentId": null,
+        "tokenId": "$tokens[0]"
+      }
+      """
+    And the second "session" should have the following attributes:
+      """
+      {
+        "bearerType": "Environment",
+        "bearerId": "$environments[0]",
+        "environmentId": "$environments[0]",
+        "expiry": "$sessions[0].expiry",
+        "parentId": "$sessions[0]",
         "tokenId": "$tokens[1]"
       }
       """
@@ -203,7 +247,7 @@ Feature: Token sessions
     And the response body should be a "token"
     And the response headers should contain "Set-Cookie" with an encrypted cookie:
       """
-      session_id=$sessions[0];
+      session_id.$environments[0]=$sessions[0];
       """
     And the response headers should contain the following:
       """
@@ -218,6 +262,92 @@ Feature: Token sessions
       }
       """
 
+  @ee
+  Scenario: Admin creates an isolated environment child session with session authentication
+    Given the current account is "test1"
+    And the current account has 1 isolated "environment"
+    And I am an admin of account "test1"
+    And I authenticate with a session
+    When I send a POST request to "/accounts/test1/tokens" with the following:
+      """
+      {
+        "data": {
+          "type": "token",
+          "relationships": {
+            "environment": {
+              "data": { "type": "environment", "id": "$environments[0]" }
+            }
+          }
+        }
+      }
+      """
+    Then the response status should be "201"
+    And the response body should be a "token"
+    And the response headers should contain "Set-Cookie" with an encrypted cookie:
+      """
+      session_id.$environments[0]=$sessions[1];
+      """
+    And the current account should have 2 "sessions"
+    And the first "session" should have the following attributes:
+      """
+      {
+        "bearerType": "User",
+        "bearerId": "$users[0]",
+        "environmentId": null,
+        "parentId": null,
+        "tokenId": "$tokens[0]"
+      }
+      """
+    And the second "session" should have the following attributes:
+      """
+      {
+        "bearerType": "User",
+        "bearerId": "$users[0]",
+        "environmentId": "$environments[0]",
+        "expiry": "$sessions[0].expiry",
+        "parentId": "$sessions[0]",
+        "tokenId": "$tokens[1]"
+      }
+      """
+
+  @ee
+  Scenario: Admin can authenticate with an environment child session without sending its parent session
+    Given the current account is "test1"
+    And the current account has 1 isolated "environment"
+    And I am an admin of account "test1"
+    And I have a session for "isolated" with a child session
+    And I authenticate with the second session for "isolated"
+    And I send the following headers:
+      """
+      { "Keygen-Environment": "isolated" }
+      """
+    When I send a GET request to "/accounts/test1/me"
+    Then the response status should be "200"
+    And the response headers should contain the following:
+      """
+      { "Keygen-Environment": "isolated" }
+      """
+
+  @ee
+  Scenario: Environment revokes a parent session and its child sessions
+    Given the current account is "test1"
+    And the current account has 1 isolated "environment"
+    And I am an environment of account "test1"
+    And I have a session for "isolated" with a child session
+    And the current account should have 2 "sessions"
+    And the second "session" should have the following attributes:
+      """
+      { "parentId": "$sessions[0]" }
+      """
+    And I authenticate with the first session for "isolated"
+    And I send the following headers:
+      """
+      { "Keygen-Environment": "isolated" }
+      """
+    When I send a DELETE request to "/accounts/test1/tokens/$0"
+    Then the response status should be "204"
+    And the current account should have 0 "sessions"
+
   # revoke
   Scenario: Admin revokes their session token with session authentication
     Given the current account is "test1"
@@ -227,7 +357,7 @@ Feature: Token sessions
     Then the response status should be "204"
     And the response headers should contain "Set-Cookie" with a cookie:
       """
-      session_id=; domain=keygen.sh; expires=Thu, 01 Jan 1970 00:00:00 GMT; samesite=None; partitioned;
+      session_id=; domain=keygen.sh; expires=Thu, 01 Jan 1970 00:00:00 GMT; secure; samesite=None; partitioned;
       """
     And the current account should have 0 "sessions"
 
@@ -323,7 +453,7 @@ Feature: Token sessions
     Then the response status should be "401"
     And the response headers should contain "Set-Cookie" with a cookie:
       """
-      session_id=; domain=keygen.sh; expires=Thu, 01 Jan 1970 00:00:00 GMT; samesite=None; partitioned;
+      session_id=; domain=keygen.sh; expires=Thu, 01 Jan 1970 00:00:00 GMT; secure; samesite=None; partitioned;
       """
 
   Scenario: User creates a license with an invalid session
@@ -406,7 +536,7 @@ Feature: Token sessions
     Then the response status should be "401"
     And the response headers should contain "Set-Cookie" with a cookie:
       """
-      session_id=; domain=keygen.sh; expires=Thu, 01 Jan 1970 00:00:00 GMT; samesite=None; partitioned;
+      session_id=; domain=keygen.sh; expires=Thu, 01 Jan 1970 00:00:00 GMT; secure; samesite=None; partitioned;
       """
 
   Scenario: User reads their profile with a valid session (insecure same-site portal)
@@ -564,7 +694,7 @@ Feature: Token sessions
       """
     And the current account has 1 isolated "license" for the last "policy"
     And I am a license of account "test1"
-    And I authenticate with a session
+    And I authenticate with a session for "isolated"
     And I send the following headers:
       """
       { "Keygen-Environment": "isolated" }
@@ -587,7 +717,7 @@ Feature: Token sessions
       """
     And the current account has 1 shared "license" for the last "policy"
     And I am a license of account "test1"
-    And I authenticate with a session
+    And I authenticate with a session for "shared"
     And I send the following headers:
       """
       { "Keygen-Environment": "shared" }
@@ -619,7 +749,7 @@ Feature: Token sessions
     Then the response status should be "401"
     And the response headers should contain "Set-Cookie" with a cookie:
       """
-      session_id=; domain=keygen.sh; expires=Thu, 01 Jan 1970 00:00:00 GMT; samesite=None; partitioned;
+      session_id=; domain=keygen.sh; expires=Thu, 01 Jan 1970 00:00:00 GMT; secure; samesite=None; partitioned;
       """
     And the response headers should contain the following:
       """
@@ -636,7 +766,7 @@ Feature: Token sessions
       """
     And the current account has 1 global "license" for the last "policy"
     And I am a license of account "test1"
-    And I authenticate with a session
+    And I authenticate with a session for "shared"
     And I send the following headers:
       """
       { "Keygen-Environment": "shared" }
@@ -664,7 +794,7 @@ Feature: Token sessions
     Then the response status should be "401"
     And the response headers should contain "Set-Cookie" with a cookie:
       """
-      session_id=; domain=keygen.sh; expires=Thu, 01 Jan 1970 00:00:00 GMT; samesite=None; partitioned;
+      session_id=; domain=keygen.sh; expires=Thu, 01 Jan 1970 00:00:00 GMT; secure; samesite=None; partitioned;
       """
 
   @ee
@@ -687,7 +817,7 @@ Feature: Token sessions
     Then the response status should be "401"
     And the response headers should contain "Set-Cookie" with a cookie:
       """
-      session_id=; domain=keygen.sh; expires=Thu, 01 Jan 1970 00:00:00 GMT; samesite=None; partitioned;
+      session_id=; domain=keygen.sh; expires=Thu, 01 Jan 1970 00:00:00 GMT; secure; samesite=None; partitioned;
       """
     And the response headers should contain the following:
       """
@@ -709,7 +839,7 @@ Feature: Token sessions
     Then the response status should be "401"
     And the response headers should contain "Set-Cookie" with a cookie:
       """
-      session_id=; domain=keygen.sh; expires=Thu, 01 Jan 1970 00:00:00 GMT; samesite=None; partitioned;
+      session_id=; domain=keygen.sh; expires=Thu, 01 Jan 1970 00:00:00 GMT; secure; samesite=None; partitioned;
       """
 
   # create
@@ -837,7 +967,7 @@ Feature: Token sessions
     When I send a POST request to "/accounts/test1/licenses/$0/actions/validate"
     And the response headers should contain "Set-Cookie" with a cookie:
       """
-      session_id=; domain=keygen.sh; expires=Thu, 01 Jan 1970 00:00:00 GMT; samesite=None; partitioned;
+      session_id=; domain=keygen.sh; expires=Thu, 01 Jan 1970 00:00:00 GMT; secure; samesite=None; partitioned;
       """
     Then the response status should be "403"
 
@@ -868,7 +998,7 @@ Feature: Token sessions
     Then the response status should be "403"
     And the response headers should contain "Set-Cookie" with a cookie:
       """
-      session_id=; domain=keygen.sh; expires=Thu, 01 Jan 1970 00:00:00 GMT; samesite=None; partitioned;
+      session_id=; domain=keygen.sh; expires=Thu, 01 Jan 1970 00:00:00 GMT; secure; samesite=None; partitioned;
       """
     And the first error should have the following properties:
       """
@@ -892,7 +1022,7 @@ Feature: Token sessions
     Then the response status should be "403"
     And the response headers should contain "Set-Cookie" with a cookie:
       """
-      session_id=; domain=keygen.sh; expires=Thu, 01 Jan 1970 00:00:00 GMT; samesite=None; partitioned;
+      session_id=; domain=keygen.sh; expires=Thu, 01 Jan 1970 00:00:00 GMT; secure; samesite=None; partitioned;
       """
     And the first error should have the following properties:
       """
@@ -930,7 +1060,7 @@ Feature: Token sessions
     Then the response status should be "403"
     And the response headers should contain "Set-Cookie" with a cookie:
       """
-      session_id=; domain=keygen.sh; expires=Thu, 01 Jan 1970 00:00:00 GMT; samesite=None; partitioned;
+      session_id=; domain=keygen.sh; expires=Thu, 01 Jan 1970 00:00:00 GMT; secure; samesite=None; partitioned;
       """
     And the first error should have the following properties:
       """
@@ -950,7 +1080,7 @@ Feature: Token sessions
     When I send a POST request to "/accounts/test1/licenses/$0/actions/validate"
     And the response headers should contain "Set-Cookie" with a cookie:
       """
-      session_id=; domain=keygen.sh; expires=Thu, 01 Jan 1970 00:00:00 GMT; samesite=None; partitioned;
+      session_id=; domain=keygen.sh; expires=Thu, 01 Jan 1970 00:00:00 GMT; secure; samesite=None; partitioned;
       """
     Then the response status should be "403"
 

--- a/features/api/v1/tokens/sessions.feature
+++ b/features/api/v1/tokens/sessions.feature
@@ -145,18 +145,8 @@ Feature: Token sessions
       """
     Then the response status should be "201"
     And the response body should be a "token"
-    And the response headers should contain "Set-Cookie" with an encrypted cookie:
-      """
-      session_id=$sessions[0];
-      """
-    And the first "session" should have the following attributes:
-      """
-      {
-        "bearerType": "User",
-        "bearerId": "$users[1]",
-        "tokenId": "$tokens[1]"
-      }
-      """
+    And the response headers should not contain "Set-Cookie"
+    And the current account should have 0 "sessions"
 
   @ee
   Scenario: Environment generates a new session token (isolated)
@@ -310,44 +300,6 @@ Feature: Token sessions
       }
       """
 
-  @ee
-  Scenario: Admin can authenticate with an environment child session without sending its parent session
-    Given the current account is "test1"
-    And the current account has 1 isolated "environment"
-    And I am an admin of account "test1"
-    And I have a session for "isolated" with a child session
-    And I authenticate with the second session for "isolated"
-    And I send the following headers:
-      """
-      { "Keygen-Environment": "isolated" }
-      """
-    When I send a GET request to "/accounts/test1/me"
-    Then the response status should be "200"
-    And the response headers should contain the following:
-      """
-      { "Keygen-Environment": "isolated" }
-      """
-
-  @ee
-  Scenario: Environment revokes a parent session and its child sessions
-    Given the current account is "test1"
-    And the current account has 1 isolated "environment"
-    And I am an environment of account "test1"
-    And I have a session for "isolated" with a child session
-    And the current account should have 2 "sessions"
-    And the second "session" should have the following attributes:
-      """
-      { "parentId": "$sessions[0]" }
-      """
-    And I authenticate with the first session for "isolated"
-    And I send the following headers:
-      """
-      { "Keygen-Environment": "isolated" }
-      """
-    When I send a DELETE request to "/accounts/test1/tokens/$0"
-    Then the response status should be "204"
-    And the current account should have 0 "sessions"
-
   # revoke
   Scenario: Admin revokes their session token with session authentication
     Given the current account is "test1"
@@ -379,6 +331,48 @@ Feature: Token sessions
     When I send a DELETE request to "/accounts/test1/tokens/$2"
     Then the response status should be "204"
     And the response headers should not contain "Set-Cookie"
+    And the current account should have 1 "session"
+
+  @ee
+  Scenario: Admin revokes a parent session and its child sessions
+    Given the current account is "test1"
+    And the current account has 1 isolated "environment"
+    And I am an admin of account "test1"
+    And I have a session with a child session for "isolated"
+    And I authenticate with the first session
+    When I send a DELETE request to "/accounts/test1/tokens/$0"
+    Then the response status should be "204"
+    And the response headers should contain "Set-Cookie" with the cookie:
+      """
+      session_id=; domain=keygen.sh; expires=Thu, 01 Jan 1970 00:00:00 GMT; secure; samesite=None; partitioned;
+      """
+    And the response headers should contain "Set-Cookie" with the cookie:
+      """
+      session_id.$environments[0]=; domain=keygen.sh; expires=Thu, 01 Jan 1970 00:00:00 GMT; secure; samesite=None; partitioned;
+      """
+    And the current account should have 0 "sessions"
+
+  @ee
+  Scenario: Admin revokes an environment child session without unsetting its parent session cookie
+    Given the current account is "test1"
+    And the current account has 1 isolated "environment"
+    And I am an admin of account "test1"
+    And I have a session with a child session for "isolated"
+    And I authenticate with the first session for "isolated"
+    And I send the following headers:
+      """
+      { "Keygen-Environment": "isolated" }
+      """
+    When I send a DELETE request to "/accounts/test1/tokens/$1"
+    Then the response status should be "204"
+    And the response headers should not contain "Set-Cookie" with the cookie:
+      """
+      session_id=; domain=keygen.sh; expires=Thu, 01 Jan 1970 00:00:00 GMT; secure; samesite=None; partitioned;
+      """
+    And the response headers should contain "Set-Cookie" with the cookie:
+      """
+      session_id.$environments[0]=; domain=keygen.sh; expires=Thu, 01 Jan 1970 00:00:00 GMT; secure; samesite=None; partitioned;
+      """
     And the current account should have 1 "session"
 
   # regen
@@ -747,10 +741,6 @@ Feature: Token sessions
       """
     When I send a POST request to "/accounts/test1/licenses/$0/actions/validate"
     Then the response status should be "401"
-    And the response headers should contain "Set-Cookie" with a cookie:
-      """
-      session_id=; domain=keygen.sh; expires=Thu, 01 Jan 1970 00:00:00 GMT; secure; samesite=None; partitioned;
-      """
     And the response headers should contain the following:
       """
       { "Keygen-Environment": "isolated" }
@@ -792,10 +782,6 @@ Feature: Token sessions
     And I authenticate with a session
     When I send a POST request to "/accounts/test1/licenses/$0/actions/validate"
     Then the response status should be "401"
-    And the response headers should contain "Set-Cookie" with a cookie:
-      """
-      session_id=; domain=keygen.sh; expires=Thu, 01 Jan 1970 00:00:00 GMT; secure; samesite=None; partitioned;
-      """
 
   @ee
   Scenario: License validates itself with session authentication (isolated license in shared env)
@@ -815,10 +801,6 @@ Feature: Token sessions
       """
     When I send a POST request to "/accounts/test1/licenses/$0/actions/validate"
     Then the response status should be "401"
-    And the response headers should contain "Set-Cookie" with a cookie:
-      """
-      session_id=; domain=keygen.sh; expires=Thu, 01 Jan 1970 00:00:00 GMT; secure; samesite=None; partitioned;
-      """
     And the response headers should contain the following:
       """
       { "Keygen-Environment": "shared" }
@@ -837,10 +819,6 @@ Feature: Token sessions
     And I authenticate with a session
     When I send a POST request to "/accounts/test1/licenses/$0/actions/validate"
     Then the response status should be "401"
-    And the response headers should contain "Set-Cookie" with a cookie:
-      """
-      session_id=; domain=keygen.sh; expires=Thu, 01 Jan 1970 00:00:00 GMT; secure; samesite=None; partitioned;
-      """
 
   # create
   Scenario: User creates a trial license with session authentication
@@ -1083,6 +1061,24 @@ Feature: Token sessions
       session_id=; domain=keygen.sh; expires=Thu, 01 Jan 1970 00:00:00 GMT; secure; samesite=None; partitioned;
       """
     Then the response status should be "403"
+
+  @ee
+  Scenario: Admin uses a child session without a parent cookie
+    Given the current account is "test1"
+    And the current account has 1 isolated "environment"
+    And I am an admin of account "test1"
+    And I have a session for "isolated" with a child session
+    And I authenticate with the first session for "isolated"
+    And I send the following headers:
+      """
+      { "Keygen-Environment": "isolated" }
+      """
+    When I send a GET request to "/accounts/test1/me"
+    Then the response status should be "200"
+    And the response headers should contain the following:
+      """
+      { "Keygen-Environment": "isolated" }
+      """
 
   # update
   Scenario: Product updates their license with session authentication

--- a/features/auth/sso.feature
+++ b/features/auth/sso.feature
@@ -95,7 +95,7 @@ Feature: SSO
     And the response headers should contain "Location" with "https://portal.keygen.sh/ecorp-example?env=isolated"
     And the response headers should contain "Set-Cookie" with an encrypted cookie:
       """
-      session_id=$sessions[0]; domain=keygen.sh; path=/; expires=Mon, 28 Feb 2552 12:00:00 GMT; secure; httponly; samesite=None; partitioned;
+      session_id.$environments[0]=$sessions[0]; domain=keygen.sh; path=/; expires=Mon, 28 Feb 2552 12:00:00 GMT; secure; httponly; samesite=None; partitioned;
       """
     And the account "ecorp-example" should have 2 "admins"
     And the last "admin" of account "ecorp-example" should have the following attributes:
@@ -156,7 +156,7 @@ Feature: SSO
     And the response headers should contain "Location" with "https://portal.keygen.sh/ecorp-example?env=isolated"
     And the response headers should contain "Set-Cookie" with an encrypted cookie:
       """
-      session_id=$sessions[0]; domain=keygen.sh; path=/; expires=Mon, 28 Feb 2552 12:00:00 GMT; secure; httponly; samesite=None; partitioned;
+      session_id.$environments[0]=$sessions[0]; domain=keygen.sh; path=/; expires=Mon, 28 Feb 2552 12:00:00 GMT; secure; httponly; samesite=None; partitioned;
       """
     And the account "ecorp-example" should have 1 "admin"
     And the last "admin" of account "ecorp-example" should have the following attributes:
@@ -218,7 +218,7 @@ Feature: SSO
     And the response headers should contain "Location" with "https://portal.keygen.sh/ecorp-example?env=shared"
     And the response headers should contain "Set-Cookie" with an encrypted cookie:
       """
-      session_id=$sessions[0]; domain=keygen.sh; path=/; expires=Mon, 28 Feb 2552 12:00:00 GMT; secure; httponly; samesite=None; partitioned;
+      session_id.$environments[0]=$sessions[0]; domain=keygen.sh; path=/; expires=Mon, 28 Feb 2552 12:00:00 GMT; secure; httponly; samesite=None; partitioned;
       """
     And the account "ecorp-example" should have 2 "admins"
     And the last "admin" of account "ecorp-example" should have the following attributes:
@@ -279,7 +279,7 @@ Feature: SSO
     And the response headers should contain "Location" with "https://portal.keygen.sh/ecorp-example?env=shared"
     And the response headers should contain "Set-Cookie" with an encrypted cookie:
       """
-      session_id=$sessions[0]; domain=keygen.sh; path=/; expires=Mon, 28 Feb 2552 12:00:00 GMT; secure; httponly; samesite=None; partitioned;
+      session_id.$environments[0]=$sessions[0]; domain=keygen.sh; path=/; expires=Mon, 28 Feb 2552 12:00:00 GMT; secure; httponly; samesite=None; partitioned;
       """
     And the account "ecorp-example" should have 1 "admin"
     And the last "admin" of account "ecorp-example" should have the following attributes:
@@ -665,7 +665,7 @@ Feature: SSO
     And the response headers should contain "Location" with "https://portal.keygen.sh/lumon-example?env=isolated"
     And the response headers should contain "Set-Cookie" with an encrypted cookie:
       """
-      session_id=$sessions[0]; domain=keygen.sh; path=/; expires=Mon, 28 Feb 2552 08:00:00 GMT; secure; httponly; samesite=None; partitioned;
+      session_id.$environments[0]=$sessions[0]; domain=keygen.sh; path=/; expires=Mon, 28 Feb 2552 08:00:00 GMT; secure; httponly; samesite=None; partitioned;
       """
     And the account "lumon-example" should have 1 "admin"
     And the account "lumon-example" should have 1 "read-only" admin

--- a/features/step_definitions/authentication_steps.rb
+++ b/features/step_definitions/authentication_steps.rb
@@ -217,21 +217,35 @@ Given /^I authenticate with (?:a|my)(?: valid)? session$/ do
   authenticate_with_session(@session, environment: nil)
 end
 
-Given /^I authenticate with (?:(?:a|my)|the (first|second|third|fourth|fifth|last)) session for "([^\"]+)"$/ do |index_in_words, environment_code|
-  environment = @account.environments.find_by!(code: environment_code)
-  @session    = if index_in_words.present?
-                  @account.sessions.send(index_in_words)
-                else
-                  token = @bearer.tokens.first_or_create!(account: @bearer.account, bearer: @bearer)
+Given /^I authenticate with the (first|second|third|fourth|fifth|last) session$/ do |index_in_words|
+  @session = @account.sessions.send(index_in_words)
+  @token   = @session.token
+  @bearer  = @session.bearer
 
-                  token.sessions.create!(
-                    account: @bearer.account,
-                    environment:,
-                    expiry: 10.hours.from_now,
-                    user_agent: 'keygen/test',
-                    ip: '127.0.0.1',
-                  )
-                end
+  authenticate_with_session(@session, environment: nil)
+end
+
+Given /^I authenticate with a session for "([^\"]+)"$/ do |environment_code|
+  environment = @account.environments.find_by!(code: environment_code)
+
+  @token   = @bearer.tokens.first_or_create!(account: @bearer.account, bearer: @bearer)
+  @session = @token.sessions.create!(
+    account: @bearer.account,
+    environment:,
+    expiry: 10.hours.from_now,
+    user_agent: 'keygen/test',
+    ip: '127.0.0.1',
+  )
+
+  authenticate_with_session(@session, environment:)
+end
+
+Given /^I authenticate with the (first|second|third|fourth|fifth|last) session for "([^\"]+)"$/ do |index_in_words, environment_code|
+  environment = @account.environments.find_by!(code: environment_code)
+
+  @session = @account.sessions.for_environment(environment).send(index_in_words)
+  @token   = @session.token
+  @bearer  = @session.bearer
 
   authenticate_with_session(@session, environment:)
 end
@@ -245,6 +259,29 @@ Given /^I have a session for "([^\"]+)" with a child session$/ do |environment_c
   parent_session = parent_token.sessions.create!(
     account: @bearer.account,
     environment: parent_environment,
+    expiry: 10.hours.from_now,
+    user_agent: 'keygen/test',
+    ip: '127.0.0.1',
+  )
+
+  child_token.sessions.create!(
+    account: @bearer.account,
+    environment:,
+    parent: parent_session,
+    expiry: parent_session.expiry,
+    user_agent: 'keygen/test',
+    ip: '127.0.0.1',
+  )
+end
+
+Given /^I have a session with a child session for "([^\"]+)"$/ do |environment_code|
+  environment  = @account.environments.find_by!(code: environment_code)
+  parent_token = @bearer.tokens.create!(account: @bearer.account, bearer: @bearer, environment: nil)
+  child_token  = @bearer.tokens.create!(account: @bearer.account, bearer: @bearer, environment:)
+
+  parent_session = parent_token.sessions.create!(
+    account: @bearer.account,
+    environment: nil,
     expiry: 10.hours.from_now,
     user_agent: 'keygen/test',
     ip: '127.0.0.1',
@@ -283,9 +320,9 @@ Given /^I authenticate with an expired session$/ do
 end
 
 Given /^I authenticate with an invalid session$/ do
-  @token   = @bearer.tokens.first_or_create!(account: @bearer.account, bearer: @bearer)
+  @token = @bearer.tokens.first_or_create!(account: @bearer.account, bearer: @bearer)
 
-  set_session_cookie_header(:session_id, SecureRandom.uuid)
+  authenticate_with_session_id(SecureRandom.uuid)
 end
 
 Given /^the SSO callback code "([^\"]*)" returns the following profile:$/ do |code, body|

--- a/features/step_definitions/authentication_steps.rb
+++ b/features/step_definitions/authentication_steps.rb
@@ -214,23 +214,50 @@ Given /^I authenticate with (?:a|my)(?: valid)? session$/ do
     ip: '127.0.0.1',
   )
 
-  app       = Rails.application
-  config    = app.config
-  keygen    = app.key_generator
-  salt      = config.action_dispatch.authenticated_encrypted_cookie_salt
-  cipher    = config.action_dispatch.encrypted_cookie_cipher
-  key_len   = ActiveSupport::MessageEncryptor.key_len(cipher)
-  key       = keygen.generate_key(salt, key_len)
-  encryptor = ActiveSupport::MessageEncryptor.new(key,
-    serializer: ActiveSupport::MessageEncryptor::NullSerializer,
-    cipher:,
+  authenticate_with_session(@session, environment: nil)
+end
+
+Given /^I authenticate with (?:(?:a|my)|the (first|second|third|fourth|fifth|last)) session for "([^\"]+)"$/ do |index_in_words, environment_code|
+  environment = @account.environments.find_by!(code: environment_code)
+  @session    = if index_in_words.present?
+                  @account.sessions.send(index_in_words)
+                else
+                  token = @bearer.tokens.first_or_create!(account: @bearer.account, bearer: @bearer)
+
+                  token.sessions.create!(
+                    account: @bearer.account,
+                    environment:,
+                    expiry: 10.hours.from_now,
+                    user_agent: 'keygen/test',
+                    ip: '127.0.0.1',
+                  )
+                end
+
+  authenticate_with_session(@session, environment:)
+end
+
+Given /^I have a session for "([^\"]+)" with a child session$/ do |environment_code|
+  environment        = @account.environments.find_by!(code: environment_code)
+  parent_environment = @bearer.is_a?(Environment) ? environment : nil
+  parent_token       = @bearer.tokens.create!(account: @bearer.account, bearer: @bearer, environment: parent_environment)
+  child_token        = @bearer.tokens.create!(account: @bearer.account, bearer: @bearer, environment:)
+
+  parent_session = parent_token.sessions.create!(
+    account: @bearer.account,
+    environment: parent_environment,
+    expiry: 10.hours.from_now,
+    user_agent: 'keygen/test',
+    ip: '127.0.0.1',
   )
 
-  dec = JSON.dump(@session.id)
-  enc = encryptor.encrypt_and_sign(dec, purpose: 'cookie.session_id')
-  esc = CGI.escape(enc)
-
-  header "Cookie", %(session_id=#{esc})
+  child_token.sessions.create!(
+    account: @bearer.account,
+    environment:,
+    parent: parent_session,
+    expiry: parent_session.expiry,
+    user_agent: 'keygen/test',
+    ip: '127.0.0.1',
+  )
 end
 
 Given /^I authenticate with an expiring session$/ do
@@ -241,23 +268,7 @@ Given /^I authenticate with an expiring session$/ do
     ip: '127.0.0.1',
   )
 
-  app       = Rails.application
-  config    = app.config
-  keygen    = app.key_generator
-  salt      = config.action_dispatch.authenticated_encrypted_cookie_salt
-  cipher    = config.action_dispatch.encrypted_cookie_cipher
-  key_len   = ActiveSupport::MessageEncryptor.key_len(cipher)
-  key       = keygen.generate_key(salt, key_len)
-  encryptor = ActiveSupport::MessageEncryptor.new(key,
-    serializer: ActiveSupport::MessageEncryptor::NullSerializer,
-    cipher:,
-  )
-
-  dec = JSON.dump(@session.id)
-  enc = encryptor.encrypt_and_sign(dec, purpose: 'cookie.session_id')
-  esc = CGI.escape(enc)
-
-  header "Cookie", %(session_id=#{esc})
+  authenticate_with_session(@session)
 end
 
 Given /^I authenticate with an expired session$/ do
@@ -268,45 +279,13 @@ Given /^I authenticate with an expired session$/ do
     ip: '127.0.0.1',
   )
 
-  app       = Rails.application
-  config    = app.config
-  keygen    = app.key_generator
-  salt      = config.action_dispatch.authenticated_encrypted_cookie_salt
-  cipher    = config.action_dispatch.encrypted_cookie_cipher
-  key_len   = ActiveSupport::MessageEncryptor.key_len(cipher)
-  key       = keygen.generate_key(salt, key_len)
-  encryptor = ActiveSupport::MessageEncryptor.new(key,
-    serializer: ActiveSupport::MessageEncryptor::NullSerializer,
-    cipher:,
-  )
-
-  dec = JSON.dump(@session.id)
-  enc = encryptor.encrypt_and_sign(dec, purpose: 'cookie.session_id')
-  esc = CGI.escape(enc)
-
-  header "Cookie", %(session_id=#{esc})
+  authenticate_with_session(@session)
 end
 
 Given /^I authenticate with an invalid session$/ do
   @token   = @bearer.tokens.first_or_create!(account: @bearer.account, bearer: @bearer)
 
-  app       = Rails.application
-  config    = app.config
-  keygen    = app.key_generator
-  salt      = config.action_dispatch.authenticated_encrypted_cookie_salt
-  cipher    = config.action_dispatch.encrypted_cookie_cipher
-  key_len   = ActiveSupport::MessageEncryptor.key_len(cipher)
-  key       = keygen.generate_key(salt, key_len)
-  encryptor = ActiveSupport::MessageEncryptor.new(key,
-    serializer: ActiveSupport::MessageEncryptor::NullSerializer,
-    cipher:,
-  )
-
-  dec = JSON.dump(SecureRandom.uuid)
-  enc = encryptor.encrypt_and_sign(dec, purpose: 'cookie.session_id')
-  esc = CGI.escape(enc)
-
-  header "Cookie", %(session_id=#{esc})
+  set_session_cookie_header(:session_id, SecureRandom.uuid)
 end
 
 Given /^the SSO callback code "([^\"]*)" returns the following profile:$/ do |code, body|

--- a/features/step_definitions/request_steps.rb
+++ b/features/step_definitions/request_steps.rb
@@ -956,13 +956,25 @@ end
 Then /^the response headers should contain "([^\"]+)" with (?:a|the) cookie:$/ do |header_name, cookie_value|
   expect(last_response.headers).to have_key header_name
 
-  cookie_value = parse_placeholders(cookie_value, account: @account, bearer: @bearer, crypt: @crypt)
-  header_value = last_response.headers[header_name]
+  cookie_value  = parse_placeholders(cookie_value, account: @account, bearer: @bearer, crypt: @crypt)
+  header_value  = last_response.headers[header_name]
+  header_values = header_value.split("\n")
 
   expected = Rack::Utils.parse_cookies_header(cookie_value).transform_keys(&:downcase)
-  actual   = Rack::Utils.parse_cookies_header(header_value).transform_keys(&:downcase)
+  actual   = header_values.collect { Rack::Utils.parse_cookies_header(it).transform_keys(&:downcase) }
 
-  expect(actual).to include expected
+  expect(actual).to include hash_including(expected)
+end
+
+Then /^the response headers should not contain "([^\"]+)" with (?:an?|the)(?: encrypted|signed)? cookie:$/ do |header_name, cookie_value|
+  cookie_value  = parse_placeholders(cookie_value, account: @account, bearer: @bearer, crypt: @crypt)
+  header_value  = last_response.headers[header_name]
+  header_values = header_value.split("\n")
+
+  expected = Rack::Utils.parse_cookies_header(cookie_value).transform_keys(&:downcase)
+  actual   = header_values.collect { Rack::Utils.parse_cookies_header(it).transform_keys(&:downcase) }
+
+  expect(actual).to_not include hash_including(expected)
 end
 
 Then /^the response headers should not contain "([^\"]+)"$/ do |header_name|

--- a/features/support/factory_bot.rb
+++ b/features/support/factory_bot.rb
@@ -3,4 +3,4 @@
 require 'factory_bot_rails'
 
 World FactoryBot::Syntax::Methods
-World EnvHelper::WorldMethods
+

--- a/features/support/helpers.rb
+++ b/features/support/helpers.rb
@@ -1,3 +1,6 @@
 # frozen_string_literal: true
 
-Dir[Rails.root.join('spec/support/helpers/*.rb')].each { |f| require(f) }
+Dir[Rails.root / 'spec/support/helpers/*.rb'].each { require it }
+
+World SessionHelper::WorldMethods
+World EnvHelper::WorldMethods

--- a/spec/factories/session.rb
+++ b/spec/factories/session.rb
@@ -8,6 +8,7 @@ FactoryBot.define do
     environment { NIL_ENVIRONMENT }
     token       { build(:token, bearer:, account:, environment:) }
     bearer      { build(:admin, account:, environment:) }
+    parent      { nil }
 
     expiry     { 2.weeks.from_now }
     user_agent { Faker::Internet.user_agent }

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -116,14 +116,6 @@ describe Session, type: :model do
       expect(child).to_not be_valid
       expect(child.errors[:bearer]).to include 'bearer must match parent bearer'
     end
-
-    it 'should not allow a child session to outlive its parent' do
-      parent = create(:session, account:, environment: nil, token: nil, expiry: 1.hour.from_now)
-      child  = build(:session, account:, bearer: parent.bearer, parent:, token: nil, expiry: 2.hours.from_now)
-
-      expect(child).to_not be_valid
-      expect(child.errors[:expiry]).to include 'cannot outlive parent session'
-    end
   end
 
   describe '#expires_in?' do

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -69,6 +69,63 @@ describe Session, type: :model do
     end
   end
 
+  describe '#parent=' do
+    before { Sidekiq::Testing.inline! }
+    after  { Sidekiq::Testing.fake! }
+
+    it 'should allow a child session for a nil environment parent' do
+      environment = create(:environment, :isolated, account:)
+      parent      = create(:session, account:, environment: nil, token: nil)
+      child       = build(:session, account:, environment:, bearer: parent.bearer, parent:, token: nil, expiry: parent.expiry)
+
+      expect(child).to be_valid
+    end
+
+    it 'should allow a nested child session' do
+      environment = create(:environment, :isolated, account:)
+      parent      = create(:session, account:, environment: nil, token: nil)
+      child       = create(:session, account:, environment:, bearer: parent.bearer, parent:, token: nil, expiry: parent.expiry)
+      grandchild  = build(:session, account:, environment:, bearer: child.bearer, parent: child, token: nil, expiry: child.expiry)
+
+      expect(grandchild).to be_valid
+    end
+
+    it 'should allow a parent from an environment' do
+      environment = create(:environment, :isolated, account:)
+      parent      = create(:session, account:, environment:)
+      child       = build(:session, account:, environment:, bearer: parent.bearer, parent:, token: nil, expiry: parent.expiry)
+
+      expect(child).to be_valid
+    end
+
+    it 'should destroy child sessions with their parent' do
+      environment = create(:environment, :isolated, account:)
+      parent      = create(:session, account:, environment: nil, token: nil)
+      child       = create(:session, account:, environment:, bearer: parent.bearer, parent:, token: nil, expiry: parent.expiry)
+      grandchild  = create(:session, account:, environment:, bearer: child.bearer, parent: child, token: nil, expiry: child.expiry)
+
+      expect { parent.destroy }.to change(Session, :count).by(-3)
+      expect(Session.exists?(child.id)).to be false
+      expect(Session.exists?(grandchild.id)).to be false
+    end
+
+    it "should not allow a child session with a different bearer than its parent" do
+      parent = create(:session, account:, environment: nil, token: nil)
+      child  = build(:session, account:, bearer: create(:admin, account:), parent:, token: nil, expiry: parent.expiry)
+
+      expect(child).to_not be_valid
+      expect(child.errors[:bearer]).to include 'bearer must match parent bearer'
+    end
+
+    it 'should not allow a child session to outlive its parent' do
+      parent = create(:session, account:, environment: nil, token: nil, expiry: 1.hour.from_now)
+      child  = build(:session, account:, bearer: parent.bearer, parent:, token: nil, expiry: 2.hours.from_now)
+
+      expect(child).to_not be_valid
+      expect(child.errors[:expiry]).to include 'cannot outlive parent session'
+    end
+  end
+
   describe '#expires_in?' do
     it 'should return true when expiring within duration' do
       session = create(:session, account:, expiry: 3.hours.from_now)

--- a/spec/policies/environment_policy_spec.rb
+++ b/spec/policies/environment_policy_spec.rb
@@ -126,6 +126,8 @@ describe EnvironmentPolicy, type: :policy do
 
       with_scenarios %i[accessing_an_environment] do
         with_token_authentication do
+          denies :me
+
           with_wildcard_permissions do
             without_token_permissions do
               denies :show, :create, :update, :destroy
@@ -150,6 +152,8 @@ describe EnvironmentPolicy, type: :policy do
 
       with_scenarios %i[accessing_itself] do
         with_token_authentication do
+          allows :me
+
           with_wildcard_permissions do
             without_token_permissions do
               denies :show, :create, :update, :destroy

--- a/spec/policies/license_policy_spec.rb
+++ b/spec/policies/license_policy_spec.rb
@@ -643,6 +643,8 @@ describe LicensePolicy, type: :policy do
   with_role_authorization :license do
     with_scenarios %i[accessing_itself] do
       with_license_authentication do
+        allows :me
+
         with_permissions %w[license.read] do
           allows :show
         end
@@ -675,6 +677,8 @@ describe LicensePolicy, type: :policy do
       end
 
       with_token_authentication do
+        allows :me
+
         with_permissions %w[license.read] do
           without_token_permissions { denies :show }
 
@@ -747,6 +751,8 @@ describe LicensePolicy, type: :policy do
 
     with_scenarios %i[accessing_a_license] do
       with_license_authentication do
+        denies :me
+
         with_permissions %w[license.read] do
           denies :show
         end
@@ -777,6 +783,8 @@ describe LicensePolicy, type: :policy do
       end
 
       with_token_authentication do
+        denies :me
+
         with_permissions %w[license.read] do
           denies :show
         end

--- a/spec/policies/product_policy_spec.rb
+++ b/spec/policies/product_policy_spec.rb
@@ -360,6 +360,8 @@ describe ProductPolicy, type: :policy do
 
     with_scenarios %i[accessing_itself] do
       with_token_authentication do
+        allows :me
+
         with_permissions %w[product.read] do
           allows :show
         end
@@ -386,6 +388,8 @@ describe ProductPolicy, type: :policy do
 
     with_scenarios %i[accessing_a_product] do
       with_token_authentication do
+        denies :me
+
         with_permissions %w[product.read] do
           denies :show
         end

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -1343,6 +1343,8 @@ describe UserPolicy, type: :policy do
   with_role_authorization :user do
     with_scenarios %i[accessing_itself] do
       with_token_authentication do
+        allows :me
+
         with_permissions %w[user.read] do
           without_token_permissions { denies :show }
 
@@ -1481,6 +1483,8 @@ describe UserPolicy, type: :policy do
 
     with_scenarios %i[accessing_a_user] do
       with_token_authentication do
+        denies :me
+
         with_permissions %w[user.read] do
           denies :show
         end

--- a/spec/support/helpers/session_helper.rb
+++ b/spec/support/helpers/session_helper.rb
@@ -3,16 +3,33 @@
 module SessionHelper
   module WorldMethods
     def authenticate_with_session(session, environment: session.environment)
-      set_session_cookie_header(session_cookie_name_for(environment), session.id)
+      cookies = session_cookie_pairs_for(session, environment:)
+
+      header "Cookie", cookies.join("; ")
     end
 
-    def set_session_cookie_header(name, value)
-      enc = encrypted_cookie_value(name, value)
+    def authenticate_with_session_id(session_id, environment: nil)
+      name = session_cookie_name_for(environment)
+      enc  = encrypted_cookie_value(name, session_id)
 
       header "Cookie", %(#{name}=#{enc})
     end
 
     private
+
+    def session_cookie_pairs_for(session, environment: session.environment)
+      [
+        session_cookie_pair_for(session),
+        *session.children.flat_map { session_cookie_pairs_for(it) },
+      ]
+    end
+
+    def session_cookie_pair_for(session, environment: session.environment)
+      name = session_cookie_name_for(environment)
+      enc  = encrypted_cookie_value(name, session.id)
+
+      %(#{name}=#{enc})
+    end
 
     def session_cookie_name_for(environment)
       environment.present? ? :"session_id.#{environment.id}" : :session_id

--- a/spec/support/helpers/session_helper.rb
+++ b/spec/support/helpers/session_helper.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module SessionHelper
+  module WorldMethods
+    def authenticate_with_session(session, environment: session.environment)
+      set_session_cookie_header(session_cookie_name_for(environment), session.id)
+    end
+
+    def set_session_cookie_header(name, value)
+      enc = encrypted_cookie_value(name, value)
+
+      header "Cookie", %(#{name}=#{enc})
+    end
+
+    private
+
+    def session_cookie_name_for(environment)
+      environment.present? ? :"session_id.#{environment.id}" : :session_id
+    end
+
+    def encrypted_cookie_value(name, value)
+      app       = Rails.application
+      config    = app.config
+      keygen    = app.key_generator
+      salt      = config.action_dispatch.authenticated_encrypted_cookie_salt
+      cipher    = config.action_dispatch.encrypted_cookie_cipher
+      key_len   = ActiveSupport::MessageEncryptor.key_len(cipher)
+      key       = keygen.generate_key(salt, key_len)
+      encryptor = ActiveSupport::MessageEncryptor.new(key,
+        serializer: ActiveSupport::MessageEncryptor::NullSerializer,
+        cipher:,
+      )
+
+      dec = JSON.dump(value)
+      enc = encryptor.encrypt_and_sign(dec, purpose: "cookie.#{name}")
+
+      CGI.escape(enc)
+    end
+  end
+end


### PR DESCRIPTION
Related to https://github.com/keygen-sh/keygen-portal/pull/181. Switching environments was broken in Portal because the environment session would overwrite the session for the nil environment, which broke switching back to nil. This separates the sessions.