### PR TITLE
Add filtering by bearer type to tokens

### DIFF
--- a/app/controllers/api/v1/tokens_controller.rb
+++ b/app/controllers/api/v1/tokens_controller.rb
@@ -5,7 +5,9 @@ module Api::V1
     include ActionController::HttpAuthentication::Basic::ControllerMethods
     include ActionController::HttpAuthentication::Token::ControllerMethods
 
-    has_scope(:bearer, type: :any) { |c, s, v| s.for_bearer(v) }
+    has_scope(:bearer, type: :hash) { |c, s, v|
+      s.for_bearer(**v.symbolize_keys.slice(:type, :id, :role))
+    }
 
     before_action :scope_to_current_account!
     before_action :require_active_subscription!, only: %i[index regenerate regenerate_current]

--- a/app/models/token.rb
+++ b/app/models/token.rb
@@ -135,29 +135,21 @@ class Token < ApplicationRecord
     end
   }
 
-  scope :for_product, -> id { for_bearer(Product.name, id) }
-  scope :for_license, -> id { for_bearer(License.name, id) }
-  scope :for_user,    -> id { for_bearer(User.name, id) }
+  scope :for_product, -> id { for_bearer(type: Product.name, id:) }
+  scope :for_license, -> id { for_bearer(type: License.name, id:) }
+  scope :for_user,    -> id { for_bearer(type: User.name, id:) }
 
-  scope :for_bearer, -> *terms {
-    case terms
-    in [ActiveRecord::Base => bearer]
-      where(bearer:)
-    in [Hash => params]
-      for_bearer(params.symbolize_keys.values_at(:type, :id))
-    in [[String | Symbol => type, nil]]
-      for_bearer_type(type)
-    in [[String | Symbol => type, String => id]]
-      for_bearer_type(type).for_bearer_id(id)
-    in [String | Symbol => type, nil]
-      for_bearer_type(type)
-    in [String | Symbol => type, String => id]
-      for_bearer_type(type).for_bearer_id(id)
-    in [String => id]
-      for_bearer_id(id)
-    else
-      none
-    end
+  scope :for_bearer, -> (bearer = nil, type: nil, id: nil, role: nil) {
+    return where(bearer:) if bearer in ActiveRecord::Base
+    return none if
+      type.blank? && id.blank? && role.blank?
+
+    scope = all
+    scope = scope.for_bearer_type(type) if type.present?
+    scope = scope.for_bearer_id(id)     if id.present?
+    scope = scope.for_bearer_role(role) if role.present?
+
+    scope
   } do
     def environments = for_bearer_type(:environment)
     def products     = for_bearer_type(:product)
@@ -179,6 +171,18 @@ class Token < ApplicationRecord
       bearer_id.empty?
 
     where(bearer_id: bearer_id)
+  }
+
+  scope :for_bearer_role, -> role {
+    name = role.to_s.underscore
+    return none if
+      name.empty?
+
+    joins(<<~SQL.squish).where(roles: { name: })
+      INNER JOIN roles
+        ON roles.resource_type = tokens.bearer_type
+       AND roles.resource_id   = tokens.bearer_id
+    SQL
   }
 
   delegate :role, :role_permissions,

--- a/app/models/token.rb
+++ b/app/models/token.rb
@@ -145,8 +145,12 @@ class Token < ApplicationRecord
       where(bearer:)
     in [Hash => params]
       for_bearer(params.symbolize_keys.values_at(:type, :id))
+    in [[String | Symbol => type, nil]]
+      for_bearer_type(type)
     in [[String | Symbol => type, String => id]]
       for_bearer_type(type).for_bearer_id(id)
+    in [String | Symbol => type, nil]
+      for_bearer_type(type)
     in [String | Symbol => type, String => id]
       for_bearer_type(type).for_bearer_id(id)
     in [String => id]

--- a/features/api/v1/tokens/index.feature
+++ b/features/api/v1/tokens/index.feature
@@ -72,7 +72,7 @@ Feature: List authentication tokens
     Then the response status should be "200"
     And the response body should be an array of 1 "token"
 
-  Scenario: Admin requests all tokens for product bearers
+  Scenario: Admin requests all tokens with product bearers
     Given the current account is "test1"
     And I am an admin of account "test1"
     And the current account has 3 "products"
@@ -85,6 +85,20 @@ Feature: List authentication tokens
     When I send a GET request to "/accounts/test1/tokens?bearer[type]=product"
     Then the response status should be "200"
     And the response body should be an array of 3 "tokens"
+
+  Scenario: Admin requests all tokens for admin bearers
+    Given the current account is "test1"
+    And the current account has 3 "products"
+    And the current account has 1 "token" for each "product"
+    And the current account has 5 "users"
+    And the current account has 1 "token" for each "user"
+    And the current account has 2 "licenses"
+    And the current account has 1 "token" for each "license"
+    And I am an admin of account "test1"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/tokens?bearer[role]=admin"
+    Then the response status should be "200"
+    And the response body should be an array of 1 "token"
 
   @ee
   Scenario: Isolated environment requests their tokens while authenticated

--- a/features/api/v1/tokens/index.feature
+++ b/features/api/v1/tokens/index.feature
@@ -72,6 +72,20 @@ Feature: List authentication tokens
     Then the response status should be "200"
     And the response body should be an array of 1 "token"
 
+  Scenario: Admin requests all tokens for product bearers
+    Given the current account is "test1"
+    And I am an admin of account "test1"
+    And the current account has 3 "products"
+    And the current account has 1 "token" for each "product"
+    And the current account has 5 "users"
+    And the current account has 1 "token" for each "user"
+    And the current account has 2 "licenses"
+    And the current account has 1 "token" for each "license"
+    And I use an authentication token
+    When I send a GET request to "/accounts/test1/tokens?bearer[type]=product"
+    Then the response status should be "200"
+    And the response body should be an array of 3 "tokens"
+
   @ee
   Scenario: Isolated environment requests their tokens while authenticated
     Given the current account is "test1"

--- a/spec/models/token_spec.rb
+++ b/spec/models/token_spec.rb
@@ -201,6 +201,92 @@ describe Token, type: :model do
     end
   end
 
+  describe '.for_bearer' do
+    it 'should filter by bearer' do
+      admin_token   = create(:token, account:, bearer: create(:admin, account:))
+      user_token    = create(:token, account:, bearer: create(:user, account:))
+      product_token = create(:token, account:, bearer: create(:product, account:))
+      license_token = create(:token, account:, bearer: create(:license, account:))
+
+      tokens = described_class.for_bearer(license_token.bearer)
+
+      expect(tokens).to_not include admin_token
+      expect(tokens).to_not include user_token
+      expect(tokens).to_not include product_token
+      expect(tokens).to include license_token
+    end
+
+    it 'should filter by bearer type' do
+      admin_token   = create(:token, account:, bearer: create(:admin, account:))
+      user_token    = create(:token, account:, bearer: create(:user, account:))
+      product_token = create(:token, account:, bearer: create(:product, account:))
+      license_token = create(:token, account:, bearer: create(:license, account:))
+
+      tokens = described_class.for_bearer(type: :user)
+
+      expect(tokens).to include admin_token
+      expect(tokens).to include user_token
+      expect(tokens).to_not include product_token
+      expect(tokens).to_not include license_token
+    end
+
+    it 'should filter by bearer role' do
+      admin_token   = create(:token, account:, bearer: create(:admin, account:))
+      user_token    = create(:token, account:, bearer: create(:user, account:))
+      product_token = create(:token, account:, bearer: create(:product, account:))
+      license_token = create(:token, account:, bearer: create(:license, account:))
+
+      tokens = described_class.for_bearer(role: :product)
+
+      expect(tokens).to include product_token
+      expect(tokens).to_not include admin_token
+      expect(tokens).to_not include user_token
+      expect(tokens).to_not include license_token
+    end
+
+    it 'should filter by bearer type and role' do
+      admin_token   = create(:token, account:, bearer: create(:admin, account:))
+      user_token    = create(:token, account:, bearer: create(:user, account:))
+      product_token = create(:token, account:, bearer: create(:product, account:))
+      license_token = create(:token, account:, bearer: create(:license, account:))
+
+      tokens = described_class.for_bearer(type: :user, role: :admin)
+
+      expect(tokens).to include admin_token
+      expect(tokens).to_not include user_token
+      expect(tokens).to_not include product_token
+      expect(tokens).to_not include license_token
+    end
+
+    it 'should filter by bearer id' do
+      admin_token   = create(:token, account:, bearer: create(:admin, account:))
+      user_token    = create(:token, account:, bearer: create(:user, account:))
+      product_token = create(:token, account:, bearer: create(:product, id: admin_token.bearer_id, account:))
+      license_token = create(:token, account:, bearer: create(:license, account:))
+
+      tokens = described_class.for_bearer(id: admin_token.bearer_id)
+
+      expect(tokens).to include admin_token
+      expect(tokens).to_not include user_token
+      expect(tokens).to include product_token
+      expect(tokens).to_not include license_token
+    end
+
+    it 'should filter by bearer type and id' do
+      admin_token   = create(:token, account:, bearer: create(:admin, account:))
+      user_token    = create(:token, account:, bearer: create(:user, account:))
+      product_token = create(:token, account:, bearer: create(:product, id: admin_token.bearer_id, account:))
+      license_token = create(:token, account:, bearer: create(:license, account:))
+
+      tokens = described_class.for_bearer(type: :user, id: admin_token.bearer_id)
+
+      expect(tokens).to include admin_token
+      expect(tokens).to_not include user_token
+      expect(tokens).to_not include product_token
+      expect(tokens).to_not include license_token
+    end
+  end
+
   describe '#permissions' do
     it 'should return default permissions' do
       bearer  = create(:user, account:, permissions: %w[license.validate license.read machine.read machine.create machine.delete])


### PR DESCRIPTION
Part of https://github.com/keygen-sh/keygen-portal/issues/248. Adds support for filtering on only `bearer[type]`, as well as `bearer[role]` to differentiate between users and admins, for example.