### PR TITLE
Clear session on new account

### DIFF
--- a/app/controllers/api/v1/accounts_controller.rb
+++ b/app/controllers/api/v1/accounts_controller.rb
@@ -55,6 +55,8 @@ module Api::V1
       authorize! account
 
       if account.save
+        unset_session_cookies # clear any existing session
+
         render jsonapi: account, status: :created, location: v1_account_url(account)
       else
         render_unprocessable_resource account

--- a/app/controllers/concerns/cookies.rb
+++ b/app/controllers/concerns/cookies.rb
@@ -22,7 +22,7 @@ module Cookies
     }
   end
 
-  def unset_session_cookies(session, skip_verify_origin: false)
+  def unset_session_cookies(session = nil, skip_verify_origin: false)
     return unless
       skip_verify_origin || request.origin == Keygen::Portal::ORIGIN
 

--- a/features/api/v1/accounts/create.feature
+++ b/features/api/v1/accounts/create.feature
@@ -6,6 +6,10 @@ Feature: Create account
     And there exists 1 "plan"
 
   Scenario: Anonymous creates an account
+    Given I send the following headers:
+      """
+      { "Origin": "https://portal.keygen.sh" }
+      """
     When I send a POST request to "/accounts" with the following:
       """
       {
@@ -40,6 +44,7 @@ Feature: Create account
       }
       """
     Then the response status should be "201"
+    And the response headers should not contain "Set-Cookie"
     And the response body should be an "account" with the name "Google"
     And the response body should be an "account" with the slug "google"
     And the response body should be an "account" with the following meta:
@@ -58,6 +63,51 @@ Feature: Create account
     And sidekiq should have 0 "request-log" jobs
     And the account "google" should not have a referral
     And the account "google" should have 1 "admin"
+
+  Scenario: Anonymous creates an account with an existing session
+    Given there exists an account "test1"
+    And the current account is "test1"
+    And I am an admin of account "test1"
+    And I authenticate with a session
+    And I send the following headers:
+      """
+      { "Origin": "https://portal.keygen.sh" }
+      """
+    When I send a POST request to "/accounts" with the following:
+      """
+      {
+        "data": {
+          "type": "accounts",
+          "attributes": {
+            "name": "Keygen",
+            "slug": "keygen"
+          },
+          "relationships": {
+            "plan": {
+              "data": { "type": "plans", "id": "$plan[0]" }
+            },
+            "admins": {
+              "data": [
+                {
+                  "type": "user",
+                  "attributes": {
+                    "firstName": "Zeke",
+                    "email": "zeke@keygen.sh",
+                    "password": "secret123"
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+      """
+    Then the response status should be "201"
+    And the response headers should contain "Set-Cookie" with a cookie:
+      """
+      session_id=; domain=keygen.sh; expires=Thu, 01 Jan 1970 00:00:00 GMT; secure; samesite=None; partitioned;
+      """
+    And the response body should be an "account"
 
   Scenario: Anonymous creates an account with multiple admins
     When I send a POST request to "/accounts" with the following:

--- a/features/step_definitions/placeholder_steps.rb
+++ b/features/step_definitions/placeholder_steps.rb
@@ -130,7 +130,7 @@ def parse_placeholders(str, account:, bearer:, crypt:)
         ROTP::TOTP.new(@second_factor.secret).now
       else
         model =
-          if account && resource.singularize != 'account'
+          if account && !(resource.singularize in 'account' | 'plan') # FIXME(ezekg) it all sucks
             args = case index
                    in UUID_RE => id
                      [:find_by, id:]


### PR DESCRIPTION
Before we tackle #1127, this resolves an issue where existing sessions lingered into new accounts, causing a 401 error on initial authentication post-registration because the session was used instead of the new user's credentials.